### PR TITLE
Add hwcomposer xorg drivers

### DIFF
--- a/overlay/android-headers/default.nix
+++ b/overlay/android-headers/default.nix
@@ -1,6 +1,6 @@
 {
 stdenvNoCC
-, fetchgit
+, fetchFromGitHub
 }:
 
 let
@@ -10,10 +10,11 @@ stdenvNoCC.mkDerivation {
   inherit version;
   name = "android-headers";
 
-  src = fetchgit {
-    url = https://git.launchpad.net/android-headers;
-    rev = "957ab6e28aea03d0cf6495f33ade9ddfff480ccc";
-    sha256 = "1ma872lq46qqpfvc3x9hlcs28w7vbaaf6k5p9v114h92qsza3cm0";
+  src = fetchFromGitHub {
+    owner = "ubports";
+    repo = "android-headers";
+    rev = "5baa625723a3ad77648012e4017f4de48374953a";
+    sha256 = "115ayzdrv17rjh5c8816wm3h9sjw7syh43y6g35rf5zgnrmw2x0i";
   };
 
   installPhase = ''
@@ -23,5 +24,10 @@ stdenvNoCC.mkDerivation {
     cd $out/include
     ln -s android android-${version}
     )
+
+    substituteInPlace debian/android-headers-${version}.pc \
+      --replace "prefix=/usr" "prefix=$out"
+    mkdir -p $out/lib/pkgconfig
+    cp debian/android-headers-${version}.pc $out/lib/pkgconfig/android-headers.pc
   '';
 }

--- a/overlay/drihybris/default.nix
+++ b/overlay/drihybris/default.nix
@@ -1,0 +1,56 @@
+{ stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkgconfig
+, utilmacros
+, xorgserver
+, android-headers
+, libhybris
+, drihybrisproto
+, file
+}:
+
+stdenv.mkDerivation {
+  pname = "drihybris";
+
+  inherit (drihybrisproto) src version;
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkgconfig
+  ];
+
+  configureFlags = [
+    "--enable-drihybris"
+  ];
+
+  installFlags = [
+    "DESTDIR=$(out)"
+  ];
+
+  # TODO: Fix upstream
+  postInstall = ''
+    mv $out/${xorgserver.dev}/include $out/
+    rm -r $out/${xorgserver.dev}
+    mv $out/$out/lib $out/lib
+    rm -r $out/$out
+  '';
+
+  preConfigure = ''
+    substituteInPlace configure \
+      --replace "/usr/bin/file" "${file}/bin/file"
+  '';
+
+  buildInputs = [
+    drihybrisproto
+    utilmacros
+    xorgserver
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = "https://github.com/NotKit/drihybris";
+    description = "Custom DRI3-based Xorg extension for use with libhybris";
+    maintainers = with maintainers; [ adisbladis ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/overlay/drihybrisproto/default.nix
+++ b/overlay/drihybrisproto/default.nix
@@ -1,0 +1,29 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation {
+  pname = "drihybrisproto";
+  version = "unstable-2018-12-16";
+
+  src = fetchFromGitHub {
+    owner = "NotKit";
+    repo = "drihybris";
+    rev = "3291c0ff9af4a2568474aa7b1b0a3786818705dc";
+    sha256 = "0300q2yhi4g5rx2pd6scc92j6kypsa2hl6v04sk0mvf88vcrzh7k";
+  };
+
+  dotConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    install -Dm644 src/drihybrisproto.h $out/include/X11/extensions/drihybrisproto.h
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/NotKit/drihybris;
+    description = "X11 DRIHYBRIS protocol";
+    maintainers = with maintainers; [ adisbladis ];
+    platforms = stdenv.lib.platforms.linux;
+    license = licenses.mit;  #x11
+  };
+
+}

--- a/overlay/glamor-hybris/default.nix
+++ b/overlay/glamor-hybris/default.nix
@@ -1,0 +1,78 @@
+{ stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkgconfig
+, utilmacros
+, xorgserver
+, drihybrisproto
+, drihybris
+, file
+, xorg
+, libdrm
+, libhybris
+}:
+
+stdenv.mkDerivation {
+  pname = "glamor-hybris";
+  version = "unstable-2018-12-16";
+
+  src = fetchFromGitHub {
+    owner = "NotKit";
+    repo = "glamor-hybris";
+    rev = "347463bcd688b75067d0dda2a920fb74fc976f51";
+    sha256 = "1b6nihxlfavvry9v7wfwddd7wllyr9bhgqsc66n421yydg8imay5";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkgconfig
+  ];
+
+  buildInputs = [
+    xorgserver
+    xorg.libXi
+    xorg.libX11
+    xorg.xorgproto
+    drihybrisproto
+    drihybris
+    utilmacros
+    libdrm
+    libhybris
+  ];
+
+  NIX_CFLAGS_COMPILE = stdenv.lib.concatStringsSep " " [
+    # For drihybris.h
+    "-I${drihybris}/include/xorg"
+    # For drm.h
+    "-I${libdrm.dev}/include/libdrm"
+  ];
+
+  configureScript = "./autogen.sh --enable-glamor-gles2";
+
+  installFlags = [
+    "DESTDIR=$(out)"
+  ];
+
+  preConfigure = ''
+    substituteInPlace configure \
+      --replace "/usr/bin/file" "${file}/bin/file"
+  '';
+
+
+  postInstall = ''
+    # TODO: Fix upstream
+    mv $out/${xorgserver.dev}/include $out/
+    rm -r $out/${xorgserver.dev}
+    mv $out/$out/lib $out/lib
+    rm -r $out/$out
+
+    mv $out/include/xorg/glamor.h $out/include/xorg/glamor-hybris.h
+  '';
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/gemian/xf86-video-hwcomposer;
+    description = "Glamor Xserver 2D acceleration, modified to work with libhybris drivers";
+    maintainers = with maintainers; [ adisbladis ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}

--- a/overlay/libhybris/default.nix
+++ b/overlay/libhybris/default.nix
@@ -2,15 +2,26 @@
 stdenv
 , lib
 , fetchFromGitHub
+, fetchpatch
 , autoreconfHook
 , pkgconfig
 
 , android-headers
 , file
+, wayland
+, xorg
 }:
 
 let
   inherit (stdenv) targetPlatform;
+
+  fetchpmospatch = {name, sha256}: fetchpatch {
+    inherit name;
+    url = "https://gitlab.com/postmarketOS/pmaports/raw/c2cb2a17d47458083f4e62714a46b1875d73cebb/hybris/libhybris/${name}";
+    inherit sha256;
+    stripLen = 1;
+  };
+
 in
 stdenv.mkDerivation {
   name = "libhybris";
@@ -19,9 +30,29 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "libhybris";
     repo = "libhybris";
-    rev = "07b547e90db625685050bdfd00c92ccafc64aa09";
-    sha256 = "0g0cqjydbahbzas40vz0awwyw2xjyjj3hxrkdydkn9qscyiyx593";
+    # Use same rev as postmarketOS so patches applies
+    rev = "8ddb15b53d6a63b1545bbf97d00ea93827bd68eb";
+    sha256 = "1xv714f8xz9j83y4snchz0m6flgvf82nhr75hdjwcjn3rlkwq2vb";
   };
+
+  patches = [
+    (fetchpmospatch {
+      name = "0002-tests-Regression-test-for-EGL-glibc-TLS-conflict.patch";
+      sha256 = "0nzw51hd8z1xz7vjlr1hsban4aikapq71g3r2wsil0jjk745b24z";
+    })
+    (fetchpmospatch {
+      name = "0003-PATCH-v2-Implement-X11-EGL-platform-based-on-wayland.patch";
+      sha256 = "0ijfygxw6hlgam74cjbygr6agy60b24nwjg14q1a0xnrbs5g828x";
+    })
+    (fetchpmospatch {
+      name = "0004-Build-test-hwcomposer-7-caf.patch";
+      sha256 = "0zdphi1ypw3l2z10nrr60xx2ymcnff1h03sc228q57kl46cd9nhm";
+    })
+    (fetchpmospatch {
+      name = "0005-eglplatform_wayland-link-libEGL-at-runtime.patch";
+      sha256 = "1fgydb2i6awska47ajylahfw7azndqqc31nazvicai10b47b151b";
+    })
+  ];
 
   postAutoreconf = ''
     substituteInPlace configure \
@@ -29,6 +60,9 @@ stdenv.mkDerivation {
   '';
 
   configureFlags = [
+    "--enable-wayland"
+    "--enable-trace"
+    "--enable-experimental"
     "--with-android-headers=${android-headers}/include/android/"
   ]
   ++ lib.optional targetPlatform.isAarch64 "--enable-arch=arm64"
@@ -40,5 +74,11 @@ stdenv.mkDerivation {
   nativeBuildInputs = [
     autoreconfHook
     pkgconfig
+  ];
+
+  buildInputs = [
+    wayland
+    xorg.libX11
+    xorg.libXext
   ];
 }

--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -18,6 +18,7 @@ in
     # Keep sorted.
     adbd = callPackage ./adbd { };
     android-headers = callPackage ./android-headers { };
+    drihybrisproto = callPackage ./drihybrisproto { };
     dtbTool = callPackage ./dtbtool { };
     hard-reboot = callPackage ./misc/hard-reboot.nix { };
     hard-shutdown = callPackage ./misc/hard-shutdown.nix { };

--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -18,6 +18,7 @@ in
     # Keep sorted.
     adbd = callPackage ./adbd { };
     android-headers = callPackage ./android-headers { };
+    drihybris = callPackage ./drihybris { };
     drihybrisproto = callPackage ./drihybrisproto { };
     dtbTool = callPackage ./dtbtool { };
     hard-reboot = callPackage ./misc/hard-reboot.nix { };

--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -21,6 +21,7 @@ in
     drihybris = callPackage ./drihybris { };
     drihybrisproto = callPackage ./drihybrisproto { };
     dtbTool = callPackage ./dtbtool { };
+    glamor-hybris = callPackage ./glamor-hybris { };
     hard-reboot = callPackage ./misc/hard-reboot.nix { };
     hard-shutdown = callPackage ./misc/hard-shutdown.nix { };
     libhybris = callPackage ./libhybris {

--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -34,6 +34,11 @@ in
     msm-fb-handle = callPackage ./msm-fb-handle { };
     ply-image = callPackage ./ply-image { };
     pulseaudio-modules-droid = callPackage ./pulseaudio-modules-droid { };
+    xorg = super.xorg.overrideScope'(self: super: {
+      xf86videohwcomposer = callPackage ./xf86-video-hwcomposer { };
+    }) # See all-packages.nix for more about this messy composition :/
+    // { inherit (self) xlibsWrapper; };
+    qt5-qpa-hwcomposer-plugin = self.qt5.callPackage ./qt5-qpa-hwcomposer-plugin { };
 
     # Extra "libs"
     mkExtraUtils = import ./lib/extra-utils.nix {

--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -33,6 +33,7 @@ in
     msm-fb-refresher = callPackage ./msm-fb-refresher { };
     msm-fb-handle = callPackage ./msm-fb-handle { };
     ply-image = callPackage ./ply-image { };
+    pulseaudio-modules-droid = callPackage ./pulseaudio-modules-droid { };
 
     # Extra "libs"
     mkExtraUtils = import ./lib/extra-utils.nix {

--- a/overlay/pulseaudio-modules-droid/default.nix
+++ b/overlay/pulseaudio-modules-droid/default.nix
@@ -1,0 +1,69 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, autoreconfHook
+, pkgconfig
+, runtimeShell
+, pulseaudio
+, libpulseaudio
+, libtool
+, runCommand
+, android-headers
+, libhybris
+, dbus
+}:
+
+let
+  version = "12.2.79";
+
+  # Export private header files
+  pulsecore = runCommand "pulsecore-headers" {} ''
+    mkdir -p $out/include/pulsecore/filter
+    tar -xf ${pulseaudio.src}
+    cp -a pulseaudio-${pulseaudio.version}/src/pulsecore/*.h $out/include/pulsecore/
+    cp -a pulseaudio-${pulseaudio.version}/src/pulsecore/filter/*.h $out/include/pulsecore/filter/
+    mkdir -p $out/lib/pkgconfig/
+    sed s/'Name: libpulse'/'Name: pulsecore'/ ${lib.getDev pulseaudio}/lib/pkgconfig/libpulse.pc > $out/lib/pkgconfig/pulsecore.pc
+  '';
+
+in stdenv.mkDerivation rec {
+  pname = "pulseaudio-modules-droid";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "mer-hybris";
+    repo = "pulseaudio-modules-droid";
+    rev = version;
+    sha256 = "0r8i84hwl2by233s522lgbxhjh23m9m3bz28adg0an9xnv2gzszp";
+  };
+
+  postPatch = ''
+    # Patch git usage
+    cat > git-version-gen << EOF
+    #!${runtimeShell}
+    echo -n ${version}
+    EOF
+  '';
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkgconfig
+    libtool
+  ];
+
+  buildInputs = [
+    android-headers
+    pulsecore
+    pulseaudio
+    libhybris
+    dbus
+  ];
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/mer-hybris/pulseaudio-modules-droid;
+    description = "PulseAudio Droid modules";
+    platforms = platforms.linux;
+    license = licenses.lgpl21;
+    maintainers = with maintainers; [ adisbladis ];
+  };
+}

--- a/overlay/xf86-video-hwcomposer/default.nix
+++ b/overlay/xf86-video-hwcomposer/default.nix
@@ -6,6 +6,9 @@
 , xorgserver
 , android-headers
 , libhybris
+, glamor-hybris
+, drihybris
+, drihybrisproto
 }:
 
 stdenv.mkDerivation {
@@ -24,14 +27,28 @@ stdenv.mkDerivation {
     pkgconfig
   ];
 
+  configureFlags = [
+    "--enable-drihybris"
+    "--enable-glamor-hybris"
+  ];
+
   buildInputs = [
+    drihybrisproto
     android-headers
     libhybris
     utilmacros
     xorgserver
+    glamor-hybris
+    drihybris
   ];
 
-  NIX_CFLAGS_COMPILE = "-I${android-headers}/include/android";
+  NIX_CFLAGS_COMPILE = stdenv.lib.concatStringsSep " " [
+    "-I${android-headers}/include/android"
+    # For glamor-hybris.h
+    "-I${glamor-hybris}/include/xorg"
+    # For drihybris.h
+    "-I${drihybris}/include/xorg"
+  ];
 
   meta = with stdenv.lib; {
     homepage = https://github.com/gemian/xf86-video-hwcomposer;

--- a/overlay/xf86-video-hwcomposer/default.nix
+++ b/overlay/xf86-video-hwcomposer/default.nix
@@ -1,0 +1,42 @@
+{ stdenv
+, fetchFromGitHub
+, autoreconfHook
+, pkgconfig
+, utilmacros
+, xorgserver
+, android-headers
+, libhybris
+}:
+
+stdenv.mkDerivation {
+  pname = "xf86-video-hwcomposer";
+  version = "unstable-2019-02-07";
+
+  src = fetchFromGitHub {
+    owner = "gemian";
+    repo = "xf86-video-hwcomposer";
+    rev = "0440e52d31ebe4565d0f92dfb45a8c52aab18b03";
+    sha256 = "0yz02jgr12g8gln01qh1rpbixkc6bdcg6rf6h6g04na3gw4f3xr7";
+  };
+
+  nativeBuildInputs = [
+    autoreconfHook
+    pkgconfig
+  ];
+
+  buildInputs = [
+    android-headers
+    libhybris
+    utilmacros
+    xorgserver
+  ];
+
+  NIX_CFLAGS_COMPILE = "-I${android-headers}/include/android";
+
+  meta = with stdenv.lib; {
+    homepage = https://github.com/gemian/xf86-video-hwcomposer;
+    description = "Xorg DDX driver to renderer through HWComposer API on Android devices via libhybris";
+    maintainers = with maintainers; [ adisbladis ];
+    platforms = stdenv.lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
The Xorg driver builds fine but is not yet tested.
`qt5-qpa-hwcomposer-plugin` doesn't build because of some GL things, not sure how to approach this one.

Based on https://github.com/samueldr/mobile-nixos/pull/29 because of the changes in `android-headers`.