### PR TITLE
libhybris: 2018-06-18 -> 2019-12-02

### DIFF
--- a/overlay/adbd/default.nix
+++ b/overlay/adbd/default.nix
@@ -36,7 +36,7 @@ stdenv.mkDerivation {
   ];
 
   propagatedBuildInputs = [
-    libhybris
+    (libhybris.override { useLegacyProperties = true; })
     zlib
     openssl
   ];

--- a/overlay/libhybris/0001-HACK-Rely-on-legacy-properties-rather-than-native-pr.patch
+++ b/overlay/libhybris/0001-HACK-Rely-on-legacy-properties-rather-than-native-pr.patch
@@ -1,0 +1,94 @@
+From 3ffcc51679542cc8052de26a8aa7ed99112e15d1 Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Mon, 9 Dec 2019 23:52:28 -0500
+Subject: [PATCH] [HACK]: Rely on legacy properties rather than native
+ properties
+
+---
+ hybris/properties/hybris_properties.c | 60 +++++----------------------
+ 1 file changed, 10 insertions(+), 50 deletions(-)
+
+diff --git a/hybris/properties/hybris_properties.c b/hybris/properties/hybris_properties.c
+index 7a6e06c..1ab60c8 100644
+--- a/properties/hybris_properties.c
++++ b/properties/hybris_properties.c
+@@ -15,66 +15,26 @@
+  *
+  */
+ 
+-#include <stdio.h>
+-#include <stdlib.h>
+-#include <dlfcn.h>
+-
+-#include <hybris/common/binding.h>
+-
+-static void *libcutils = NULL;
+-
+-// These may point to the libhybris implementation or to the bionic implementation, depending on the linker being used.
+-static int (*bionic_property_list)(void (*propfn)(const char *key, const char *value, void *cookie), void *cookie) = NULL;
+-static int (*bionic_property_get)(const char *key, char *value, const char *default_value) = NULL;
+-static int (*bionic_property_set)(const char *key, const char *value) = NULL;
+-
+-static void unload_libcutils(void)
+-{
+-    if (libcutils) {
+-        android_dlclose(libcutils);
+-    }
+-}
+-
+-#define PROPERTY_DLSYM(func) {*(void **)(&bionic_##func) = (void*)android_dlsym(libcutils, #func); \
+-                              if (!bionic_##func) { \
+-                                  fprintf(stderr, "failed to load " #func " from bionic libcutils\n"); \
+-                                  abort(); \
+-                              }}
+-
+-static void ensure_bionic_properties_initialized(void)
+-{
+-    if (!libcutils) {
+-        libcutils = android_dlopen("libcutils.so", RTLD_LAZY);
+-        if (libcutils) {
+-            PROPERTY_DLSYM(property_get);
+-            PROPERTY_DLSYM(property_set);
+-            PROPERTY_DLSYM(property_list);
+-            atexit(unload_libcutils);
+-        } else {
+-            fprintf(stderr, "failed to load bionic libc.so\n");
+-            abort();
+-        }
+-    }
+-}
++/**
++ * Mobile NixOS hack:
++ * This property "provider" relies on the older "legacy" behaviour. This is used
++ * to avoid loading libraries in the stage-1 environment. This is possible since
++ * adbd doesn't care much about using the actual libraries from the device, but
++ * only relies on other functions from libhybris.
++ */
+ 
+ int property_list(void (*propfn)(const char *key, const char *value, void *cookie), void *cookie)
+ {
+-    ensure_bionic_properties_initialized();
+-
+-    return bionic_property_list(propfn, cookie);
++    return my_property_list(propfn, cookie);
+ }
+ 
+ int property_get(const char *key, char *value, const char *default_value)
+ {
+-    ensure_bionic_properties_initialized();
+-
+-    return bionic_property_get(key, value, default_value);
++    return my_property_get(key, value, default_value);
+ }
+ 
+ int property_set(const char *key, const char *value)
+ {
+-    ensure_bionic_properties_initialized();
+-
+-    return bionic_property_set(key, value);
++    return my_property_set(key, value);
+ }
+ 
+-- 
+2.23.0
+

--- a/overlay/libhybris/0001-Removes-failing-test-for-wayland-less-builds.patch
+++ b/overlay/libhybris/0001-Removes-failing-test-for-wayland-less-builds.patch
@@ -1,0 +1,24 @@
+From 95d9181f725f06e4d00d920c9608cb1ed9c6537a Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Mon, 9 Dec 2019 23:38:59 -0500
+Subject: [PATCH] Removes failing test for wayland-less builds
+
+---
+ hybris/tests/Makefile.am | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/hybris/tests/Makefile.am b/hybris/tests/Makefile.am
+index 6f97c3e..1a1656d 100644
+--- a/tests/Makefile.am
++++ b/tests/Makefile.am
+@@ -7,7 +7,6 @@ bin_PROGRAMS = \
+ 	test_sensors \
+ 	test_input \
+ 	test_lights \
+-	test_camera \
+ 	test_vibrator \
+ 	test_media \
+ 	test_recorder \
+-- 
+2.23.0
+

--- a/overlay/libhybris/default.nix
+++ b/overlay/libhybris/default.nix
@@ -13,14 +13,14 @@ let
   inherit (stdenv) targetPlatform;
 in
 stdenv.mkDerivation {
-  name = "libhybris";
-  version = "0";
+  pname = "libhybris";
+  version = "2019-12-02";
 
   src = fetchFromGitHub {
     owner = "libhybris";
     repo = "libhybris";
-    rev = "07b547e90db625685050bdfd00c92ccafc64aa09";
-    sha256 = "0g0cqjydbahbzas40vz0awwyw2xjyjj3hxrkdydkn9qscyiyx593";
+    rev = "d27c1a85703db8dea4539ceb4d869792fd78ee37";
+    sha256 = "014wrpzd1w2bbza5jsy51qhhn9lvffz5h8l6mkwvkkn98i3h9yzn";
   };
 
   postAutoreconf = ''

--- a/overlay/libhybris/default.nix
+++ b/overlay/libhybris/default.nix
@@ -24,7 +24,11 @@ stdenv.mkDerivation {
     sha256 = "014wrpzd1w2bbza5jsy51qhhn9lvffz5h8l6mkwvkkn98i3h9yzn";
   };
 
-  patches = lib.optional useLegacyProperties ./0001-HACK-Rely-on-legacy-properties-rather-than-native-pr.patch;
+  patches = [
+    ./0001-Removes-failing-test-for-wayland-less-builds.patch
+  ]
+    ++ lib.optional useLegacyProperties ./0001-HACK-Rely-on-legacy-properties-rather-than-native-pr.patch
+  ;
 
   postAutoreconf = ''
     substituteInPlace configure \

--- a/overlay/libhybris/default.nix
+++ b/overlay/libhybris/default.nix
@@ -7,6 +7,7 @@ stdenv
 
 , android-headers
 , file
+, useLegacyProperties ? false
 }:
 
 let
@@ -22,6 +23,8 @@ stdenv.mkDerivation {
     rev = "d27c1a85703db8dea4539ceb4d869792fd78ee37";
     sha256 = "014wrpzd1w2bbza5jsy51qhhn9lvffz5h8l6mkwvkkn98i3h9yzn";
   };
+
+  patches = lib.optional useLegacyProperties ./0001-HACK-Rely-on-legacy-properties-rather-than-native-pr.patch;
 
   postAutoreconf = ''
     substituteInPlace configure \


### PR DESCRIPTION
Two big things

 * Upgrades libhybris to its latest version
 * Fixes issue with adbd with newer libhybris

The main issue with adbd (better described in commit messages and the patch) is that new versions of libhybris highly assume that you will be using libhybris with vendor libraries available.

This is not true here, and especially not with adbd in stage-1.

The adb daemon was running quite fine with the few bits of libhybris it was using, before they changed the behaviour. The added patch reverts the new behaviour to the older behaviour, which makes libhybris not load any libraries for adbd.

In the future, it might be ideal to extract the minimum libhybris required to run adbd, and rely on that instead.

* * *

This does mean that #30 will conflict, I'll rebase it on top of this PR.