### PR TITLE
Add workarounds to enable minimal rootfs cross-compilation.

### DIFF
--- a/modules/cross-workarounds.nix
+++ b/modules/cross-workarounds.nix
@@ -1,0 +1,21 @@
+{ lib, config, ... }:
+
+# This module adds system-level workarounds when cross-compiling.
+# These workarounds are only expected to be implemented for the *basic* build.
+# That is `nix-build ./default.nix`, without additional configuration.
+let
+  isCross =
+    config.nixpkgs.crossSystem != null &&
+    config.nixpkgs.localSystem.system != null &&
+    config.nixpkgs.crossSystem.system != config.nixpkgs.localSystem.system;
+in
+lib.mkIf isCross
+{
+  # building '/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-fc-cache.drv'...
+  # [...]-fontconfig-2.10.2-aarch64-unknown-linux-gnu-bin/bin/fc-cache: cannot execute binary file: Exec format error
+  fonts.fontconfig.enable = false;
+
+  # building '/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-mesa-19.3.3-aarch64-unknown-linux-gnu.drv'...
+  # meson.build:1537:2: ERROR: Dependency "wayland-scanner" not found, tried pkgconfig
+  security.polkit.enable = false;
+}

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -8,6 +8,7 @@
   ./_nixos-disintegration
   ./adb.nix
   ./boot-initrd.nix
+  ./cross-workarounds.nix
   ./hardware-generic.nix
   ./hardware-qualcomm.nix
   ./hardware-ram.nix


### PR DESCRIPTION
With this, we can build disk images with a rootfs with cross-compilation.

They are *not* useful rootfs! They simply compile!

A future upgrade to this will be to make an example system (in the examples folder) which starts a hardware testing LVGUI "applet".

For now, this is enough to make the upcoming hydra builds happy.