### PR TITLE
Update lvgui for better pointer support

### DIFF
--- a/modules/initrd.nix
+++ b/modules/initrd.nix
@@ -123,7 +123,10 @@ let
     echo 'ENV{PATH}="${extraUtils}/bin"' >> $out/00-env.rules
 
     cp -v ${udev}/lib/udev/rules.d/60-cdrom_id.rules $out/
+    cp -v ${udev}/lib/udev/rules.d/60-input-id.rules $out/
+    cp -v ${udev}/lib/udev/rules.d/60-persistent-input.rules $out/
     cp -v ${udev}/lib/udev/rules.d/60-persistent-storage.rules $out/
+    cp -v ${udev}/lib/udev/rules.d/70-touchpad.rules $out/
     cp -v ${udev}/lib/udev/rules.d/80-drivers.rules $out/
     cp -v ${pkgs.lvm2}/lib/udev/rules.d/*.rules $out/
 

--- a/overlay/mruby-builder/mrbgems/mruby-lvgui/lvgui.nix
+++ b/overlay/mruby-builder/mrbgems/mruby-lvgui/lvgui.nix
@@ -1,8 +1,8 @@
 { stdenv
+, pkgs
 , lib
 , fetchFromGitHub
 , pkg-config
-, libevdev
 , SDL2
 , withSimulator ? false
 }:
@@ -12,6 +12,15 @@ let
   simulatorDeps = [
     SDL2
   ];
+
+  # Allow libevdev to cross-compile.
+  libevdev = (pkgs.libevdev.override({
+    python3 = null;
+  })).overrideAttrs({nativeBuildsInputs ? [], ...}: {
+    nativeBuildInputs = nativeBuildsInputs ++ [
+      pkgs.buildPackages.python3
+    ];
+  });
 in
   stdenv.mkDerivation {
     pname = "mobile-nixos-early-boot-gui";
@@ -21,8 +30,8 @@ in
       fetchSubmodules = true;
       repo = "lvgui";
       owner = "mobile-nixos";
-      rev = "27ce1511c3c30ed0921fb92504337f1917ab0943";
-      sha256 = "1vdahc0lymzprnlckdxcba9p78gqymvsy3bhmyqzjx68r8xcd985";
+      rev = "a3412d9e2a8d1c7a23b48cf2cdf2c39cf4009651";
+      sha256 = "1ibdjnqjacw27wmdg1fir4isffq2v87ml382f4g76ldmi5za0n9l";
     };
 
     # Document `LVGL_ENV_SIMULATOR` in the built headers.
@@ -65,7 +74,7 @@ in
       Name: lvgui
       Description: LVGL-based GUI library
       Version: $version
-      Requires: ${optionalString withSimulator "sdl2"}
+      Requires: ${optionalString withSimulator "sdl2"} ${optionalString (!withSimulator) "libevdev"}
 
       Cflags: -I$out/include
       Libs: $out/lib/liblvgui.a


### PR DESCRIPTION
This adds the necessary support to better handle other pointing-type
inputs.

 * Cursor for non-touch devices
 * Handle abs min/max
 * Handle touchpads

With this, a tablet-type input, like used by QEMU, now works.

This is important for non-touch uses. It seems antithetical to "Mobile" NixOS, but it's not. The whole boot chain should be dogfood-able on any device NixOS runs. Not all of them have touchscreens.

~~Though, with that said, an improvement could be made with the cursor. The main one would be to use a circle "touch zone" cursor. The way LVGL handles cursors it's not possible, as it assumes `[0, 0]` on the object given as a cursor is the pointy bit of the pointer. A non LVGL-native handling of the cursor will be needed. This would, in turn, gives us the benefit of being able to guesstimate touch inputs from non-touch, and hide the cursor like `unclutter` does, hiding quicker when we're sure it's a touch.~~

With the new way I handle touchpads/mice, we can drop that requirement, at least for now. Touch-only devices will not see a cursor, and if you have touch+mice the cursor will not jump on touch.