### PR TITLE
Add GitHub actions for simple validations

### DIFF
--- a/.ci/instantiate-all.nix
+++ b/.ci/instantiate-all.nix
@@ -1,0 +1,63 @@
+# This file is used to flattenize release.nix for `nix-env` use.
+# In turn, this is used by the CI steps for validating the evaluation is still
+# working fine, and to get a list of diffs for the changes.
+let
+  # Evaluate release.nix
+  release = import ../release.nix {
+    systems = [ "aarch64-linux" "x86_64-linux" ];
+  };
+
+  # Get "a" Nixpkgs for its lib.
+  pkgs = import <nixpkgs> {};
+  inherit (pkgs) lib;
+  # And import what we need in scope.
+  inherit (lib.attrsets) getAttrFromPath nameValuePair mapAttrs' mapAttrsToList;
+  inherit (lib.strings) splitString;
+  inherit (lib.lists) flatten;
+
+  # Given a path, returns the attrset at that path in release,
+  # with the attribute names prefixed with path.
+  dig = dig' release;
+
+  # Given a path, returns the attrset at that path in attrset,
+  # with the attribute names prefixed with path.
+  dig' = attrset: path:
+    mapAttrs' (name: value: nameValuePair "${path}.${name}" value)
+    (getAttrFromPath (splitString "." path) attrset)
+  ;
+
+  # Flattened attrset of device builds.
+  devices =
+    let
+      # Listifies devices in a list of lists of nameValuePairs.
+      # This will be flattened and re-hydrated in a shallow attrset.
+      devicesList =
+        mapAttrsToList
+        (deviceName: list: mapAttrsToList (platformName: value: {
+            name = "device.${deviceName}.${platformName}";
+            value = value;
+          }) list)
+        release.device
+      ;
+    in
+      builtins.listToAttrs (flatten devicesList)
+    ;
+
+  flattened =
+    release //
+    devices //
+    # We could try and do something smart to unwrap two levels of attrsets
+    # automatically, but by stating we want those paths we are ensuring that
+    # they are still present in the attrsets.
+    (dig "overlay.aarch64-linux.aarch64-linux") //
+    (dig "overlay.x86_64-linux.aarch64-linux-cross") //
+    (dig "overlay.x86_64-linux.armv7l-linux-cross") //
+    (dig "overlay.x86_64-linux.x86_64-linux")
+  ;
+
+  # Escape the name so `nix-env` will show it.
+  escapeName = builtins.replaceStrings ["."] ["++"];
+in
+  mapAttrs'
+  (name: value: nameValuePair (escapeName name) value)
+  flattened

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "**" ]
+
+jobs:
+  Parse_nix:
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: "actions/checkout@58070a9fc3a91197fc9cbf24841ea31a2ab19980"
+      - uses: "cachix/install-nix-action@ebed63b0a20f20951a06a507ea1a1596bfce35b6"
+      - name: "Parse .nix files"
+        run: |
+          git ls-files | grep '.nix$' | xargs nix-instantiate --parse --quiet > /dev/null
+  Documentation:
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: "actions/checkout@58070a9fc3a91197fc9cbf24841ea31a2ab19980"
+      - uses: "cachix/install-nix-action@ebed63b0a20f20951a06a507ea1a1596bfce35b6"
+      - name: "Build documentation"
+        run: |
+          nix-build doc
+          cp -prf $(readlink -f result) built-documentation
+      - uses: actions/upload-artifact@v1
+        with:
+          name: documentation
+          path: built-documentation
+  Instantiation:
+    runs-on: [ubuntu-latest]
+    steps:
+      - uses: "actions/checkout@58070a9fc3a91197fc9cbf24841ea31a2ab19980"
+      - uses: "cachix/install-nix-action@ebed63b0a20f20951a06a507ea1a1596bfce35b6"
+      - name: "Instantiation"
+        run: |
+          nix-env --out-path -qaP --no-name -f .ci/instantiate-all.nix \
+            | sed -e 's/\+\+/./g' \
+            | sort

--- a/modules/system-types.nix
+++ b/modules/system-types.nix
@@ -7,7 +7,7 @@ let
 
   system_type = config.mobile.system.type;
 
-  known_system_types = config.mobile.system.types;
+  known_system_types = config.mobile.system.types ++ [ "none" ];
 in
 {
   imports = [

--- a/modules/system-types/u-boot.nix
+++ b/modules/system-types/u-boot.nix
@@ -191,6 +191,7 @@ in
         inherit boot-partition;
         disk-image = withBootloader;
         u-boot = cfg.package;
+        default = system.build.disk-image;
       };
     })
   ];

--- a/release.nix
+++ b/release.nix
@@ -1,3 +1,5 @@
+# Note:
+# Verify that .ci/instantiate-all.nix lists the expected paths when adding to this file.
 let
   all-devices =
     builtins.filter

--- a/release.nix
+++ b/release.nix
@@ -91,6 +91,7 @@ let
           special = true;
           inherit name;
           config = {
+            mobile.system.type = "none";
             mobile.hardware.soc = {
               x86_64-linux = "generic-x86_64";
               aarch64-linux = "generic-aarch64";


### PR DESCRIPTION
We can expand for more serious work later.

This

 * Validates all nix files are parsable.
 * Builds the documentation.
 * Instantiates everything from release.nix.

The built documentation is also available as an artifact in the checks, as a zip, look at the top right corner. Though, not as useful as if it was directly consumable and uploaded somewhere :(.

* * *

This also fixes two semi-related issues.

 * Something with the `nix-env` based eval triggered a behaviour from the system eval that didn't work the same way as on Hydra. This is fixed by having the "none" system type.
 * The Pinephone change had a broken eval! This PR would have shown that easily!