### PR TITLE
google-marlin: Fix CONFIG_VT

### DIFF
--- a/devices/google-marlin/kernel/0001-Revert-four-tty-related-commits.patch
+++ b/devices/google-marlin/kernel/0001-Revert-four-tty-related-commits.patch
@@ -1,0 +1,250 @@
+From fa9724dd4b960acfd60643a02ba45e764522f964 Mon Sep 17 00:00:00 2001
+From: Daniel Fullmer <danielrf12@gmail.com>
+Date: Sat, 23 Nov 2019 20:37:08 -0500
+Subject: [PATCH] Revert four tty-related commits
+
+With these commits, CONFIG_VT fails to boot on google-marlin, with no
+serial port output.
+
+These commits were found by matching the commit messages of samueldr's
+reverts for google-walleye with the corresponding commits in
+google-marlin.
+
+Revert "tty:  check before stopping kthread"
+
+This reverts commit abac1caf3e8b6a479a5db31b2f52b1187b41d520.
+
+Revert "tty: move tty_port workqueue to be a kthread"
+
+This reverts commit 1bb88fcb4961166195e2cb1973901ecf931983a1.
+
+Revert "tty: add tty_port_set_policy function"
+
+This reverts commit 2074f5b7c3b6b00d8ed80738f4c9169a1599fc5a.
+
+Revert "msm_serial_hs:  make the Bluetooth tty thread RT"
+
+This reverts commit 89f0850619a154520827a3f22300d095a977f494.
+---
+ drivers/tty/n_tty.c                |  2 +-
+ drivers/tty/serial/msm_serial_hs.c |  2 --
+ drivers/tty/tty_buffer.c           | 27 ++++++---------------------
+ drivers/tty/tty_io.c               |  2 +-
+ drivers/tty/tty_ldisc.c            |  5 ++---
+ drivers/tty/tty_port.c             | 12 +-----------
+ include/linux/tty.h                |  7 +------
+ 7 files changed, 12 insertions(+), 45 deletions(-)
+
+diff --git a/drivers/tty/n_tty.c b/drivers/tty/n_tty.c
+index 1f2e6130cb4..118466d539b 100644
+--- a/drivers/tty/n_tty.c
++++ b/drivers/tty/n_tty.c
+@@ -244,7 +244,7 @@ static void n_tty_set_room(struct tty_struct *tty)
+ 		 */
+ 		WARN_RATELIMIT(test_bit(TTY_LDISC_HALTED, &tty->flags),
+ 			       "scheduling buffer work for halted ldisc\n");
+-		queue_kthread_work(&tty->port->worker, &tty->port->buf.work);
++		queue_work(system_unbound_wq, &tty->port->buf.work);
+ 	}
+ }
+ 
+diff --git a/drivers/tty/serial/msm_serial_hs.c b/drivers/tty/serial/msm_serial_hs.c
+index efc7e1be154..f8f28d0b1f9 100644
+--- a/drivers/tty/serial/msm_serial_hs.c
++++ b/drivers/tty/serial/msm_serial_hs.c
+@@ -61,7 +61,6 @@
+ #include <linux/ipc_logging.h>
+ #include <asm/irq.h>
+ #include <linux/kthread.h>
+-#include <uapi/linux/sched.h>
+ 
+ #include <linux/msm-sps.h>
+ #include <linux/platform_data/msm_serial_hs.h>
+@@ -3288,7 +3287,6 @@ static void  msm_serial_hs_rt_init(struct uart_port *uport)
+ 	msm_uport->pm_state = MSM_HS_PM_SUSPENDED;
+ 	mutex_unlock(&msm_uport->mtx);
+ 	pm_runtime_enable(uport->dev);
+-	tty_port_set_policy(&uport->state->port, SCHED_FIFO, 1);
+ }
+ 
+ static int msm_hs_runtime_suspend(struct device *dev)
+diff --git a/drivers/tty/tty_buffer.c b/drivers/tty/tty_buffer.c
+index 157d43500da..8a7655166ad 100644
+--- a/drivers/tty/tty_buffer.c
++++ b/drivers/tty/tty_buffer.c
+@@ -72,7 +72,7 @@ void tty_buffer_unlock_exclusive(struct tty_port *port)
+ 	atomic_dec(&buf->priority);
+ 	mutex_unlock(&buf->lock);
+ 	if (restart)
+-		queue_kthread_work(&port->worker, &buf->work);
++		queue_work(system_unbound_wq, &buf->work);
+ }
+ EXPORT_SYMBOL_GPL(tty_buffer_unlock_exclusive);
+ 
+@@ -133,8 +133,6 @@ void tty_buffer_free_all(struct tty_port *port)
+ 	buf->tail = &buf->sentinel;
+ 
+ 	atomic_set(&buf->mem_used, 0);
+-	if (!IS_ERR_OR_NULL(port->worker_thread))
+-		kthread_stop(port->worker_thread);
+ }
+ 
+ /**
+@@ -371,11 +369,8 @@ void tty_schedule_flip(struct tty_port *port)
+ {
+ 	struct tty_bufhead *buf = &port->buf;
+ 
+-	/* paired w/ acquire in flush_to_ldisc(); ensures
+-	 * flush_to_ldisc() sees buffer data.
+-	 */
+-	smp_store_release(&buf->tail->commit, buf->tail->used);
+-	queue_kthread_work(&port->worker, &buf->work);
++	buf->tail->commit = buf->tail->used;
++	schedule_work(&buf->work);
+ }
+ EXPORT_SYMBOL(tty_schedule_flip);
+ 
+@@ -444,7 +439,7 @@ receive_buf(struct tty_struct *tty, struct tty_buffer *head, int count)
+  *		 'consumer'
+  */
+ 
+-static void flush_to_ldisc(struct kthread_work *work)
++static void flush_to_ldisc(struct work_struct *work)
+ {
+ 	struct tty_port *port = container_of(work, struct tty_port, buf.work);
+ 	struct tty_bufhead *buf = &port->buf;
+@@ -508,7 +503,7 @@ static void flush_to_ldisc(struct kthread_work *work)
+  */
+ void tty_flush_to_ldisc(struct tty_struct *tty)
+ {
+-	flush_kthread_work(&tty->port->buf.work);
++	flush_work(&tty->port->buf.work);
+ }
+ 
+ /**
+@@ -547,18 +542,8 @@ void tty_buffer_init(struct tty_port *port)
+ 	init_llist_head(&buf->free);
+ 	atomic_set(&buf->mem_used, 0);
+ 	atomic_set(&buf->priority, 0);
++	INIT_WORK(&buf->work, flush_to_ldisc);
+ 	buf->mem_limit = TTYB_DEFAULT_MEM_LIMIT;
+-	init_kthread_work(&buf->work, flush_to_ldisc);
+-	init_kthread_worker(&port->worker);
+-	port->worker_thread = kthread_run(kthread_worker_fn, &port->worker,
+-					  "tty_worker_thread");
+-	if (IS_ERR(port->worker_thread)) {
+-		/*
+-		 * Not good, we can't unwind, this tty is going to be really
+-		 * sad...
+-		 */
+-		pr_err("Unable to start tty_worker_thread\n");
+-	}
+ }
+ 
+ /**
+diff --git a/drivers/tty/tty_io.c b/drivers/tty/tty_io.c
+index 08a587b6564..7b308d2b83a 100644
+--- a/drivers/tty/tty_io.c
++++ b/drivers/tty/tty_io.c
+@@ -1635,7 +1635,7 @@ static void release_tty(struct tty_struct *tty, int idx)
+ 	tty->port->itty = NULL;
+ 	if (tty->link)
+ 		tty->link->port->itty = NULL;
+-	flush_kthread_work(&tty->port->buf.work);
++	cancel_work_sync(&tty->port->buf.work);
+ 
+ 	if (tty->link)
+ 		tty_kref_put(tty->link);
+diff --git a/drivers/tty/tty_ldisc.c b/drivers/tty/tty_ldisc.c
+index 222534b9cf1..6a34d7d0d45 100644
+--- a/drivers/tty/tty_ldisc.c
++++ b/drivers/tty/tty_ldisc.c
+@@ -599,10 +599,9 @@ int tty_set_ldisc(struct tty_struct *tty, int ldisc)
+ 
+ 	/* Restart the work queue in case no characters kick it off. Safe if
+ 	   already running */
+-	queue_kthread_work(&tty->port->worker, &tty->port->buf.work);
++	schedule_work(&tty->port->buf.work);
+ 	if (o_tty)
+-		queue_kthread_work(&o_tty->port->worker,
+-				   &o_tty->port->buf.work);
++		schedule_work(&o_tty->port->buf.work);
+ 
+ 	tty_unlock(tty);
+ 	return retval;
+diff --git a/drivers/tty/tty_port.c b/drivers/tty/tty_port.c
+index d8778d4aa34..1b9335796da 100644
+--- a/drivers/tty/tty_port.c
++++ b/drivers/tty/tty_port.c
+@@ -16,7 +16,6 @@
+ #include <linux/bitops.h>
+ #include <linux/delay.h>
+ #include <linux/module.h>
+-#include <uapi/linux/sched.h>
+ 
+ void tty_port_init(struct tty_port *port)
+ {
+@@ -132,7 +131,7 @@ EXPORT_SYMBOL(tty_port_free_xmit_buf);
+  */
+ void tty_port_destroy(struct tty_port *port)
+ {
+-	flush_kthread_work(&port->buf.work);
++	cancel_work_sync(&port->buf.work);
+ 	tty_buffer_free_all(port);
+ }
+ EXPORT_SYMBOL(tty_port_destroy);
+@@ -621,12 +620,3 @@ int tty_port_open(struct tty_port *port, struct tty_struct *tty,
+ }
+ 
+ EXPORT_SYMBOL(tty_port_open);
+-
+-int tty_port_set_policy(struct tty_port *port, int policy, int sched_priority)
+-{
+-	struct sched_param param = { .sched_priority = sched_priority };
+-
+-	return sched_setscheduler(port->worker_thread, policy, &param);
+-}
+-EXPORT_SYMBOL_GPL(tty_port_set_policy);
+-
+diff --git a/include/linux/tty.h b/include/linux/tty.h
+index 9a50ffac2b2..47d0bfa536e 100644
+--- a/include/linux/tty.h
++++ b/include/linux/tty.h
+@@ -12,7 +12,6 @@
+ #include <uapi/linux/tty.h>
+ #include <linux/rwsem.h>
+ #include <linux/llist.h>
+-#include <linux/kthread.h>
+ 
+ 
+ 
+@@ -60,7 +59,7 @@ static inline char *flag_buf_ptr(struct tty_buffer *b, int ofs)
+ 
+ struct tty_bufhead {
+ 	struct tty_buffer *head;	/* Queue head */
+-	struct kthread_work work;
++	struct work_struct work;
+ 	struct mutex	   lock;
+ 	atomic_t	   priority;
+ 	struct tty_buffer sentinel;
+@@ -219,8 +218,6 @@ struct tty_port {
+ 						   based drain is needed else
+ 						   set to size of fifo */
+ 	struct kref		kref;		/* Ref counter */
+-	struct kthread_worker   worker;         /* worker thread */
+-	struct task_struct      *worker_thread; /* worker thread */
+ };
+ 
+ /*
+@@ -560,8 +557,6 @@ static inline int tty_port_users(struct tty_port *port)
+ {
+ 	return port->count + port->blocked_open;
+ }
+-extern int tty_port_set_policy(struct tty_port *port, int policy,
+-			       int sched_priority);
+ 
+ extern int tty_register_ldisc(int disc, struct tty_ldisc_ops *new_ldisc);
+ extern int tty_unregister_ldisc(int disc);
+-- 
+2.23.0
+

--- a/devices/google-marlin/kernel/default.nix
+++ b/devices/google-marlin/kernel/default.nix
@@ -24,6 +24,7 @@ in
   };
 
   patches = [
+    ./0001-Revert-four-tty-related-commits.patch
     ./0003-arch-arm64-Add-config-option-to-fix-bootloader-cmdli.patch
     ./99_framebuffer.patch
   ];


### PR DESCRIPTION
Without this kernel patch to revert these commits, the kernel hangs immediately with no serial port output. My earlier testing was apparently incorrect. I was unknowingly booting with CONFIG_VT disabled. Maybe I tested against the wrong branch or something.

The patch for google-walleye does not apply cleanly, so a new patch was made by matching the commit messages of samueldr's reverts for google-walleye with the corresponding commits in
google-marlin.

With this patch, the configuration under `examples/demo` now boots to xfce, with working touchscreen:
![3024-4032-max (1)](https://user-images.githubusercontent.com/1298344/69488484-c045a000-0e37-11ea-843d-b5512e7f3123.jpg)
