### PR TITLE
Allow rootfs to expand to the backing partition

### DIFF
--- a/modules/initrd-devices.nix
+++ b/modules/initrd-devices.nix
@@ -28,6 +28,10 @@ in
 
       mkdir -p /etc/udev /tmp /run /lib /mnt /var/log
 
+      # Some tools, notably extfs tools, will bark angrily
+      # when they cannot determine if the device is mounted.
+      ln -s /proc/mounts /etc/mtab
+
       mkdir -p /dev/pts
       mount -t devpts devpts /dev/pts
 

--- a/modules/initrd-growpart.nix
+++ b/modules/initrd-growpart.nix
@@ -1,0 +1,26 @@
+# This builds a rootfs image (ext4) from the current configuration.
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (config.boot) growPartition;
+  inherit (lib) mkIf mkOrder optionalString;
+  inherit (import ./initrd-order.nix) BEFORE_SWITCH_ROOT_INIT;
+  root = config.fileSystems."/";
+in
+{
+
+  mobile.boot.stage-1.init = mkIf growPartition (mkOrder BEFORE_SWITCH_ROOT_INIT ''
+    (
+      ${optionalString growPartition ''
+        ${optionalString (root.fsType == "ext4") ''
+          e2fsck -fp ${root.device}
+          resize2fs -f ${root.device}
+        ''}
+      ''}
+    )
+  '');
+
+  mobile.boot.stage-1.extraUtils = with pkgs; [
+    { package = e2fsprogs; extraCommand = ""; }
+  ];
+}

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -17,6 +17,7 @@
   ./initrd-devices.nix
   ./initrd-fbterm.nix
   ./initrd-framebuffer.nix
+  ./initrd-growpart.nix
   ./initrd-kernel.nix
   ./initrd-logger.nix
   ./initrd-loop.nix

--- a/systems/rootfs.nix
+++ b/systems/rootfs.nix
@@ -1,6 +1,10 @@
 # This builds a rootfs image (ext4) from the current configuration.
 { config, lib, pkgs, ... }:
 
+let
+  inherit (config.boot) growPartition;
+  inherit (lib) optionalString;
+in
 {
   boot.loader.grub.enable = false;
   boot.loader.generic-extlinux-compatible.enable = false;
@@ -40,25 +44,9 @@
     }
   ;
 
-  #pkgs.runCommandNoCC "mobile-nixos-rootfs" {} ''
-  #  echo "${config.system.build.toplevel}" > $out
-  #'';
-
   boot.postBootCommands = ''
     # On the first boot do some maintenance tasks
     if [ -f /nix-path-registration ]; then
-      ${""
-      # TODO : optionally resize NIXOS_SYSTEM, depending on the target.
-      # # Figure out device names for the boot device and root filesystem.
-      # rootPart=$(readlink -f /dev/disk/by-label/NIXOS_SYSTEM)
-      # bootDevice=$(lsblk -npo PKNAME $rootPart)
-
-      # # Resize the root partition and the filesystem to fit the disk
-      # echo ",+," | sfdisk -N2 --no-reread $bootDevice
-      # ${pkgs.parted}/bin/partprobe
-      # ${pkgs.e2fsprogs}/bin/resize2fs $rootPart
-      }
-
       # Register the contents of the initial Nix store
       ${config.nix.package.out}/bin/nix-store --load-db < /nix-path-registration
 

--- a/systems/rootfs.nix
+++ b/systems/rootfs.nix
@@ -9,6 +9,8 @@ in
   boot.loader.grub.enable = false;
   boot.loader.generic-extlinux-compatible.enable = false;
 
+  boot.growPartition = lib.mkDefault true;
+
   system.build.rootfs =
     pkgs.imageBuilder.fileSystem.makeExt4 {
       name = "NIXOS_SYSTEM";
@@ -27,8 +29,9 @@ in
         echo "Done copying system closure..."
         cp -v ${closureInfo}/registration ./nix-path-registration
       '';
-      # FIXME : fixup the partition autoexpand.
-      extraPadding = pkgs.imageBuilder.size.MiB 500;
+
+      # Give some headroom for initial mounting.
+      extraPadding = pkgs.imageBuilder.size.MiB 20;
     }
   ;
 


### PR DESCRIPTION
With this, the rootfs will expand to the size of the partition it is written on.

Note: NO `fdisk` or similar partitioning tool is being used. This is **only** a dumb "resize to the partition size" operation. This should be safe on all targets.

One issue, though, is that this is **always** being done on boot, using this initrd method.

This probably should rather be done in an installer. This is especially relevant considering that stage-1 is not being updated with rebuilds currently.