### PR TITLE
Graphical boot selection

### DIFF
--- a/artwork/logo/logo.white.svg
+++ b/artwork/logo/logo.white.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg8"
+   version="1.1"
+   viewBox="0 0 170.07874 36.759375"
+   height="9.7259178mm"
+   width="45mm">
+  <defs
+     id="defs2" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="stroke-width:4.68141079"
+     transform="matrix(0.21361082,0,0,0.21361082,0,-25.61006)"
+     id="g868">
+    <g
+       style="stroke-width:4.68141079"
+       id="g882">
+      <path
+         id="path4683-8-5-2"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:395.09683228px;line-height:125%;font-family:Vegur;-inkscape-font-specification:Vegur;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.41818738px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="M 552.64185,175.23687 H 541.9535 v 48.50867 c 0,6.8515 0.27406,17.67689 0.68515,29.73554 h -0.41109 c -5.34417,-10.0032 -11.3735,-19.59531 -15.62144,-26.17276 l -33.57238,-52.07145 h -14.66223 v 92.90643 h 10.68835 v -48.50867 c 0,-6.85151 -0.27406,-19.73234 -0.68515,-31.65396 h 0.41109 c 7.94775,13.84004 12.60678,21.51373 16.99174,28.09118 l 33.57239,52.07145 h 13.29192 z" />
+      <path
+         id="path4685-9-4-4"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:395.09683228px;line-height:125%;font-family:Vegur;-inkscape-font-specification:Vegur;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.41818738px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 572.99084,268.1433 h 11.51052 v -66.32259 h -11.51052 z m 5.75524,-76.05173 c 3.97387,0 7.12559,-3.15169 7.12559,-7.12556 0,-3.97388 -3.15172,-7.12557 -7.12559,-7.12557 -3.97387,0 -7.12555,3.15169 -7.12555,7.12557 0,3.97387 3.15168,7.12556 7.12555,7.12556 z" />
+      <path
+         id="path4687-6-2-7"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:395.09683228px;line-height:125%;font-family:Vegur;-inkscape-font-specification:Vegur;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.41818738px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 656.2131,201.82071 h -13.1549 l -16.16955,24.39137 h -0.41109 L 610.8561,201.82071 h -14.25111 l 23.7062,32.33912 v 0.41109 L 595.7828,268.1433 h 13.1549 l 17.2658,-26.30978 h 0.41109 l 17.2658,26.30978 h 14.25111 l -25.07651,-34.1205 v -0.41109 z" />
+      <path
+         id="path4680-6-9-6"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:367.48727417px;line-height:125%;font-family:Vegur;-inkscape-font-specification:Vegur;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.41818738px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 700.73596,176.89149 c -21.81015,0 -39.74293,17.56285 -39.74293,46.78957 0,29.22673 17.93278,46.78957 39.74293,46.78957 21.81015,0 39.74296,-17.56284 39.74296,-46.78957 0,-29.22672 -17.93281,-46.78957 -39.74296,-46.78957 z m 0,9.1166 c 16.23645,0 28.59553,13.40675 28.59553,37.67297 0,24.26623 -12.35908,37.67298 -28.59553,37.67298 -16.23645,0 -28.59553,-13.40675 -28.59553,-37.67298 0,-24.26622 12.35908,-37.67297 28.59553,-37.67297 z" />
+      <path
+         id="path4677-0-9-7"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:386.55480957px;line-height:125%;font-family:Vegur;-inkscape-font-specification:Vegur;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.41818738px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 744.99468,200.63564 c 0,12.87049 6.70336,19.842 22.25521,26.14318 11.93202,4.82643 16.75842,9.11659 16.75842,17.96505 0,10.7254 -8.71436,16.0881 -20.24417,16.0881 -6.03305,0 -12.8705,-0.93847 -20.37829,-3.48575 l -1.20661,9.25066 c 6.56931,2.41322 13.80898,3.35169 21.0486,3.35169 17.96507,0 32.98063,-9.1166 32.98063,-27.48385 0,-12.73642 -7.77593,-18.90352 -23.46183,-25.2047 -10.45724,-4.15609 -15.55181,-8.58032 -15.55181,-17.83098 0,-8.98252 7.77592,-13.94302 17.56285,-13.94302 5.76489,0 12.06607,1.47474 16.4903,3.21762 l 1.20661,-9.1166 c -5.09458,-2.14508 -11.39576,-3.21762 -18.36725,-3.21762 -16.49033,0 -29.09266,9.5188 -29.09266,24.26622 z" />
+      <path
+         id="path2870"
+         d="m 62.60085,175.23871 -3.07227,86.85743 10.47266,6.04687 1.91797,-53.71484 c 0.27405,-8.22165 0.13794,-15.89422 -0.41016,-23.8418 h 0.41016 c 2.0554,7.81055 4.65861,15.62015 7.94726,23.8418 l 20.41797,50.97461 h 11.09961 l 20.68945,-50.97461 c 3.28866,-8.22165 6.03054,-16.16931 8.08594,-24.25391 h 0.41016 c -0.41108,7.94758 -0.54749,16.03226 -0.27344,24.25391 l 1.91797,53.71484 h 11.50976 l -3.28711,-92.9043 h -14.11523 l -19.1836,48.09571 c -3.83676,9.5919 -7.12479,17.81371 -10.6875,30.2832 h -0.4121 c -3.28866,-12.46949 -6.57566,-21.10238 -10.2754,-30.2832 L 76.8528,175.23871 Z"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:127.73706055px;line-height:1.25;font-family:Vegur602;-inkscape-font-specification:Vegur602;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:46.55730438;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers" />
+      <path
+         id="path2872"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:127.73706055px;line-height:1.25;font-family:Vegur602;-inkscape-font-specification:Vegur602;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:46.55730438;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+         d="m 200.08911,200.45183 c -20.00598,0 -31.92735,15.07299 -31.92735,34.53087 0,19.45787 11.92137,34.53088 31.92735,34.53088 20.00598,0 31.92736,-15.07301 31.92736,-34.53088 0,-19.45788 -11.92138,-34.53087 -31.92736,-34.53087 z m 0,60.29199 c -13.83975,0 -19.86895,-11.92137 -19.86895,-25.76112 0,-13.83976 6.0292,-25.76113 19.86895,-25.76113 13.83976,0 19.86896,11.92137 19.86896,25.76113 0,13.83975 -6.0292,25.76112 -19.86896,25.76112 z" />
+      <path
+         id="path2874"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:127.73706055px;line-height:1.25;font-family:Vegur602;-inkscape-font-specification:Vegur602;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:46.55730438;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+         d="m 259.94648,257.86626 c 4.93298,8.0846 11.92137,11.64732 21.37625,11.64732 17.81355,0 29.87195,-14.79896 29.87195,-35.76413 0,-20.00598 -10.82516,-33.29762 -29.04979,-33.29762 -9.72893,0 -16.99138,4.38486 -22.19841,11.64732 h -0.27406 v -42.61549 h -11.51029 v 98.65964 h 11.09921 l 0.41108,-10.27704 z m -0.27406,-26.85735 c 0,-11.51029 7.12542,-21.78734 18.90977,-21.78734 13.15461,0 20.55409,10.41408 20.55409,25.6241 0,15.75814 -7.12542,25.89815 -20.28004,25.89815 -10.68813,0 -19.18382,-9.04379 -19.18382,-21.78733 z" />
+      <path
+         id="path2876"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:127.73706055px;line-height:1.25;font-family:Vegur602;-inkscape-font-specification:Vegur602;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:46.55730438;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+         d="m 327.1134,268.1433 h 11.51029 V 201.8221 H 327.1134 Z m 5.75515,-76.05013 c 3.97379,0 7.12541,-3.15164 7.12541,-7.12542 0,-3.97379 -3.15162,-7.12542 -7.12541,-7.12542 -3.9738,0 -7.12542,3.15163 -7.12542,7.12542 0,3.97378 3.15162,7.12542 7.12542,7.12542 z" />
+      <path
+         id="path2878"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:127.73706055px;line-height:1.25;font-family:Vegur602;-inkscape-font-specification:Vegur602;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:46.55730438;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+         d="M 371.0071,268.1433 V 169.48366 H 359.49681 V 268.1433 Z" />
+      <path
+         id="path2880"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:127.73706055px;line-height:1.25;font-family:Vegur602;-inkscape-font-specification:Vegur602;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:46.55730438;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:stroke fill markers"
+         d="m 444.77274,237.58622 c 0.27405,-2.4665 0.41108,-4.5219 0.41108,-6.57731 0,-16.99138 -8.90677,-30.55708 -26.03518,-30.55708 -18.49869,0 -32.06439,15.34705 -32.06439,35.76411 0,22.47248 13.5657,33.29764 32.06439,33.29764 8.22164,0 14.38787,-1.23326 20.82815,-3.83677 l -1.09623,-8.76974 c -5.07,2.46648 -12.33245,3.83675 -18.08759,3.83675 -13.29164,0 -21.92437,-8.0846 -22.19842,-23.1576 z m -26.58329,-28.36465 c 10.14002,0 15.62111,8.35866 15.62111,19.32085 h -34.6679 c 1.64432,-11.64733 8.0846,-19.32085 19.04679,-19.32085 z" />
+      <path
+         id="use7631"
+         d="m 77.43288,119.89492 c -4.820166,0.12175 -9.454205,3.20761 -11.992187,7.60352 L 2.1281873,237.16055 c -3.609609,6.25198 -2.806248,14.85348 3.787109,18.66015 L 66.79421,290.96719 c 0.75261,0.43452 1.523533,0.76122 2.300779,1.00975 l 0.453129,-12.51171 -57.962899,-33.46484 c -0.06752,-0.0389 -0.790996,-1.17404 0.361331,-3.16993 L 75.260999,133.16641 c 1.152341,-1.9959 2.497021,-1.93544 2.564451,-1.89649 l 58.52736,33.78907 h 13.74609 c -0.56491,-3.42622 -2.41432,-6.54862 -5.72656,-8.46094 L 83.49539,121.4496 c -1.64834,-0.95166 -3.3761,-1.4392 -5.09572,-1.53905 -0.32242,-0.0187 -0.64545,-0.0237 -0.96679,-0.0156 z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:53.08056641;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    </g>
+  </g>
+</svg>

--- a/boot/applets/key-held.rb
+++ b/boot/applets/key-held.rb
@@ -1,0 +1,32 @@
+# Simple wrapper around `evtest`.
+# Returns `0` when one of the listed keys is held on any input device
+# Returns `10` when none of the keys are held on any input device
+#
+# See:
+#  * https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h
+
+# TODO: Remove dependency on `evtest` and rather rely on direct evdev bindings.
+
+# Mostly useless indirection.
+# This better documents what we hope to achieve using this.
+keys = ARGV
+
+# `evdev` works on `/dev/input/event*` nodes.
+# Check them *all*. We can't know which is a keyboard.
+Dir.glob("/dev/input/event*").each do |ev|
+  # `evtest` only tests one key at a time with `--query`...
+  keys.each do |key|
+    system("evtest", "--query", ev, "EV_KEY", key)
+    # One of the keys desired is held
+    if $?.exitstatus == 10
+      puts "#{key} is being held"
+      exit 0
+    end
+
+    # Failed for other reason
+    exit $?.exitstatus unless $?.exitstatus == 0
+  end
+end
+
+# Re-use 10 as "no keys held", as we're using 0 as "key held".
+exit 10

--- a/boot/gui/lib/001-monkey-patches.rb
+++ b/boot/gui/lib/001-monkey-patches.rb
@@ -1,0 +1,7 @@
+class File
+  def self.write(filename, contents)
+    File.open(filename, "w") do |file|
+      file.write(contents)
+    end
+  end
+end

--- a/boot/gui/lib/args.rb
+++ b/boot/gui/lib/args.rb
@@ -1,0 +1,80 @@
+# Extremely minimal and naïve arguments parsing.
+module Args
+  @@parsed = nil
+
+  def self.define(defaults)
+    self.const_set(:DEFAULTS, defaults)
+    self.parse
+  end
+
+  def self.get(key)
+    if DEFAULTS.has_key?(key)
+      parse[:values][key]
+    else
+      raise "Unknown argument #{key} requested."
+    end
+  end
+
+  def self.unused()
+    parsed[:unused]
+  end
+
+  def self.parse()
+    return @@parsed if @@parsed
+
+    argv = ARGV.dup
+    unused = []
+
+    # Default values.
+    # `nil` means it expects a parameter.
+    # `false` means it's a boolean toggle without parameter.
+    values = DEFAULTS.dup
+    while argv.length > 0
+      arg = argv.shift
+      if arg.match(/^--help$/)
+        print_help
+        exit 0
+      elsif arg.match(/^--/)
+        key = arg.sub(/^--/, "").gsub("-", "_").to_sym
+        if values.has_key?(key)
+          if values[key] == nil
+            if argv.length == 0
+              raise "Expected a value for #{arg}."
+            end
+            values[key] = argv.shift
+          else
+            values[key] = true
+          end
+        else
+          raise "Unexpected parameter #{arg}."
+        end
+      else
+        unused << arg
+      end
+    end
+
+    @@parsed = {
+      unused: unused,
+      values: values,
+    }
+  end
+
+  def self.print_help()
+    puts <<EOF
+Usage: $PROGRAM_NAME
+
+#{
+  DEFAULTS.map do |k, default|
+    [
+    "  --#{k.to_s.gsub("_", "-")}",
+    if default == nil
+      "<value>"
+    else
+      nil
+    end
+    ].compact.join(" ")
+  end.join("\n")
+}
+EOF
+  end
+end

--- a/boot/gui/lib/vtconsole.rb
+++ b/boot/gui/lib/vtconsole.rb
@@ -1,0 +1,22 @@
+module VTConsole
+  # Allows unmapping the "vtcon" console from the frame buffer
+  # This will ensure it doesn't trample on our lvgui.
+  def self.map_console(value)
+    # BAD HACK!
+    # This always tries to map/unmap the console from the framebuffer
+    # even when not using the framebuffer output! (Simulator)
+    # TODO: better introspection to allow the app to know it is running in a
+    # simulated environment.
+    begin
+      # We don't know which one(s) are running on the frame buffer.
+      Dir.glob("/sys/class/vtconsole/vtcon*").each do |dir|
+        # So we check...
+        if File.read(File.join(dir, "name")).strip.match(/frame buffer/)
+          # And only write to those.
+          File.write(File.join(dir, "bind"), value.to_s)
+        end
+      end
+    rescue
+    end
+  end
+end

--- a/boot/gui/main.rb
+++ b/boot/gui/main.rb
@@ -1,0 +1,304 @@
+# Refreshing at 120 times per second *really* helps with the drag operations
+# responsiveness. At 60 it feels a bit sluggish.
+# This likely comes from the naïve implementation that we are not refreshing at
+# 60 times per seconds, but rather, refresh and wait 1/60th of a second. This
+# makes the refresh rate a tad slower.
+# Boosting to 120 doesn't seem to have ill effects. It's simply refreshed more.
+REFRESH_RATE = 120
+
+# UI constants
+NIXOS_LIGHT_HUE = 205
+NIXOS_DARK_HUE  = 220
+
+# Define the arguments
+Args.define({
+  resolution: nil,
+})
+
+# This is used by the "simulator".
+if Args.get(:resolution)
+  pair = Args.get(:resolution).split("x")
+  unless pair.length == 2
+    $stderr.puts "--resolution <width>x<height>"
+    exit 2
+  end
+  LVGL::Hacks.monitor_width = ARGV.first.to_i
+  LVGL::Hacks.monitor_height = ARGV.last.to_i
+else
+  LVGL::Hacks.monitor_width = 720
+  LVGL::Hacks.monitor_height = 1280
+end
+
+# Get exclusive control of the framebuffer
+VTConsole.map_console(0)
+
+# Prepare LVGL
+LVGL::Hacks.init()
+# And switch to the desired theme
+LVGL::Hacks.theme_night(NIXOS_LIGHT_HUE)
+
+# Unsightly hacks {{{
+
+# Dummy container to get its style.
+LVGL::LVContainer.new.tap do |container|
+  style = container.get_style(LVGL::CONT_STYLE::MAIN)
+  # TODO: Determine what this "constant" is
+  # This ends up being different depending on the generations, probably the DPI
+  # This is used to "fix" some layouting issues where filling fails.
+  # 1280 == 10
+  # 1920 == 15
+  $fix_padding = style.body_padding_inner
+end
+
+# }}}
+
+# Wraps an LVGL widget.
+class Widget
+  def initialize(widget)
+    @widget = widget
+  end
+  def method_missing(*args)
+    @widget.send(*args)
+  end
+end
+
+# Implements a clock as a wrapped LVLabel.
+class Clock < Widget
+  def initialize(parent)
+    super(LVGL::LVLabel.new(parent))
+    set_align(LVGL::LABEL_ALIGN::LEFT)
+    set_long_mode(LVGL::LABEL_LONG::CROP)
+
+    # Update the text once
+    update_clock
+
+    # Then register a task to update regularly.
+    @task = LVGL::Hacks::LVTask.create_task(250, LVGL::TASK_PRIO::MID, ->() do
+      update_clock
+    end)
+  end
+
+  def update_clock()
+    set_text(Time.now.strftime("%T"))
+  end
+end
+
+# Big ball of code to build the UI.
+# Should be refactored in discrete "Widget" things.
+class UI
+  attr_reader :container
+  def initialize()
+    screen
+    header
+    logo
+    container
+  end
+
+  def screen()
+    @screen = LVGL::LVContainer.new()
+    #@screen.set_fit2(LVGL::FIT::FILL, LVGL::FIT::TIGHT)
+    @screen.set_layout(LVGL::LAYOUT::COL_M)
+
+    style = @screen.get_style(LVGL::CONT_STYLE::MAIN).dup
+    @screen.set_style(LVGL::CONT_STYLE::MAIN, style)
+    style.body_padding_top = 0
+    style.body_padding_left = 0
+    style.body_padding_right = 0
+    style.body_padding_bottom = 0
+  end
+
+  def container()
+    @tabview = LVGL::LVTabview.new(@screen)
+    @tabview.set_sliding(false)
+    @tabview.set_anim_time(0)
+
+    tab_style = @tabview.get_style(LVGL::TABVIEW_STYLE::BG).dup
+    @tabview.set_style(LVGL::TABVIEW_STYLE::BG, tab_style)
+    #tab_style.body_main_color = 0xFF0000FF
+    #tab_style.body_grad_color = 0xFF0000FF
+
+    @tabs = {}
+    @tabs[:default] = @tabview.add_tab("Boot options")
+    @tabs[:generations] = @tabview.add_tab("Generations")
+
+    @tabs.each do |id, tab|
+      page = LVGL::LVPage.new(tab)
+
+      # It seems tabview auto-height is broken :/
+      # This assumes there is nothing *after* the tabview.
+      @tabview.set_height(
+        @screen.get_height - @tabview.get_y
+      )
+
+      # "tabview" filling is seemingly broken...
+      page.set_width(
+        tab.get_width_fit - page.get_x*2
+      )
+      page.set_height(
+        tab.get_height_fit - page.get_y -
+        tab.get_style(LVGL::CONT_STYLE::MAIN).body_padding_inner - $fix_padding
+      )
+      style = LVGL::LVStyle::STYLE_TRANSP.dup
+      style.body_padding_top = 0
+      style.body_padding_left = 0
+      style.body_padding_right = 0
+      style.body_padding_bottom = 0
+      #style.body_main_color = 0xFFFF0000
+      #style.body_grad_color = 0xFFFF0000
+      page.set_style(LVGL::PAGE_STYLE::BG, style)
+      page.set_style(LVGL::PAGE_STYLE::SCRL, style)
+      page.set_scrl_layout(LVGL::LAYOUT::COL_M)
+
+      instance_variable_set("@#{id}_page".to_sym, page)
+    end
+  end
+
+  def header()
+    @header = LVGL::LVContainer.new(@screen)
+
+    header_style = @header.get_style(LVGL::CONT_STYLE::MAIN).dup
+    @header.set_style(LVGL::CONT_STYLE::MAIN, header_style)
+    header_style.glass = 1
+    header_style.body_radius = 0
+    #header_style.body_main_color = 0xFF0000FF
+    #header_style.body_grad_color = 0xFF0000FF
+
+    @header.set_fit2(LVGL::FIT::FILL, LVGL::FIT::TIGHT)
+    @header.set_layout(LVGL::LAYOUT::PRETTY)
+
+    # Split 50/50
+    child_width = (
+      @screen.get_width -
+      header_style.body_padding_left -
+      header_style.body_padding_right -
+      header_style.body_padding_inner*2
+    ) / 2
+
+    @clock = Clock.new(@header)
+    @clock.set_width(child_width)
+
+    @tagline = LVGL::LVLabel.new(@header)
+    @tagline.set_text("Recovery Menu")
+    @tagline.set_long_mode(LVGL::LABEL_LONG::SROLL_CIRC)
+    @tagline.set_align(LVGL::LABEL_ALIGN::RIGHT)
+    @tagline.set_width(child_width)
+  end
+
+  def logo()
+    file = nil
+    file = "/etc/logo.svg" if File.exist?("/etc/logo.svg")
+    file = "./logo.svg" if File.exist?("./logo.svg")
+    unless file
+      return
+    end
+    if @screen.get_height > @screen.get_width
+      LVGL::LVNanoSVG.resize_next_width((@screen.get_width_fit * 0.8).to_i)
+    else
+      # Detecting the available space where the layout will stretch into is
+      # apparently hard with lvgl, thus we rely on the vertical resolution.
+      # Meh, that's not *so* bad.
+      # While it's a crude approximation, for layouting it's fine.
+      LVGL::LVNanoSVG.resize_next_height((@screen.get_height * 0.15).to_i)
+    end
+
+    @logo = LVGL::LVImage.new(@screen)
+    @logo.set_src(file)
+  end
+
+  def button(label, page: nil)
+    if page
+      page = instance_variable_get("@#{page}_page".to_sym)
+    else
+      page = @default_page
+    end
+
+    btn = LVGL::LVButton.new(page)
+    btn.set_layout(LVGL::LAYOUT::COL_M)
+    btn.set_ink_in_time(200)
+    btn.set_ink_wait_time(100)
+    btn.set_ink_out_time(500)
+    btn.set_fit2(LVGL::FIT::FILL, LVGL::FIT::TIGHT)
+    btn.glue_obj(true)
+
+    LVGL::LVLabel.new(btn).tap do |obj|
+      obj.set_text(label)
+    end
+
+    btn
+  end
+end
+
+# Create the UI
+ui = UI.new
+
+def run(*cmd)
+  $stderr.puts " $ " + cmd.join(" ")
+  # TODO: better introspection to allow the app to know it is running in a
+  # simulated environment, and dry-run in simulator.
+  system(*cmd)
+end
+
+# TODO: wait ~0.3s for the animation before doing the button actions.
+# Otherwise, it looks jarring.
+
+# Default tab
+
+ui.button("Reboot to bootloader").tap do |btn|
+  btn.event_handler = ->(event) do
+    case event
+    when LVGL::EVENT::CLICKED
+      run("reboot bootloader")
+    end
+  end
+end
+
+ui.button("Reboot to recovery").tap do |btn|
+  btn.event_handler = ->(event) do
+    case event
+    when LVGL::EVENT::CLICKED
+      run("reboot recovery")
+    end
+  end
+end
+
+ui.button("Reboot to system").tap do |btn|
+  btn.event_handler = ->(event) do
+    case event
+    when LVGL::EVENT::CLICKED
+      run("reboot")
+    end
+  end
+end
+
+ui.button("Power off").tap do |btn|
+  btn.event_handler = ->(event) do
+    case event
+    when LVGL::EVENT::CLICKED
+      run("poweroff")
+    end
+  end
+end
+
+# Generations tab
+
+JSON.parse(File.read("/run/boot/selection.json")).each do |selection|
+  ui.button(selection["name"], page: :generations).tap do |btn|
+    btn.event_handler = ->(event) do
+      case event
+      when LVGL::EVENT::CLICKED
+        File.write("/run/boot/choice", selection["id"])
+        exit 0
+      end
+    end
+  end
+end
+
+# Main loop
+while true
+  LVGL::Hacks::LVTask.handle_tasks
+  sleep(1.0/REFRESH_RATE)
+  # TODO : Allow exiting!
+end
+
+# Put back the console on the framebuffer
+VTConsole.map_console(1)

--- a/boot/init/default.nix
+++ b/boot/init/default.nix
@@ -54,13 +54,20 @@ mruby.builder {
     { core = "mruby-exit"; }
     { core = "mruby-io"; }
     { core = "mruby-sleep"; }
+    { core = "mruby-time"; }
     mruby-dir
     mruby-dir-glob
     mruby-env
+    mruby-file-stat
     mruby-json
     mruby-logger
+    mruby-lvgui
     mruby-open3
     mruby-regexp-pcre
     mruby-singleton
+    mruby-time-strftime
+
+    # This needs to be the last gem
+    mruby-require
   ];
 }

--- a/boot/init/default.nix
+++ b/boot/init/default.nix
@@ -33,9 +33,16 @@ mruby.builder {
       done | sort
     }
 
-    makeBin init \
+    # This is the "script" that will be loaded.
+    mrbc -o init.mrb \
       $(find lib -type f | sort) \
       $(get_tasks) \
+      init.rb
+    mkdir -p $out/libexec
+    cp init.mrb $out/libexec/init.mrb
+
+    # We're building a script loader here.
+    makeBin loader \
       main.rb
   '';
 

--- a/boot/init/init.rb
+++ b/boot/init/init.rb
@@ -1,0 +1,61 @@
+begin
+# TODO: Allow defining depending on stage-0/stage-1.
+STAGE = 1
+
+log("************************")
+log("* Mobile NixOS stage-#{STAGE} *")
+log("************************")
+log("")
+log("Built for device #{Configuration["device"]["name"]}")
+log("")
+
+# This file is a hard-coded map of non-implicit tasks.
+# To these tasks, add all Singleton tasks found under tasks/*
+
+# Without any added dependency, show a first splash ASAP
+Tasks::Splash.new("stage-0")
+
+# Some software (mainly extfs tools) bark angrily and fail when this is missing.
+Tasks::Symlink.new("/proc/mounts", "/etc/mtab")
+
+Mounting.create_special_mount_points()
+Mounting.create_boot_mount_points()
+
+[
+  "/etc/udev",
+  "/var/log",
+].each do |dir|
+  Tasks::Directory.new(dir)
+end
+
+Tasks::Splash.new("stage-1")
+  .add_dependency(:Target, :Devices)
+
+Tasks::Modules.new(*Configuration["kernel"]["modules"])
+
+Tasks::go()
+
+$logger.fatal("Tasks all ran, but we're still here...")
+System.failure("did_not_switch", color: "ff0000")
+
+rescue => e
+  System.sad_phone("765300")
+  3.times do
+    $logger.fatal("********************")
+  end
+  $logger.fatal("Handling exception")
+  $logger.fatal(e.inspect)
+  $logger.fatal("`init` will exit and the kernel will crash.")
+  $logger.fatal("********************")
+  # Leave some time for the $logger.fatals to flush before the kernel crashes.
+  sleep(1)
+  System.shell if System.respond_to?(:shell)
+
+  # Users with access to serial debug may prefer crashing to the bootloader.
+  # Though, crashing the kernel is *required* for console ramoops to be present.
+  if Configuration["boot"]["crashToBootloader"] then
+    System.run("reboot bootloader")
+  else
+    exit 99
+  end
+end

--- a/boot/init/main.rb
+++ b/boot/init/main.rb
@@ -1,61 +1,12 @@
-begin
-# TODO: Allow defining depending on stage-0/stage-1.
-STAGE = 1
+$:.unshift(Dir.pwd)
+unless ARGV.length == 0
+  load ARGV.shift
+else
+  $stderr.puts <<EOF
+mruby script loader.
 
-log("************************")
-log("* Mobile NixOS stage-#{STAGE} *")
-log("************************")
-log("")
-log("Built for device #{Configuration["device"]["name"]}")
-log("")
+Usage: #{$PROGRAM_NAME} <file>
 
-# This file is a hard-coded map of non-implicit tasks.
-# To these tasks, add all Singleton tasks found under tasks/*
-
-# Without any added dependency, show a first splash ASAP
-Tasks::Splash.new("stage-0")
-
-# Some software (mainly extfs tools) bark angrily and fail when this is missing.
-Tasks::Symlink.new("/proc/mounts", "/etc/mtab")
-
-Mounting.create_special_mount_points()
-Mounting.create_boot_mount_points()
-
-[
-  "/etc/udev",
-  "/var/log",
-].each do |dir|
-  Tasks::Directory.new(dir)
-end
-
-Tasks::Splash.new("stage-1")
-  .add_dependency(:Target, :Devices)
-
-Tasks::Modules.new(*Configuration["kernel"]["modules"])
-
-Tasks::go()
-
-$logger.fatal("Tasks all ran, but we're still here...")
-System.failure("did_not_switch", color: "ff0000")
-
-rescue => e
-  System.sad_phone("765300")
-  3.times do
-    $logger.fatal("********************")
-  end
-  $logger.fatal("Handling exception")
-  $logger.fatal(e.inspect)
-  $logger.fatal("`init` will exit and the kernel will crash.")
-  $logger.fatal("********************")
-  # Leave some time for the $logger.fatals to flush before the kernel crashes.
-  sleep(1)
-  System.shell if System.respond_to?(:shell)
-
-  # Users with access to serial debug may prefer crashing to the bootloader.
-  # Though, crashing the kernel is *required* for console ramoops to be present.
-  if Configuration["boot"]["crashToBootloader"] then
-    System.run("reboot bootloader")
-  else
-    exit 99
-  end
+The file argument will be shifted from `ARGV`.
+EOF
 end

--- a/boot/init/tasks/auto_resize.rb
+++ b/boot/init/tasks/auto_resize.rb
@@ -11,7 +11,18 @@ class Tasks::AutoResize < Task
   def run()
     log("Resizing #{@device}...")
     if @type.match(/^ext[234]$/)
-      System.run("e2fsck", "-fp", @device)
+      # TODO: Understand the actual underlying issue with e2fsck.
+      # It seems `e2fsck` succeeds, according to the output, but has a >0 exit
+      # status. Running it again in those situations is a no-op, which is weird
+      # to me.
+      # This is why we unconditionally run it once, then twice.
+      # The second will hopefully abort the boot if it fails too.
+      begin
+        System.run("e2fsck", "-fp", @device)
+      rescue System::CommandError
+        $logger.info("Re-running e2fsc...")
+        System.run("e2fsck", "-fp", @device)
+      end
       System.run("resize2fs", "-f", @device)
     else
       $logger.warn("Cannot resize #{@type}... filesystem left untouched.")

--- a/boot/init/tasks/switch_root.rb
+++ b/boot/init/tasks/switch_root.rb
@@ -118,12 +118,31 @@ class Tasks::SwitchRoot < SingletonTask
       boot_as_recovery_wants_recovery
   end
 
+  def is_boot_interrupted()
+    keys = [
+      "KEY_VOLUMEUP",
+      "KEY_VOLUMEDOWN",
+      "KEY_LEFTCTRL",
+      "KEY_RIGHTCTRL",
+      "KEY_LEFTSHIFT",
+      "KEY_RIGHTSHIFT",
+      "KEY_ESC", # QEMU doesn't pass through CTRL and SHIFT as expected here...
+    ]
+
+    # Do *not* use System.run as it would fail the boot on return value != 0
+    system($PROGRAM_NAME, "/applets/key-held.mrb", *keys)
+
+    # It returns `0` on key being held.
+    $?.exitstatus == 0
+  end
+
   # Checks if the user wants to select a generation.
   def user_wants_selection()
     [
       # Booted a recovery partition.
       is_recovery,
-      # TODO: Check for held [VOL UP, VOL DOWN, CTRL].any keys (needs some mruby evdev bindings or a simple C tool to list held keys)
+      # Or signaling the boot selection menu should be shown.
+      is_boot_interrupted,
     ].any?
   end
 

--- a/boot/init/tasks/switch_root.rb
+++ b/boot/init/tasks/switch_root.rb
@@ -1,6 +1,6 @@
 class Tasks::SwitchRoot < SingletonTask
   # Relative to root.
-  SYSTEM_LINK = "/nix/var/nix/profiles/system"
+  DEFAULT_SYSTEM_LINK = "/nix/var/nix/profiles/system"
 
   # Where the system will be mounted.
   SYSTEM_MOUNT_POINT = "/mnt"
@@ -10,10 +10,61 @@ class Tasks::SwitchRoot < SingletonTask
     @target = SYSTEM_MOUNT_POINT
   end
 
-  def find_generation()
+  # Creates the generation selection list.
+  def generate_selection()
+    FileUtils.mkdir_p("/run/boot/")
+    base = File.join(SYSTEM_MOUNT_POINT, DEFAULT_SYSTEM_LINK)
+    selection = [
+      base,
+      *(Dir.glob(base + "-*").sort do |a, b|
+        File.lstat(a).mtime <=> File.lstat(b).mtime
+      end.reverse)
+    ].map do |path|
+      if path == base then
+        {
+          id: "$default",
+          name: "Mobile NixOS - Default",
+        }
+      else
+        date = File.lstat(path).mtime.strftime("%F")
+        version_file = File.join(path, "nixos-version")
+        version =
+          if File.exist?(version_file)
+            File.read(version_file)
+          else
+            nil
+          end
+        num = path.split("-")[-2]
+        details = [
+          date,
+          version,
+        ].compact.join(" - ")
+
+        name = "Mobile NixOS ##{num} (#{details})"
+
+        # This is the path we want to switch_root into.
+        path = File.readlink(path)
+
+        {
+          id: path,
+          name: name,
+        }
+      end
+    end
+
+    File.write("/run/boot/selection.json", selection.to_json)
+  end
+
+  # Boot the default generation.
+  # This does either of:
+  #  * Booting the default system link.
+  #  * Find the generation store path that needs to be rehydrated.
+  #
+  # This is *always* a sane default to fallback on.
+  def default_generation()
     # The default generation
-    if File.symlink?(File.join(@target, SYSTEM_LINK))
-      return SYSTEM_LINK
+    if File.symlink?(File.join(@target, DEFAULT_SYSTEM_LINK))
+      return DEFAULT_SYSTEM_LINK
     end
 
     # Otherwise, we need to re-hydrate a system!
@@ -29,9 +80,55 @@ class Tasks::SwitchRoot < SingletonTask
     System.failure("init_not_found", "Could not find init path for stage-2", color: "FF00FF")
   end
 
+  # May pause the boot to allow the user to select a generation.
+  def selected_generation()
+    if user_wants_selection()
+      generate_selection()
+      # FIXME: In the future, boot GUIs will be launched async, before this
+      # task is ran.
+      System.run($PROGRAM_NAME, "/applets/boot-selection.mrb")
+      generation = File.read("/run/boot/choice")
+      # Why "$default" rather than passing a path?
+      # Because there may be no generations folder. It's easier to cheat and
+      # use "$default" and rely on the existing default "maybe rehydrate"
+      # codepath.
+      if generation == "$default"
+        default_generation()
+      else
+        generation
+      end
+    else
+      default_generation()
+    end
+  end
+
+  def boot_as_recovery_wants_recovery()
+    # "Boot as recovery" systems do not have a discrete recovery partition.
+    # For those systems, when `[s_]kip_initramfs` is in the kernel cmdline, we
+    # know the intent is to boot the normal system.
+    # Is a "boot as recovery" device, and Is `[s_]kip_initramfs` missing?
+    Configuration["device"]["boot_as_recovery"] and
+      !File.read("/proc/cmdline").split(/\s+/).grep(/[s_]kip_initramfs/).any?
+  end
+
+  def is_recovery()
+    # Check in /etc/boot/config for `is_recovery`, it's assumed to be set, and
+    # true, for recovery.img.
+    Configuration["is_recovery"] or
+      boot_as_recovery_wants_recovery
+  end
+
+  # Checks if the user wants to select a generation.
+  def user_wants_selection()
+    [
+      # Booted a recovery partition.
+      is_recovery,
+      # TODO: Check for held [VOL UP, VOL DOWN, CTRL].any keys (needs some mruby evdev bindings or a simple C tool to list held keys)
+    ].any?
+  end
+
   def run()
-    # TODO: Implement generation selection choice.
-    init = "#{find_generation}/init"
+    init = "#{selected_generation}/init"
 
     # This is the traditional way we printed the init path.
     # This is still helpful to take vertical real estate when visually looking

--- a/devices/asus-dumo/default.nix
+++ b/devices/asus-dumo/default.nix
@@ -10,7 +10,12 @@
     keyboard = false;
     external_storage = true;
     # Serial console on ttyS2, using a suzyqable or equivalent.
-    kernel_cmdline = "console=ttyS2,115200n8 earlyprintk=ttyS2,115200n8 loglevel=8 vt.global_cursor_default";
+    kernel_cmdline = lib.concatStringsSep " " [
+      "console=ttyS2,115200n8"
+      "earlyprintk=ttyS2,115200n8"
+      "loglevel=8"
+      "vt.global_cursor_default=0"
+    ];
     # TODO : move kernel outside of the basic device details
     kernel = pkgs.callPackage ./kernel {};
     # This could be further pared down to only the required dtb files.

--- a/devices/google-walleye/default.nix
+++ b/devices/google-walleye/default.nix
@@ -52,6 +52,9 @@
     flash_offset_tags = "0x00000100";
     flash_pagesize = "4096";
 
+    # This device adds skip_initramfs to cmdline for normal boots
+    boot_as_recovery = true;
+
     ab_partitions = true;
     vendor_partition = "/dev/disk/by-partlabel/vendor_a";
     gadgetfs.functions = {

--- a/devices/qemu-x86_64/default.nix
+++ b/devices/qemu-x86_64/default.nix
@@ -70,10 +70,15 @@ in
   mobile.device.info = device_info // {
     # TODO : make kernel part of options.
     inherit kernel;
-    kernel_cmdline = "console=tty1 console=ttyS0 vga=${MODE.vga}" 
+    kernel_cmdline = lib.concatStringsSep " " ([
+      "console=tty1"
+      "console=ttyS0"
+      "vga=${MODE.vga}" 
+      "vt.global_cursor_default=0"
+    ]
     # TODO : make cmdline configurable outside device.info (device.info would be used for device-specifics only)
-    + lib.optionalString splash " quiet vt.global_cursor_default=0"
-    ;
+    ++ lib.optional splash "quiet"
+    );
   };
   mobile.hardware = {
     soc = "generic-x86_64";

--- a/devices/xiaomi-lavender/default.nix
+++ b/devices/xiaomi-lavender/default.nix
@@ -41,6 +41,9 @@
     flash_offset_tags = "0x00000100";
     flash_pagesize = "4096";
 
+    # This device adds skip_initramfs to cmdline for normal boots
+    boot_as_recovery = true;
+
     vendor_partition = "/dev/disk/by-partlabel/vendor";
     gadgetfs.functions = {
       rndis = "rndis_bam.rndis";

--- a/doc/boot_process.adoc
+++ b/doc/boot_process.adoc
@@ -1,0 +1,62 @@
+= Boot Process
+include::_support/common.inc[]
+
+“How does Mobile NixOS boot?”
+
+This is what this documentation topic tries to describe. This is for end-users.
+
+For developers, see in-depth topics.
+
+
+== Booting Mobile NixOS
+
+Most devices targeted by Mobile NixOS are intended to boot only one kernel at
+a time, with one stage-1, and one system.
+
+NixOS, in turn, shines when a system can choose a _generation_, which has its
+own kernel, stage-1, and system build.
+
+Mobile NixOS, at this point in time, sits on the halfway point. The user cannot
+choose which generation a kernel and stage-1 comes from, but can boot a
+specific generation.
+
+
+== Booting a specific generation
+
+This is done through booting in "recovery mode". This will stop the stage-1
+process before it jumps into the default generation, and will allow you to
+select a system to boot into.
+
+The method to enter recovery mode depends on your device
+
+=== Android-based devices
+
+Android-based devices can be booted in their respective recovery mode.
+
+When the device is a _"Boot as recovery"_ system, no other setup than flashing
+the boot partition is required. _"Boot as recovery"_ systems are generally newer
+Android-based devices.
+
+When the device is not a _"Boot as recovery"_, or still uses a recovery
+partition, you will need to flash a recovery image to the recovery partition.
+
+....
+nix-build --argstr device $DEVICE -A build.android-recovery
+fastboot flash recovery result
+....
+
+=== All other devices
+
+_Including the default boot partition for Android-based devices._
+
+When the boot process is about to switch to the system, if any of the following
+keys are held, it will instead show the recovery menu.
+
+* Volume up
+* Volume down
+* Left shift
+* Right shift
+* Left control
+* Right control
+* Escape
+

--- a/doc/in-depth/android/boot.adoc
+++ b/doc/in-depth/android/boot.adoc
@@ -1,0 +1,39 @@
+= Notes about boot on Android-Based Devices
+include::_support/common.inc[]
+
+Some unordered thoughts about boot on Android-based devices
+
+== Common boot/recovery build
+
+We are building both `boot.img` and `recovery.img` deliberately as being the
+same configuration, except for one forcing the generation selection menu to be
+shown.
+
+This allows us to have better homogeneity for the build process as "Boot as
+recovery" devices would need to be handled otherwise.
+
+This means that the only difference between a `boot.img` and `recovery.img` for
+those older devices is a configuration line in `/etc/boot/config` that states
+the image is built as recovery. Everything else is the same exact build.
+
+_"Boot as recovery"_ devices, instead, rely solely on the lack of
+`skip_initramfs` in the kernel command-line to switch between the two boot
+flows.
+
+=== Recovery as pseudo-A/B
+
+For devices that are not _"Boot as recovery"_, this setup has the added benefit
+that the recovery partition is always a fully functional stage-1 able to boot
+in the system.
+
+Tinkering on-device is, thus, less scary as one can flash a boot.img knowing
+that they can reboot to recovery if it fails to do a proper full boot.
+
+It is recommended to flash `boot.img` first, validate it works, and then to
+flash `recovery.img` if you are not in a situation where you can trivially
+recovery a broken boot.
+
+
+== Links
+
+* https://source.android.com/devices/tech/ota/ab/ab_implement

--- a/modules/hardware-qualcomm.nix
+++ b/modules/hardware-qualcomm.nix
@@ -43,31 +43,31 @@ in
     {
       mobile = mkIf cfg.qualcomm-msm8939.enable {
         system.system = "aarch64-linux";
-        quirks.qualcomm.msm-fb-handle.enable = true;
+        quirks.qualcomm.msm-fb-refresher.enable = true;
       };
     }
     {
       mobile = mkIf cfg.qualcomm-msm8953.enable {
         system.system = "aarch64-linux";
-        quirks.qualcomm.msm-fb-handle.enable = true;
+        quirks.qualcomm.msm-fb-refresher.enable = true;
       };
     }
     {
       mobile = mkIf cfg.qualcomm-msm8996.enable {
         system.system = "aarch64-linux";
-        quirks.qualcomm.msm-fb-handle.enable = true;
+        quirks.qualcomm.msm-fb-refresher.enable = true;
       };
     }
     {
       mobile = mkIf cfg.qualcomm-msm8998.enable {
         system.system = "aarch64-linux";
-        quirks.qualcomm.msm-fb-handle.enable = true;
+        quirks.qualcomm.msm-fb-refresher.enable = true;
       };
     }
     {
       mobile = mkIf cfg.qualcomm-sdm660.enable {
         system.system = "aarch64-linux";
-        quirks.qualcomm.msm-fb-handle.enable = true;
+        quirks.qualcomm.msm-fb-refresher.enable = true;
       };
     }
     {

--- a/modules/initrd-boot-gui.nix
+++ b/modules/initrd-boot-gui.nix
@@ -1,0 +1,20 @@
+{ config, lib, pkgs, ... }:
+
+let
+  boot-gui = ../boot/gui;
+  boot-selection = pkgs.runCommand "boot-selection.mrb" {} ''
+    ${pkgs.buildPackages.mruby}/bin/mrbc -o $out ${boot-gui}/lib/*.rb ${boot-gui}/main.rb
+  '';
+in
+{
+  mobile.boot.stage-1.contents = with pkgs; [
+    {
+      object = (builtins.path { path = ../artwork/logo/logo.white.svg; });
+      symlink = "/etc/logo.svg";
+    }
+    {
+      object = boot-selection;
+      symlink = "/applets/boot-selection.mrb";
+    }
+  ];
+}

--- a/modules/initrd-boot-gui.nix
+++ b/modules/initrd-boot-gui.nix
@@ -2,6 +2,9 @@
 
 let
   boot-gui = ../boot/gui;
+  key-held = pkgs.runCommand "key-held.mrb" {} ''
+    ${pkgs.buildPackages.mruby}/bin/mrbc -o $out ${../boot/applets}/key-held.rb
+  '';
   boot-selection = pkgs.runCommand "boot-selection.mrb" {} ''
     ${pkgs.buildPackages.mruby}/bin/mrbc -o $out ${boot-gui}/lib/*.rb ${boot-gui}/main.rb
   '';
@@ -16,5 +19,13 @@ in
       object = boot-selection;
       symlink = "/applets/boot-selection.mrb";
     }
+    {
+      object = key-held;
+      symlink = "/applets/key-held.mrb";
+    }
+  ];
+  mobile.boot.stage-1.extraUtils = with pkgs; [
+    # Used for `key-held.mrb`.
+    { package = pkgsStatic.evtest; }
   ];
 }

--- a/modules/initrd.nix
+++ b/modules/initrd.nix
@@ -246,6 +246,9 @@ in
       mobile.boot.stage-1.bootConfig = {
         device = {
           inherit (device_config) name;
+          boot_as_recovery = if device_config.info ? boot_as_recovery
+            then device_config.info.boot_as_recovery
+            else false;
         };
         kernel = {
           inherit (config.mobile.boot.stage-1.kernel) modules;

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -15,6 +15,7 @@
   ./hardware-screen.nix
   ./hardware-soc.nix
   ./initrd-base.nix
+  ./initrd-boot-gui.nix
   ./initrd-fbterm.nix
   ./initrd-fail.nix
   ./initrd-kernel.nix

--- a/modules/system-types/android.nix
+++ b/modules/system-types/android.nix
@@ -1,11 +1,31 @@
-{ config, pkgs, lib, ... }:
+{ config, pkgs, lib, modules, baseModules, ... }:
 
 let
+  # In the future, this pattern should be extracted.
+  # We're basically subclassing the main config, just like nesting does in
+  # NixOS (<nixpkgs/modules/system/activation/top-level.nix>)
+  # Here we're only adding the `is_recovery` option.
+  # In the future, we may want to move the recovery configuration to a file.
+  recovery = (import ../../lib/eval-config.nix {
+    inherit baseModules;
+    modules = modules ++ [{
+      mobile.boot.stage-1.bootConfig = {
+        is_recovery = true;
+      };
+    }];
+  }).config;
+
   device_config = config.mobile.device;
   device_name = device_config.name;
   enabled = config.mobile.system.type == "android";
 
   inherit (config.system.build) rootfs;
+
+  android-recovery = pkgs.callPackage ../../systems/bootimg.nix {
+    inherit device_config;
+    initrd = recovery.system.build.initrd;
+    name = "recovery.img";
+  };
 
   android-bootimg = pkgs.callPackage ../../systems/bootimg.nix {
     inherit device_config;
@@ -16,6 +36,7 @@ let
     mkdir -p $out
     ln -s ${rootfs}/${rootfs.filename} $out/system.img
     ln -s ${android-bootimg} $out/boot.img
+    ln -s ${android-recovery} $out/recovery.img
   '';
 in
 {
@@ -24,7 +45,7 @@ in
 
     (lib.mkIf enabled {
       system.build = {
-        inherit android-bootimg android-device;
+        inherit android-bootimg android-recovery android-device;
         mobile-installer = throw "No installer yet...";
       };
     })

--- a/overlay/mruby-builder/mrbgems/default.nix
+++ b/overlay/mruby-builder/mrbgems/default.nix
@@ -2,7 +2,8 @@
 
 let
   inherit (lib) licenses;
-
+in
+rec {
   # Thin wrapper over stdenvNoCC.mkDerivation.
   mkGem = attrs: stdenvNoCC.mkDerivation ({
     # "Static" name. Just like source packages.
@@ -17,8 +18,7 @@ let
       cp -vr . $out
     '';
   } // attrs);
-in
-rec {
+
   mruby-dir = mkGem {
     src = fetchFromGitHub {
       repo = "mruby-dir";

--- a/overlay/mruby-builder/mrbgems/default.nix
+++ b/overlay/mruby-builder/mrbgems/default.nix
@@ -227,10 +227,6 @@ rec {
       ./mruby-require/0001-HACK-Prefer-first-target-if-host-is-not-present.patch
     ];
 
-    linkerFlags = [
-      "-ldl"
-    ];
-
     meta.license = licenses.mit;
   };
 

--- a/overlay/mruby-builder/mrbgems/default.nix
+++ b/overlay/mruby-builder/mrbgems/default.nix
@@ -51,6 +51,7 @@ rec {
       mruby-dir
       mruby-errno
       mruby-file-stat
+      mruby-regexp-pcre
     ];
 
     meta.license = licenses.mit;

--- a/overlay/mruby-builder/mrbgems/default.nix
+++ b/overlay/mruby-builder/mrbgems/default.nix
@@ -227,6 +227,7 @@ rec {
     patches = [
       ./mruby-require/0001-HACK-Skip-turning-gems-to-library-for-tests-output.patch
       ./mruby-require/0001-HACK-Prefer-first-target-if-host-is-not-present.patch
+      ./mruby-require/0001-Skip-realpath-on-absolute-paths.patch
     ];
 
     meta.license = licenses.mit;

--- a/overlay/mruby-builder/mrbgems/default.nix
+++ b/overlay/mruby-builder/mrbgems/default.nix
@@ -13,12 +13,8 @@ let
     buildPhase = ":";
 
     installPhase = ''
-      runHook prePatch
-
       echo " :: Copying mrbgem"
       cp -vr . $out
-
-      runHook postPatch
     '';
   } // attrs);
 in

--- a/overlay/mruby-builder/mrbgems/default.nix
+++ b/overlay/mruby-builder/mrbgems/default.nix
@@ -7,7 +7,7 @@ rec {
   # Thin wrapper over stdenvNoCC.mkDerivation.
   mkGem = attrs: stdenvNoCC.mkDerivation ({
     # "Static" name. Just like source packages.
-    name = attrs.src.name;
+    name = if attrs.src ? name then attrs.src.name else "source";
 
     # Skip these, as they may be accidentally triggered.
     configurePhase = ":";

--- a/overlay/mruby-builder/mrbgems/default.nix
+++ b/overlay/mruby-builder/mrbgems/default.nix
@@ -106,6 +106,10 @@ rec {
     ];
 
     postPatch = ''
+      # Uh... they are testing that they are not implementing something.
+      # Though it may be implemented anywya!
+      rm -vf test/io.rb
+
       substituteInPlace test/file-stat.rb \
         --replace 'dir = __FILE__[0..-18] # 18 = /test/file-stat.rb' \
         'skip "Fails in Nix sandbox"'

--- a/overlay/mruby-builder/mrbgems/default.nix
+++ b/overlay/mruby-builder/mrbgems/default.nix
@@ -119,6 +119,17 @@ rec {
     meta.license = licenses.mit;
   };
 
+  mruby-inotify = mkGem {
+    src = fetchFromGitHub {
+      repo = "mruby-inotify";
+      owner = "projectivetech";
+      rev = "cd00265532384f5eb71bb343eaad1a11d5041db3";
+      sha256 = "1h9cmam6grz32ry0gi17nimv4m7crn8jggmicgd0cz1g7kscsw5a";
+    };
+
+    meta.license = licenses.mit; # See mrbgem.rake
+  };
+
   mruby-json = mkGem {
     src = fetchFromGitHub {
       repo = "mruby-json";

--- a/overlay/mruby-builder/mrbgems/default.nix
+++ b/overlay/mruby-builder/mrbgems/default.nix
@@ -252,4 +252,15 @@ rec {
 
     meta.licenses = licenses.mit;
   };
+
+  mruby-time-strftime = mkGem {
+    src = fetchFromGitHub {
+      repo = "mruby-time-strftime";
+      owner = "monochromegane";
+      rev = "ea8a77504f43fe9f985529b987f3d88bf2a2291a";
+      sha256 = "1yh6sd7m4kqljp30yp6sy3zj6669bvzcans7vvla2rrzm0vdghlk";
+    };
+
+    meta.licenses = licenses.mit;
+  };
 }

--- a/overlay/mruby-builder/mrbgems/default.nix
+++ b/overlay/mruby-builder/mrbgems/default.nix
@@ -8,8 +8,9 @@ let
     # "Static" name. Just like source packages.
     name = attrs.src.name;
 
-    # Skip, as it may be accidentally triggered.
+    # Skip these, as they may be accidentally triggered.
     configurePhase = ":";
+    buildPhase = ":";
 
     installPhase = ''
       runHook prePatch

--- a/overlay/mruby-builder/mrbgems/mruby-lvgui/default.nix
+++ b/overlay/mruby-builder/mrbgems/mruby-lvgui/default.nix
@@ -1,0 +1,30 @@
+{ mrbgems
+, callPackage
+, fetchFromGitHub
+, pkg-config
+
+# Configuration
+, withSimulator ? false
+}:
+let
+  # This is an implementation detail of this gem.
+  # Even if unusual, let's keep it private.
+  lvgui = (callPackage ./lvgui.nix {
+    inherit withSimulator;
+  });
+in
+mrbgems.mkGem {
+  src = fetchFromGitHub {
+    repo = "mruby-lvgui";
+    owner = "mobile-nixos";
+    rev = "d281e8b59f7e70709b7cbb993a84148eaa415302";
+    sha256 = "1ial5lhwl5izn65i5ycpkz3vkmzfmf72w7rx8xb337qnarh4k60z";
+  };
+
+  gemBuildInputs = [
+    lvgui
+  ] ++ lvgui.buildInputs;
+  gemNativeBuildInputs = [
+    pkg-config
+  ];
+}

--- a/overlay/mruby-builder/mrbgems/mruby-lvgui/lvgui.nix
+++ b/overlay/mruby-builder/mrbgems/mruby-lvgui/lvgui.nix
@@ -1,0 +1,71 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, pkg-config
+, libevdev
+, nix-gitignore
+, SDL2
+, withSimulator ? false
+}:
+
+let
+  inherit (lib) optional optionals optionalString;
+  simulatorDeps = [
+    SDL2
+  ];
+in
+  stdenv.mkDerivation {
+    pname = "mobile-nixos-early-boot-gui";
+    version = "2020-02-05";
+
+    #src = nix-gitignore.gitignoreSource [] ./.;
+    src = fetchFromGitHub {
+      fetchSubmodules = true;
+      repo = "lvgui";
+      owner = "mobile-nixos";
+      rev = "27ce1511c3c30ed0921fb92504337f1917ab0943";
+      sha256 = "1vdahc0lymzprnlckdxcba9p78gqymvsy3bhmyqzjx68r8xcd985";
+    };
+
+    nativeBuildInputs = [
+      pkg-config
+    ];
+
+    buildInputs = [
+      libevdev
+    ]
+    ++ optionals withSimulator simulatorDeps
+    ;
+
+    NIX_CFLAGS_COMPILE = [
+      "-DX_DISPLAY_MISSING"
+    ];
+
+    makeFlags = [
+    ]
+    ++ optional withSimulator "LVGL_ENV_SIMULATOR=1"
+    ++ optional (!withSimulator) "LVGL_ENV_SIMULATOR=0"
+    ;
+
+    # TODO: `make install`...
+    installPhase = ''
+      mkdir -p $out/lib
+      cp -vr lib*.a $out/lib/
+
+      mkdir -p $out/include
+      find . -name '*.h' -exec install -vD '{}' $out/include/'{}' ';'
+
+      mkdir -p $out/lib/pkgconfig
+      cat <<EOF > $out/lib/pkgconfig/lvgui.pc
+      Name: lvgui
+      Description: LVGL-based GUI library
+      Version: $version
+      Requires: ${optionalString withSimulator "sdl2"}
+
+      Cflags: -I$out/include
+      Libs: $out/lib/liblvgui.a
+      EOF
+    '';
+
+    enableParallelBuilding = true;
+  }

--- a/overlay/mruby-builder/mrbgems/mruby-require/0001-Skip-realpath-on-absolute-paths.patch
+++ b/overlay/mruby-builder/mrbgems/mruby-require/0001-Skip-realpath-on-absolute-paths.patch
@@ -1,0 +1,36 @@
+From d73aaa4b4a7f639ffc59bd6324b2f95319044201 Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Thu, 27 Feb 2020 17:45:24 -0500
+Subject: [PATCH] Skip realpath on absolute paths
+
+Opening the file with stray `.` and `..` on an absolute path is not
+an issue. This only serves to satiate the compulsiveness of some
+developers.
+
+This allows mruby-require to work during early boot in systems that
+do not have /proc mounted yet, and are using musl libc. The musl libc
+requires /proc to be mounted for realpath to wor.
+---
+ src/mrb_require.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/src/mrb_require.c b/src/mrb_require.c
+index 41bf951..17b1e1b 100644
+--- a/src/mrb_require.c
++++ b/src/mrb_require.c
+@@ -171,6 +171,12 @@ find_file_check(mrb_state *mrb, mrb_value path, mrb_value fname, mrb_value ext)
+   }
+   debug("filepath: %s\n", RSTRING_PTR(filepath));
+ 
++  // We don't need to deal with `realpath` as we have an absolute path.
++  // Sure, we may have . and .. in the path, but that's not relevant to our use case.
++  if (RSTRING_PTR(fname)[0] == '/') {
++    return filepath;
++  }
++
+   if (realpath(RSTRING_CSTR(mrb, filepath), fpath) == NULL) {
+     return mrb_nil_value();
+   }
+-- 
+2.23.1
+

--- a/overlay/mruby-builder/mruby/0001-Nixpkgs-dump-linker-flags-for-re-use.patch
+++ b/overlay/mruby-builder/mruby/0001-Nixpkgs-dump-linker-flags-for-re-use.patch
@@ -1,0 +1,68 @@
+From 3a7034f2fd1060b2a1fc9d015f6df7fe73f18cf6 Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Mon, 24 Feb 2020 20:01:47 -0500
+Subject: [PATCH] Nixpkgs: dump linker flags for re-use
+
+Dumping the flags the build-system used is useful to allow re-using them
+to compile custom binaries, via mrbc + custom gcc invocations.
+
+Actually using the flags as defined by gems and mruby is much better
+than hoping we're not forgetting to define some in the project-specific
+builder.
+---
+ Rakefile | 42 ++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 42 insertions(+)
+
+diff --git a/Rakefile b/Rakefile
+index 28e2d75c..5a13046a 100644
+--- a/Rakefile
++++ b/Rakefile
+@@ -157,3 +157,45 @@ task :deep_clean => ["clean", "clean_doc"] do
+   end
+   puts "Cleaned up mrbgems build folder"
+ end
++
++desc "Output linker flags"
++task :dump_linker_flags do
++  # This assumes the first defined target is the desired one.
++  # [{ host: ...   }]
++  #  ^first  ^last
++  target = MRuby.targets.first.last
++  require "shellwords"
++
++  File.open("mruby_linker_flags.sh", "w") do |file|
++    file.puts "mrb_cflags=("
++    file.puts target.cc.all_flags
++    file.puts ")"
++    file.puts ""
++    [:flags, :flags_before_libraries, :flags_after_libraries, :libraries, :library_paths].each do |sym|
++      contents = [
++        target.linker.send(sym),
++        *target.gems.map { |g| g.linker.send(sym) },
++      ].flatten
++      file.puts "mrb_linker_#{sym}=("
++      file.puts contents.shelljoin
++      file.puts ")"
++      file.puts ""
++    end
++    contents = [
++      target.linker.libraries,
++      *target.gems.map { |g| g.linker.libraries },
++    ].flatten
++    file.puts "mrb_linker_libraries_flags=("
++    file.puts contents.map{|lib| "-l#{lib}"}.shelljoin
++    file.puts ")"
++    file.puts ""
++    contents = [
++      target.linker.library_paths,
++      *target.gems.map { |g| g.linker.library_paths },
++    ].flatten
++    file.puts "mrb_linker_library_paths_flags=("
++    file.puts contents.map{|lib| "-L#{lib}"}.shelljoin
++    file.puts ")"
++    file.puts ""
++  end
++end
+-- 
+2.23.1
+

--- a/overlay/mruby-builder/mruby/builder.nix
+++ b/overlay/mruby-builder/mruby/builder.nix
@@ -43,14 +43,21 @@ in
   buildPhase = ''
     runHook preBuild
 
+    . ${mruby}/nix-support/mruby_linker_flags.sh
+
     CFLAGS+=(
       "-I${mruby}/include"
-      ${concatStringsSep "\n" mruby.compilerFlags}
+      "''${mrb_cflags[@]}"
     )
 
     LDFLAGS+=(
       "-L${mruby}/lib"
-      ${concatStringsSep "\n" mruby.linkerFlags}
+      "-lmruby"
+      "''${mrb_linker_flags[@]}"
+      "''${mrb_linker_flags_before_libraries[@]}"
+      "''${mrb_linker_library_paths_flags[@]}"
+      "''${mrb_linker_libraries_flags[@]}"
+      "''${mrb_linker_flags_after_libraries[@]}"
     )
 
     makeBin() {

--- a/overlay/mruby-builder/mruby/builder.nix
+++ b/overlay/mruby-builder/mruby/builder.nix
@@ -31,34 +31,6 @@ let
   mruby = mruby'.override({
     inherit gems;
   });
-  stub = writeText "mruby-stub.c" ''
-    #include <mruby.h>
-    #include <mruby/irep.h>
-    #include "irep.c"
-    #include <stdlib.h>
-
-    int
-    main(void)
-    {
-      mrb_state *mrb = mrb_open();
-      if (!mrb) {
-          /* handle error */
-          printf("[FATAL] Could not open mruby.\n");
-          exit(1);
-      }
-      mrb_load_irep(mrb, ruby_irep);
-
-      if (mrb->exc) {
-          mrb_print_backtrace(mrb);
-          mrb_print_error(mrb);
-          mrb_close(mrb);
-          exit(1);
-      }
-
-      mrb_close(mrb);
-      return 0;
-    }
-  '';
 in
   stdenv.mkDerivation ((
     builtins.removeAttrs attrs ["gems"]
@@ -95,7 +67,7 @@ in
         "$@"
       )
 
-      [ ! -f stub.c ] && cp -f ${stub} stub.c
+      [ ! -f stub.c ] && cp -f ${./stub.c} stub.c
 
       echo " :: Compiling with stub"
       (set -x

--- a/overlay/mruby-builder/mruby/default.nix
+++ b/overlay/mruby-builder/mruby/default.nix
@@ -87,7 +87,11 @@ let
 
   gemsForGems = concatGemAttr "requiredGems" gems;
 
-  gems' = optionals useDefaults defaultGems ++ gems ++ gemsForGems;
+  # Gems for gems needs to be set before gems.
+  # This is because `mruby-require` has weird semantics in the gems listing.
+  # More in-depth handling of gems is required if we want to properly handle
+  # dependencies mruby-require transforms as shared libraries.
+  gems' = optionals useDefaults defaultGems ++ gemsForGems ++ gems;
   gemBoxes' = optionals useDefaults defaultGemBoxes ++ gemBoxes;
 
   gemBuildInputs = concatGemAttr "gemBuildInputs" gems;

--- a/overlay/mruby-builder/mruby/default.nix
+++ b/overlay/mruby-builder/mruby/default.nix
@@ -181,13 +181,13 @@ stdenv.mkDerivation rec {
   buildPhase = ''
     runHook preBuild
     cp -vf ${mruby-config} build_config.rb
-    ruby ./minirake -v
+    ruby ./minirake -v -j$NIX_BUILD_CORES
     runHook postBuild
   '';
 
   checkPhase = ''
     runHook preCheck
-    ruby ./minirake test
+    ruby ./minirake test -j$NIX_BUILD_CORES
     runHook postCheck
   '';
 
@@ -213,4 +213,6 @@ stdenv.mkDerivation rec {
   passthru = {
     inherit linkerFlags compilerFlags;
   };
+
+  enableParallelBuilding = true;
 }

--- a/overlay/mruby-builder/mruby/default.nix
+++ b/overlay/mruby-builder/mruby/default.nix
@@ -97,20 +97,6 @@ let
   gemBuildInputs = concatGemAttr "gemBuildInputs" gems;
   gemNativeBuildInputs = concatGemAttr "gemNativeBuildInputs" gems;
 
-  compilerFlags = [
-    "-std=c99"
-    "-Os"
-  ]
-  ++ concatGemAttr "compilerFlags" gems
-  ;
-
-  linkerFlags = [
-    "-lm"
-    "-lmruby"
-  ]
-  ++ concatGemAttr "linkerFlags" gems
-  ;
-
   shared-config = ''
       # Gemboxes
       ${concatMapStringsSep "\n" (box: "conf.gembox '${box}'") gemBoxes'}
@@ -217,10 +203,6 @@ stdenv.mkDerivation rec {
     maintainers = [ maintainers.nicknovitski ];
     license = licenses.mit;
     platforms = platforms.unix;
-  };
-
-  passthru = {
-    inherit linkerFlags compilerFlags;
   };
 
   enableParallelBuilding = true;

--- a/overlay/mruby-builder/mruby/default.nix
+++ b/overlay/mruby-builder/mruby/default.nix
@@ -167,6 +167,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     ./0001-HACK-Ensures-a-host-less-build-can-be-made.patch
+    ./0001-Nixpkgs-dump-linker-flags-for-re-use.patch
   ];
 
   nativeBuildInputs = [ ruby bison ];
@@ -182,6 +183,7 @@ stdenv.mkDerivation rec {
     runHook preBuild
     cp -vf ${mruby-config} build_config.rb
     ruby ./minirake -v -j$NIX_BUILD_CORES
+    ruby ./minirake -v dump_linker_flags
     runHook postBuild
   '';
 
@@ -200,6 +202,8 @@ stdenv.mkDerivation rec {
     cp -R build/${targetName}/bin $out
     cp -R build/${targetName}/lib $out
     cp -R include $out
+    mkdir -p $out/nix-support
+    cp mruby_linker_flags.sh $out/nix-support/
   '';
 
   meta = with stdenv.lib; {

--- a/overlay/mruby-builder/mruby/default.nix
+++ b/overlay/mruby-builder/mruby/default.nix
@@ -91,6 +91,7 @@ let
   gemBoxes' = optionals useDefaults defaultGemBoxes ++ gemBoxes;
 
   gemBuildInputs = concatGemAttr "gemBuildInputs" gems;
+  gemNativeBuildInputs = concatGemAttr "gemNativeBuildInputs" gems;
 
   compilerFlags = [
     "-std=c99"
@@ -170,7 +171,7 @@ stdenv.mkDerivation rec {
     ./0001-Nixpkgs-dump-linker-flags-for-re-use.patch
   ];
 
-  nativeBuildInputs = [ ruby bison ];
+  nativeBuildInputs = [ ruby bison ] ++ gemNativeBuildInputs;
   buildInputs = gemBuildInputs;
 
   # Necessary so it uses `gcc` instead of `ld` for linking.

--- a/overlay/mruby-builder/mruby/stub.c
+++ b/overlay/mruby-builder/mruby/stub.c
@@ -1,0 +1,27 @@
+#include <mruby.h>
+#include <mruby/irep.h>
+#include "irep.c"
+#include <stdlib.h>
+
+int
+main(void)
+{
+	mrb_state *mrb = mrb_open();
+	if (!mrb) {
+		/* handle error */
+		printf("[FATAL] Could not open mruby.\n");
+		exit(1);
+	}
+	mrb_load_irep(mrb, ruby_irep);
+
+	if (mrb->exc) {
+		mrb_print_backtrace(mrb);
+		mrb_print_error(mrb);
+		mrb_close(mrb);
+		exit(1);
+	}
+
+	mrb_close(mrb);
+	return 0;
+}
+

--- a/overlay/mruby-builder/mruby/stub.c
+++ b/overlay/mruby-builder/mruby/stub.c
@@ -1,17 +1,44 @@
-#include <mruby.h>
-#include <mruby/irep.h>
-#include "irep.c"
 #include <stdlib.h>
+#include <string.h>
+
+#include <mruby.h>
+#include <mruby/array.h>
+#include <mruby/irep.h>
+#include <mruby/variable.h>
+
+// Assumes this is produced by builder.nix
+#include "irep.c"
 
 int
-main(void)
+main(int argc, char **argv)
 {
+	int i;
+	mrb_value ARGV;
+	mrb_sym dollar_zero;
+	mrb_sym program_name;
 	mrb_state *mrb = mrb_open();
+
 	if (!mrb) {
 		/* handle error */
 		printf("[FATAL] Could not open mruby.\n");
 		exit(1);
 	}
+
+	ARGV = mrb_ary_new_capa(mrb, argc);
+	// Skip the program name here.
+	for (i = 1; i < argc; i++) {
+		mrb_ary_push(mrb, ARGV, mrb_str_new(mrb, argv[i], strlen(argv[i])));
+	}
+	mrb_define_global_const(mrb, "ARGV", ARGV);
+
+	// $0
+	dollar_zero = mrb_intern_lit(mrb, "$0");
+	mrb_gv_set(mrb, dollar_zero, mrb_str_new(mrb, argv[0], strlen(argv[0])));
+
+	// $PROGRAM_NAME
+	program_name = mrb_intern_lit(mrb, "$PROGRAM_NAME");
+	mrb_gv_set(mrb, program_name, mrb_str_new(mrb, argv[0], strlen(argv[0])));
+
 	mrb_load_irep(mrb, ruby_irep);
 
 	if (mrb->exc) {

--- a/overlay/mruby-builder/overlay.nix
+++ b/overlay/mruby-builder/overlay.nix
@@ -6,10 +6,15 @@ let
   # Let's co-opt the `dontDisableStatic` attribute it overrides into a
   # derivation, let's say, hello...
   static = if final.hello ? dontDisableStatic then final.hello.dontDisableStatic else false;
+  mrbgems = final.callPackage ./mrbgems {};
 in
 {
   hello-mruby = final.callPackage ./hello-mruby {};
-  mrbgems = final.callPackage ./mrbgems {};
+  mrbgems = mrbgems // {
+    mruby-lvgui = final.callPackage ./mrbgems/mruby-lvgui {
+      mrbgems = mrbgems;
+    };
+  };
   mruby = (final.callPackage ./mruby {}).overrideAttrs({passthru ? {}, ...}: {
     passthru = passthru // {
       builder = final.callPackage ./mruby/builder.nix {

--- a/systems/bootimg.nix
+++ b/systems/bootimg.nix
@@ -1,6 +1,7 @@
 { device_config
 , initrd
 , pkgs
+, name ? "boot.img"
 }:
 let
   inherit (pkgs) buildPackages;
@@ -15,7 +16,7 @@ let
   cmdline = device_info.kernel_cmdline;
 in
 pkgs.stdenv.mkDerivation {
-  name = "nixos-mobile_${device_name}_boot.img";
+  name = "mobile-nixos_${device_name}_${name}";
 
   src = builtins.filterSource (path: type: false) ./.;
   unpackPhase = "true";

--- a/systems/kernel-initrd.nix
+++ b/systems/kernel-initrd.nix
@@ -16,7 +16,7 @@ let
   cmdline = device_info.kernel_cmdline;
 in
 stdenv.mkDerivation {
-  name = "nixos-mobile_${device_name}_boot.img";
+  name = "mobile-nixos_${device_name}-kernel-initrd";
 
   src = builtins.filterSource (path: type: false) ./.;
   unpackPhase = "true";


### PR DESCRIPTION
This adds a GUI allowing the user to select a generation.

The current GUI is expected to be run as the "recovery" image.

This is only the most basic implementation. It does not allow `kexec`ing another kernel. It only allows selecting a generation. Though, as basic as it is, it allows further on-device tinkering to be done much more safely.

This even gives a pseudo-AB system for non-AB systems. The user can flash a new boot.img on top of their boot partition, and if it fails to boot, boot to the system using the recovery menu.

#### Implementation notes

To reduce the footprint of the init, this splits the `init` "script" from the interpreter, as previously implemented. This means we now unconditionally use the wrapper script to exec the init.

Splitting the interpreter does allow us to add more "applets". Those "applets", in turn, allow us to add more in-depth applications implemented using the same scripting environment.

The GUI is implemented using [mruby-lvgui](https://github.com/mobile-nixos/mruby-lvgui), a set of bindings for [LittlevGL](https://littlevgl.com/).

#### Other notable changes

The mruby builder infrastructure is a bit sturdier. Rather than rely on a user-provided list of flags, for the final "stub" build, it uses saved information from the actual build. No flags should be missing.

Additionally, the stub now documents `ARGV` and `$PROGRAM_NAME`. This, in turn, allows scripts written using mruby to parse arguments. Quite necessary.

#### To implement later:

 * [ ] Async boot selection with multiple agents
 * [ ] Define the "agents" spec
 * [ ] `kexec` into another kernel+initrd

 * [ ] Keyboard control for Boot GUI

This will be required for pinebook-pro usage (which is a goal). It could also be nice with volume up/down + power for phones with broken digitizers. This can be merged without keyboard control support as it's not causing a regression.

 * [ ] Mouse control for Boot GUI

In theory it's supported, in practice it's not. LVGL supports mouse input. It seems the evdev driver only supports touch input, though this is unverified. This would be required for QEMU, and helpful for laptop use.

#### To implement quickly:

 * [ ] Assume "recovery" when some keys are held

This is to be used on e.g. chromeos tablets, or non-android systems (e.g. pinephone, pinebook pro). Holding one of [volume up, volume down, right control, left control] should act as if recovery was requested.

 * [ ] Better split init from script loader

Right now they still live in the same folder. A small mark of their past.

 * [ ] Fix and make available the "simulator

There is a "simulator" for the boot GUI. This is how it was developed, not on-device, but in a window. It seems *something* happened and it doesn't work quite right anymore. This needs to be investigated, and fixed. Then, once fixed, be made available for easier development/testing.

#### Future somewhat related improvements

##### lvgui

 * [ ] use lvgui exclusively

Remove `ply-image` dependency, and use lvgui exclusively to show splash, and to show error states.

Benefits:

 * Text on error state
 * SVGs for all images
 * fix the bug with sad phone image background not being transparent