### PR TITLE
demo: Rely on lightdm now that SLiM is gone

### DIFF
--- a/examples/demo/configuration.nix
+++ b/examples/demo/configuration.nix
@@ -26,10 +26,12 @@ in
         desktopManager.xfce.enable = true;
 
         # Automatically login as nixos.
-        displayManager.slim = {
+        displayManager.lightdm = {
           enable = true;
-          defaultUser = "nixos";
-          autoLogin = true;
+          autoLogin = {
+            enable = true;
+            user = "nixos";
+          };
         };
 
       };


### PR DESCRIPTION
There is one big caveat: When the session fails, the user is thrown back at lightdm, rather than the session restarting.

This is a problem that has to be solved in the future. If we want to use X11, we need to allow the user to log-in from the display manager, rather than rely on an unsafe password-less X11 session. Though, non-X11 session types will not have this issue.