### PR TITLE
[WIP] Add concept of family with chromebook-gru

### DIFF
--- a/modules/families/chromebook-gru.nix
+++ b/modules/families/chromebook-gru.nix
@@ -12,6 +12,9 @@ let
 in
 {
   config = mkIf enabled {
+    # There no rndis gadget configured yet for the gru platform.
+    mobile.boot.stage-1.networking.enable = false;
+
     # TODO: also add to stage-2 for when we have kexec + modular kernels.
     mobile.boot.stage-1.contents = [
       (fw { filename = "dptx.bin";                  path = "firmware/rockchip"; })

--- a/modules/families/chromebook-gru.nix
+++ b/modules/families/chromebook-gru.nix
@@ -1,0 +1,23 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) mkIf;
+  enabled = config.mobile.hardware.family == "chromebook-gru";
+  fw = {filename, path}: {
+    object = let file = pkgs.runCommandNoCC "firmware-${filename}" {} ''
+      cp -r "${pkgs.firmwareLinuxNonfree}/lib/${path}/${filename}" $out
+    ''; in "${file}";
+    symlink = "/lib/${path}/${filename}";
+  };
+in
+{
+  config = mkIf enabled {
+    # TODO: also add to stage-2 for when we have kexec + modular kernels.
+    mobile.boot.stage-1.contents = [
+      (fw { filename = "dptx.bin";                  path = "firmware/rockchip"; })
+      (fw { filename = "hw3.0";                     path = "firmware/ath10k/QCA6174"; })
+      (fw { filename = "nvm_usb_00000302.bin";      path = "firmware/qca"; })
+      (fw { filename = "rampatch_usb_00000302.bin"; path = "firmware/qca"; })
+    ];
+  };
+}

--- a/modules/hardware-family.nix
+++ b/modules/hardware-family.nix
@@ -1,0 +1,24 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) mkOption types;
+  cfg = config.mobile.hardware;
+in
+{
+  # All family files are always loaded.
+  # They, themselves, need to guard themselves using the value of `family`.
+  # That is, until a method of loading an imports file based on the value of an
+  # option is figured out.
+  imports = [
+  ];
+
+  options.mobile.hardware = {
+    family = mkOption {
+      type = types.nullOr types.str;
+      default = null;
+      description = ''
+        Give the hardware family name for the device.
+      '';
+    };
+  };
+}

--- a/modules/hardware-family.nix
+++ b/modules/hardware-family.nix
@@ -10,6 +10,7 @@ in
   # That is, until a method of loading an imports file based on the value of an
   # option is figured out.
   imports = [
+    ./families/chromebook-gru.nix
   ];
 
   options.mobile.hardware = {

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -7,6 +7,7 @@
 [
   ./_nixos-disintegration
   ./boot-initrd.nix
+  ./hardware-family.nix
   ./hardware-generic.nix
   ./hardware-qualcomm.nix
   ./hardware-ram.nix


### PR DESCRIPTION
I'm not entirely sure this is a good way to do this... I'll have to think about it more before merging this.

Basically, the idea is that I want to split the *description* of the hardware from the *implementation* of said hardware. Ideally, all the description should be extractable from the source files to generate fact sheets about the hardware.

So, here's how I'm thinking about implementing family-wide quirks... but this doesn't solve implementation of things for one device only.

I'm thinking, though, that this is not good since it will possibly include a bunch of files. I also would prefer something introspectable, right now there's no way to list families from the options tree, only from the filesystem, or from reading the file.

Finally, I would prefer if all "lists" of hardware, e.g. SOCs, would all use the same foundations. At the same time, I would like it if the evaluation wouldn't balloon up in time due to the wide variety of hardware.

* * *

Maybe the solution is to somehow split *at the modules system* the description from the implementation.

The basic gist of it is have an options tree that is isolated from the actual nixos modules system, used solely to build an attrset describing the hardware. Then, use *that* attrset as an input to the full blown nixos modules system.

The idea being that the `family` value would be already known and provided, rather than the value of an option, so in `imports [ ./families + "/${hardware.family}.nix" ];`, the family is not dependent on the currently being built options tree.

Such a solution could be used for SOCs too.

The only issue I can see with this approach is that the list of acceptable values for e.g. SOCs or Families is not known at run-time if we rely solely on files on the filesystem. So, this wouldn't in itself allow building a list of known options. Though, I guess that for documentation purposes, we could cheat and make the option type aware that it's a filesystem-based option list.

What if a family wants to use the values from a bigger family? Let that family handle the `imports = [ ./relative-family-file.nix ];`, but more importantly, prefer not making a spaghetti of dependencies.