### PR TITLE
Add `bin/menuconfig` to configure kernels

### DIFF
--- a/bin/kernel-normalize-config
+++ b/bin/kernel-normalize-config
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+#!/usr/bin/env nix-shell
+#!nix-shell -p ruby -i ruby
 
 # This script is expected to be used to copy back the `kernel-builder` built
 # linux configuration to the kernel's source directory.
@@ -8,27 +9,7 @@
 #  - Changing configuration options
 #  - Changing the kernel version
 
-set -e
-set -u
-PS4=" $ "
+ROOT = File.join(__dir__, "..")
+exec(File.join(ROOT, "bin", "menuconfig"), "--only-save", *ARGV)
 
-if (( $# != 2 )); then
-	echo "Usage: bin/kernel-normalize-config <device-name> <output>"
-	exit 1
-fi
-
-device="$1"; shift
-out="$1"; shift
-
-set -x
-
-build() {
-	nix-build --no-out-link -A config.mobile.device.info.kernel --argstr device "$device"
-}
-
-# The first one actively rebuilds to get the config...
-cp "$(build)/build.config" "$out"
-# This one rebuilds with the (assumedly) normalized config
-cp "$(build)/build.config" "$out"
-# This last copy and build is likely useless. Though it's a quick no-op
-cp "$(build)/build.config" "$out"
+# vim: ft=ruby

--- a/bin/menuconfig
+++ b/bin/menuconfig
@@ -1,0 +1,57 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -p ruby -i ruby
+
+require "shellwords"
+ROOT = File.join(__dir__, "..")
+
+def usage()
+  puts "Usage: #{$PROGRAM_NAME} [--only-save] <device_name>"
+end
+
+# Poor approximation to arguments parsing.
+params, other_args = ARGV.partition { |s| s.match(/^--/) }
+
+if other_args.empty?
+  $stderr.puts "Device name required."
+  usage
+  exit 1
+end
+
+DEVICE = other_args.shift
+FILE = Dir.glob(File.join(ROOT, "devices", DEVICE, "kernel", "config.*")).sort.first
+
+ONLY_SAVE = !!params.delete("--only-save")
+
+unless params.empty?
+  $stderr.puts "Unknown parameters #{params.join(", ")}."
+  usage
+  exit 1
+end
+unless other_args.empty?
+  $stderr.puts "Unexpected arguments #{other_args.join(", ")}."
+  usage
+  exit 1
+end
+unless File.exists?(FILE)
+  $stderr.puts "Could not find kernel configuration file for #{DEVICE}."
+  usage
+  exit 1
+end
+
+Dir.chdir(ROOT) do
+  tool = File.join(`#{[
+    "nix-build",
+    "--no-out-link",
+    "--argstr", "device", DEVICE,
+    "-A", "config.mobile.device.info.kernel.menuconfig"
+  ].shelljoin}`.strip, "bin/nconf")
+
+  if ONLY_SAVE
+    # Equivalent to F9,Enter
+    `echo -e "[20~\n" | #{[tool, FILE].shelljoin}`
+  else
+    system(tool, FILE)
+  end
+end
+
+# vim: ft=ruby

--- a/doc/porting-guide.adoc
+++ b/doc/porting-guide.adoc
@@ -9,3 +9,23 @@ In a nutshell, the basic steps are:
 * Finding appropriate the sources (mainly the kernel).
 * Writing the expressions to build said sources.
 
+== Kernel configuration
+
+The kernel can be configured using the following command, where `$DEVICE` is
+the device name.
+
+```
+ $ bin/menuconfig $DEVICE
+```
+
+When importing a configuration from another source, manually editing the kernel
+configuration, or updating the kernel version, it is recommended to run the
+kernel configuration normalization too.
+
+```
+ $ bin/kernel-normalize-config $DEVICE
+```
+
+Be mindful of your `$NIX_PATH` when running these tools. Ensure it points to
+the Nixpkgs checkout you use to work on Mobile NixOS or else it may build the
+toolchain fresh.

--- a/overlay/mobile-nixos/kernel/builder.nix
+++ b/overlay/mobile-nixos/kernel/builder.nix
@@ -233,56 +233,91 @@ let kernel = stdenv.mkDerivation {
   passthru = {
     # Patching over this configuration to expose menuconfig.
     menuconfig = kernel.overrideAttrs({nativeBuildInputs ? [] , ...}: {
-      # What, another level of overriding???
-      # This time, it's to get patched sources.
-      # We'll need them at run-time for nconfig.
-      src = kernel.overrideAttrs({...}: {
-        buildPhase = ":";
-        configurePhase = ":";
-        fixupPhase = ":";
-
-        installPhase = ''
-          cp -prf . $out
-        '';
-      });
-
-      patchPhase = "echo 'Skipping, already ran...'";
-
       nativeBuildInputs = nativeBuildInputs ++ [
-        pkgconfig
         ncurses
+        pkgconfig
       ];
-      buildFlags = [ "nconfig" ];
+      buildFlags = [ "nconfig" "V=1" ];
+
+      # TODO: build `nconfig`, but copy the whole source dir
       buildPhase = ''
+        (PS4=" $ "; set -x
+
+        # Hot fixes pkg-config use.
+        export PKG_CONFIG_PATH="${buildPackages.ncurses.dev}/lib/pkgconfig"
+        if [ -e scripts/kconfig/nconf-cfg.sh ]; then
+          sed -i"" \
+            -e 's/$(pkg-config --libs $PKG)/-L $(pkg-config --variable=libdir ncursesw) $(pkg-config --libs $PKG)/' \
+            scripts/kconfig/nconf-cfg.sh
+        fi
+
+        cat >> scripts/kconfig/Makefile <<EOF
+
+        run-nconfig:
+        ${"\t"}\$(obj)/nconf \$(silent) \$(Kconfig)
+        EOF
+
+        # Stops `make ...config` from starting the application.
+        cp scripts/kconfig/Makefile scripts/kconfig/Makefile.old
         sed -i"" -e 's/$< .*$(Kconfig)/echo "no-op"/' scripts/kconfig/Makefile
+
+        # Build the ...config application.
         make $buildFlags
+
+        mv scripts/kconfig/Makefile.old scripts/kconfig/Makefile
+        )
       '';
       configurePhase = ":";
       installFlags = [];
 
       # For menuconfig, it would be: "scripts/kconfig/mconf"
+      # A future optimisation could be to filter unneeded files like .c and .h,
+      # and docs. Though generally unneeded, this is a development-only tool.
       installPhase = ''
-        mkdir -p $out/{bin,libexec}
-        cp "scripts/kconfig/nconf" "$out/libexec"
+        (PS4=" $ "; set -x
+
+        cp -prf . $out
+        mkdir -p $out/bin
+
+        find $out/ -iname '*.o' -exec 'rm' '{}' ';'
+
+        (set -u
         cat > $out/bin/nconf <<EOF
         #!${runtimeShell}
         set -e
         set -u
+        PS4=" $ "; set -x
 
         if ((\$# < 1)); then
           echo "Usage: \$0 <config.file>"
           exit 1
         fi
 
+        export KERNEL_TREE=\$(mktemp -d)
+
+        function finish {
+          rm -rf "\$KERNEL_TREE"
+        }
+        trap finish EXIT
+
+
+        rmdir "\$KERNEL_TREE"
+        cp -rf $out "\$KERNEL_TREE"
+        chmod -R +w "\$KERNEL_TREE"
+
+        export PATH="$PATH:${buildPackages.gnumake}/bin"
         export KCONFIG_CONFIG="\$(readlink -f "\$1")"; shift
 
         export SRCARCH="${stdenv.hostPlatform.platform.kernelArch}"
         export ARCH="${stdenv.hostPlatform.platform.kernelArch}"
         export KERNELVERSION="${version}"
-        cd $src
-        exec $out/libexec/nconf $src/Kconfig "\$@"
+        cd "\$KERNEL_TREE"
+        make run-nconfig "\$@"
         EOF
+        )
+
         chmod +x $out/bin/nconf
+        )
       '';
     });
   };

--- a/overlay/mobile-nixos/kernel/builder.nix
+++ b/overlay/mobile-nixos/kernel/builder.nix
@@ -233,6 +233,21 @@ let kernel = stdenv.mkDerivation {
   passthru = {
     # Patching over this configuration to expose menuconfig.
     menuconfig = kernel.overrideAttrs({nativeBuildInputs ? [] , ...}: {
+      # What, another level of overriding???
+      # This time, it's to get patched sources.
+      # We'll need them at run-time for nconfig.
+      src = kernel.overrideAttrs({...}: {
+        buildPhase = ":";
+        configurePhase = ":";
+        fixupPhase = ":";
+
+        installPhase = ''
+          cp -prf . $out
+        '';
+      });
+
+      patchPhase = "echo 'Skipping, already ran...'";
+
       nativeBuildInputs = nativeBuildInputs ++ [
         pkgconfig
         ncurses


### PR DESCRIPTION
Had an epiphany about ways to co-opt the binary from out of a source tree.

#### TODO

 * [x] Figure out why on recent kernels (e.g. `asus-dumo`) it fails find ncurses through pkgconfig.
 * [x] Add documentation


* * *

Fixes #108