### PR TITLE
Adds Hydra build support for multiple devices

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -1,0 +1,5 @@
+{ devices ? [ "google-blueline" ] }:
+
+with import <nixpkgs> {};
+
+lib.genAttrs devices ( device: (import ./. { inherit device; }).build.android-bootimg)


### PR DESCRIPTION
This enables Hydra builds of `mobile-nixos` with the ability to select the devices that are being built.