### PR TITLE
lib/eval-config.nix: Directly use the upstream one

### DIFF
--- a/lib/eval-config.nix
+++ b/lib/eval-config.nix
@@ -1,52 +1,6 @@
-# This file is based on <nixpkgs/nixos/lib/eval-config.nix>.
-
-{ # !!! system can be set modularly, would be nice to remove
-  system ? builtins.currentSystem
-, # !!! is this argument needed any more? The pkgs argument can
-  # be set modularly anyway.
-  pkgs ? null
-, # !!! what do we gain by making this configurable?
-  baseModules ? import ../modules/module-list.nix
-, # !!! See comment about args in lib/modules.nix
-  extraArgs ? {}
-, # !!! See comment about args in lib/modules.nix
-  specialArgs ? {}
-, modules
-, # !!! See comment about check in lib/modules.nix
-  check ? true
-, prefix ? []
-, lib ? import <nixpkgs/lib>
-}:
-
-let extraArgs_ = extraArgs; pkgs_ = pkgs;
-in
-
-let
-  pkgsModule = rec {
-    _file = ./eval-config.nix;
-    key = _file;
-    config = {
-      nixpkgs.localSystem = lib.mkDefault { inherit system; };
-      _module.args.pkgs = lib.mkIf (pkgs_ != null) (lib.mkForce pkgs_);
-    };
-  };
-
-in rec {
-
-  # Merge the option definitions in all modules, forming the full
-  # system configuration.
-  inherit (lib.evalModules {
-    inherit prefix check;
-    modules = modules ++ baseModules ++ [ pkgsModule ];
-    args = extraArgs;
-    specialArgs = { modulesPath = ../modules; } // specialArgs;
-  }) config options;
-
-  # These are the extra arguments passed to every module.  In
-  # particular, Nixpkgs is passed through the "pkgs" argument.
-  extraArgs = extraArgs_ // {
-    inherit modules baseModules;
-  };
-
-  inherit (config._module.args) pkgs;
-}
+{ baseModules ? import ../modules/module-list.nix
+, ...
+} @ args:
+import <nixpkgs/nixos/lib/eval-config.nix> (args // {
+  inherit baseModules;
+})

--- a/modules/initrd.nix
+++ b/modules/initrd.nix
@@ -106,9 +106,9 @@ let
   # The initrd only has to mount `/` or any FS marked as necessary for
   # booting (such as the FS containing `/nix/store`, or an FS needed for
   # mounting `/`, like `/` on a loopback).
-  bootFileSystems = listToAttrs (map (item: { inherit (item._module.args) name; value = item; })
-    (filter utils.fsNeededForBoot config.system.build.fileSystems)
-  );
+  bootFileSystems' = filter utils.fsNeededForBoot config.system.build.fileSystems;
+  # Converts from list of attrsets, to an attrset indexed by mountPoint.
+  bootFileSystems = listToAttrs (map (item: { name = item.mountPoint; value = item; }) bootFileSystems');
 
   udevRules = runCommandNoCC "udev-rules" {
     allowedReferences = [ extraUtils ];


### PR DESCRIPTION
Though with *our* modules.

With https://github.com/NixOS/nixpkgs/pull/82960 this fixes the regression from https://github.com/NixOS/nixpkgs/pull/82751.