### PR TITLE
Enhance QEMU device

### DIFF
--- a/devices/qemu-x86_64/default.nix
+++ b/devices/qemu-x86_64/default.nix
@@ -51,9 +51,11 @@ let
     "1920x1080x16" = { vga = "0x390"; width = 1920; height = 1080; depth = 16; };
     "1920x1080x24" = { vga = "0x391"; width = 1920; height = 1080; depth = 24; };
     "1920x1080x32" = { vga = "0x392"; width = 1920; height = 1080; depth = 32; };
+     "720x1280x32" = { vga = "0x393"; width =  720; height = 1280; depth = 32; };
+    "1080x1920x32" = { vga = "0x394"; width = 1080; height = 1920; depth = 32; };
   };
 
-  MODE = MODES."1280x720x32";
+  MODE = MODES."1080x1920x32";
 in
 {
   mobile.device.name = "qemu-x86_64";

--- a/devices/qemu-x86_64/default.nix
+++ b/devices/qemu-x86_64/default.nix
@@ -81,7 +81,7 @@ in
     screen = {
       inherit (MODE) height width;
     };
-    ram = 512;
+    ram = 1024 * 2;
   };
 
   mobile.system.type = "kernel-initrd";

--- a/devices/qemu-x86_64/default.nix
+++ b/devices/qemu-x86_64/default.nix
@@ -36,6 +36,15 @@ let
     "hid_generic"
     "pcips2" "atkbd" "i8042"
 
+    # Mouse
+    "mousedev"
+
+    # Input within X11
+    "uinput" "evdev"
+
+    # USB
+    "usbcore" "usbhid" "ehci_pci" "ehci_hcd"
+
     # x86 RTC needed by the stage 2 init script.
     "rtc_cmos"
   ];

--- a/modules/system-types/kernel-initrd.nix
+++ b/modules/system-types/kernel-initrd.nix
@@ -46,9 +46,11 @@ in
               -initrd "${kernel-initrd}/initrd" \
               -append "$(cat "${kernel-initrd}/cmdline.txt")" \
               -m      "$(cat "${kernel-initrd}/ram.txt")M" \
-              -serial "stdio" \
+              -serial "mon:stdio" \
               -drive  "file=fs.img,format=raw" \
               -device "e1000,netdev=net0" \
+              -device usb-ehci -device usb-kbd \
+              -device "usb-tablet" \
               -netdev "user,id=net0,hostfwd=tcp::2222-:22,hostfwd=tcp::2323-:23,net=172.16.42.0/24,dhcpstart=172.16.42.1"
           '';
         };

--- a/modules/system-types/kernel-initrd.nix
+++ b/modules/system-types/kernel-initrd.nix
@@ -41,6 +41,7 @@ in
 
             qemu-system-x86_64 \
               -enable-kvm \
+              -L ${pkgs.mobile-nixos.virtualization.bios} \
               -kernel "${kernel-initrd}/kernel" \
               -initrd "${kernel-initrd}/initrd" \
               -append "$(cat "${kernel-initrd}/cmdline.txt")" \

--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -101,6 +101,9 @@ in
       kernel-builder-gcc6 = callPackage ./mobile-nixos/kernel/builder.nix {
         stdenv = with self; overrideCC stdenv buildPackages.gcc6;
       };
+      virtualization = {
+        bios = callPackage ./seabios {};
+      };
     };
 
     imageBuilder = callPackage ../lib/image-builder {};

--- a/overlay/seabios/0001-HACK-Adds-mobile-like-VGA-modes.patch
+++ b/overlay/seabios/0001-HACK-Adds-mobile-like-VGA-modes.patch
@@ -1,0 +1,41 @@
+From fe256e0ac58e583b06640106f664ad9ae131d6ba Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Sat, 5 Oct 2019 01:27:34 -0400
+Subject: [PATCH] HACK: Adds mobile-like VGA modes
+
+---
+ vgasrc/bochsvga.c | 3 +++
+ vgasrc/cbvga.c    | 3 +++
+ 2 files changed, 6 insertions(+)
+
+diff --git a/vgasrc/bochsvga.c b/vgasrc/bochsvga.c
+index ec5d101..62e38fb 100644
+--- a/vgasrc/bochsvga.c
++++ b/vgasrc/bochsvga.c
+@@ -100,6 +100,9 @@ static struct bochsvga_mode
+     { 0x190, { MM_DIRECT, 1920, 1080, 16, 8, 16, SEG_GRAPH } },
+     { 0x191, { MM_DIRECT, 1920, 1080, 24, 8, 16, SEG_GRAPH } },
+     { 0x192, { MM_DIRECT, 1920, 1080, 32, 8, 16, SEG_GRAPH } },
++    // "Mobile" modes
++    { 0x193, { MM_DIRECT,  720, 1280, 32, 8, 16, SEG_GRAPH } },
++    { 0x194, { MM_DIRECT, 1080, 1920, 32, 8, 16, SEG_GRAPH } },
+ };
+ 
+ static int dispi_found VAR16 = 0;
+diff --git a/vgasrc/cbvga.c b/vgasrc/cbvga.c
+index f85989a..8d7395b 100644
+--- a/vgasrc/cbvga.c
++++ b/vgasrc/cbvga.c
+@@ -81,6 +81,9 @@ static struct cbvga_mode_s
+     { 0x190, { MM_DIRECT, 1920, 1080, 16, 8, 16, SEG_GRAPH } },
+     { 0x191, { MM_DIRECT, 1920, 1080, 24, 8, 16, SEG_GRAPH } },
+     { 0x192, { MM_DIRECT, 1920, 1080, 32, 8, 16, SEG_GRAPH } },
++    // "Mobile" modes
++    { 0x193, { MM_DIRECT,  720, 1280, 32, 8, 16, SEG_GRAPH } },
++    { 0x194, { MM_DIRECT, 1080, 1920, 32, 8, 16, SEG_GRAPH } },
+ };
+ 
+ struct vgamode_s *cbvga_find_mode(int mode)
+-- 
+2.23.0
+

--- a/overlay/seabios/default.nix
+++ b/overlay/seabios/default.nix
@@ -1,0 +1,33 @@
+{ seabios }:
+
+seabios.overrideAttrs({patches ? [], ...}: {
+  # Config taken from the QEMU source.
+  configurePhase = ''
+    cat > .config <<EOF
+    # for qemu machine types 2.0 + newer
+    CONFIG_QEMU=y
+    CONFIG_ROM_SIZE=256
+    CONFIG_ATA_DMA=n
+    CONFIG_NO_VGABIOS=n
+    CONFIG_VGA_BOCHS=y
+    EOF
+
+    make oldnoconfig
+  '';
+
+  patches = [
+    ./0001-HACK-Adds-mobile-like-VGA-modes.patch
+  ];
+
+  installPhase = ''
+    mkdir -p $out
+    cp ".config" "out/bios.bin" "out/vgabios.bin" $out/
+    (
+    cd $out;
+    ln -sf vgabios.bin vgabios-stdvga.bin
+    )
+  '';
+
+  dontStrip = true;
+  hardeningDisable = [ "all" ];
+})


### PR DESCRIPTION
Quick fixes:

 * Fixes issue with missing modules for input (keyboard/mouse)
 * Increases RAM
 * Attaches the serial console properly to stdin/stdout
 * Attaches absolute input

Additionally:

This adds a custom VGA BIOS build that is adding a vertical resolution. This, in turn, better emulates how a device acts.

Tip: Use the "View" menu, and select "Zoom to fit", this will allow you to resize the window.