### PR TITLE
Add installer script to android device output

### DIFF
--- a/devices/xiaomi-lavender/default.nix
+++ b/devices/xiaomi-lavender/default.nix
@@ -43,6 +43,9 @@
 
     # This device adds skip_initramfs to cmdline for normal boots
     boot_as_recovery = true;
+    # Though this device has "boot_as_recovery", it still has a classic
+    # recovery partition for recovery. Go figure.
+    has_recovery_partition = true;
 
     vendor_partition = "/dev/disk/by-partlabel/vendor";
     gadgetfs.functions = {


### PR DESCRIPTION
It will install to both A/B slots, and to the boot, and recovery partitions.

To be used like so:

```
 $ nix-build --argstr device google-walleye -A build.android-device
 $ result/flash-critical.sh
```

This is not documented as being "the way" to install on devices yet since this is almost unusable as it is right now.

The `android-device` output assumes a `rootfs` can be built. The current defaults cannot build a usable rootfs when cross-compiling.

This can be worked around like so:

`local.nix`
```
{ lib, pkgs, ... }:

{
  system.build.rootfs = (pkgs.runCommandNoCC "dummy-rootfs" {
    passthru = {
      filename = "dummy.img";
    };
  } ''
    mkdir -p $out/
    touch $out/dummy.img
  '');
}
```

Though, this points to a wart: this does not use `lib.mkForce`  or anything similar. Using `lib.mkForce` seemingly does not work for `system.build`. I'm not even sure why this works.

#### TODO

 * [ ] Make a usable rootfs when cross-compiling

Either through forcing a dummy image by default, or preferred, making a small "placeholder" nixos system that boots to an LVGL app in stage-2. (That LVGL app could be a hardware test app...)