### PR TITLE
imageBuilder.makeMBR: Fixes bug with gap

### DIFF
--- a/lib/image-builder/makeMBR.nix
+++ b/lib/image-builder/makeMBR.nix
@@ -67,6 +67,7 @@ stdenvNoCC.mkDerivation rec {
       start=$totalSize
       size=${toString partition.length}
       size=$(( $(if (($size % ${alignment})); then echo 1; else echo 0; fi ) + size / ${alignment} ))
+      size=$(( size * ${alignment} ))
       totalSize=$(( totalSize + size ))
       echo "Gap: start $start | size $size | totalSize $totalSize"
     '';


### PR DESCRIPTION
The size wasn't fixed after aligning the result, this dividing the sizes
by as the alignment.

See the `sizeFragment` for comparison of the bashy maths.