### PR TITLE
Add the demo rootfs build to release.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -46,9 +46,9 @@ let
   # `release.nix` and not part of the public API.
   evalWith = modules: import ./lib/eval-config.nix {
     modules =
-      if device ? special
+      (if device ? special
       then [ device.config ]
-      else [ (import (./. + "/devices/${final_device}" )) ]
+      else [ (import (./. + "/devices/${final_device}" )) ])
       ++ modules
       ++ [ additionalConfiguration ]
     ;

--- a/lib/image-builder/makeFilesystem.nix
+++ b/lib/image-builder/makeFilesystem.nix
@@ -141,6 +141,10 @@ stdenvNoCC.mkDerivation (args // rec {
     echo "$checkPhase"
     runHook checkPhase
 
+    if [ -n "$postProcess" ]; then
+      echo "-> Running post-processing"
+      runHook postProcess
+    fi
   '';
 
 })

--- a/modules/internal.nix
+++ b/modules/internal.nix
@@ -1,0 +1,19 @@
+# All otions defined here are *extremely internal*.
+# **Do not** set them in your configuration.
+# **Do not** rely on them existing.
+{ lib, ... }:
+
+let
+  inherit (lib) mkOption types;
+in
+{
+  options = {
+    mobile._internal = {
+      compressLargeArtifacts = mkOption {
+        type = types.bool;
+        default = false;
+        internal = true;
+      };
+    };
+  };
+}

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -28,6 +28,7 @@
   ./initrd-usb.nix
   ./initrd-vendor.nix
   ./initrd.nix
+  ./internal.nix
   ./mobile-device.nix
   ./nixpkgs.nix
   ./quirks/qualcomm/default.nix

--- a/release.nix
+++ b/release.nix
@@ -79,6 +79,21 @@ let
     }
   ;
 
+  specialConfig = {name, buildingForSystem, system}: {
+    special = true;
+    inherit name;
+    config = {
+      mobile.device.info = {};
+      mobile.system.type = "none";
+      mobile.hardware.soc = {
+        x86_64-linux = "generic-x86_64";
+        aarch64-linux = "generic-aarch64";
+        armv7l-linux = "generic-armv7l";
+      }.${buildingForSystem};
+      nixpkgs.localSystem = knownSystems.${system};
+    };
+  };
+
   # Given a system builds run on, this will return a set of further systems
   # this builds in, either native or cross.
   # The values are `overlayForEval` applied for the pair local/cross systems.
@@ -89,19 +104,7 @@ let
         # "device" name for the eval *and* key used for the set.
         name = if system == buildingForSystem then buildingForSystem else "${buildingForSystem}-cross";
         # "device" eval for our dummy device.
-        eval = evalFor {
-          special = true;
-          inherit name;
-          config = {
-            mobile.system.type = "none";
-            mobile.hardware.soc = {
-              x86_64-linux = "generic-x86_64";
-              aarch64-linux = "generic-aarch64";
-              armv7l-linux = "generic-armv7l";
-            }.${buildingForSystem};
-            nixpkgs.localSystem = knownSystems.${system};
-          };
-        };
+        eval = evalFor (specialConfig {inherit name buildingForSystem system;});
         overlay = overlayForEval eval;
       in {
         inherit name;
@@ -119,9 +122,21 @@ let
       } device).build.default
     )
   );
+
+  examples-demo =
+    let
+      device = (specialConfig {
+        name = "aarch64-linux";
+        buildingForSystem = "aarch64-linux";
+        system = "aarch64-linux";
+      });
+    in
+    import ./examples/demo { inherit device; };
+  examples-demo-rootfs = examples-demo.build.rootfs;
 in
 {
   inherit device;
+  inherit examples-demo-rootfs;
 
   # Overlays build native, and cross, according to shouldEvalOn
   overlay = lib.genAttrs systems (system:
@@ -141,6 +156,7 @@ in
       ++ lib.optionals (hasSystem "aarch64-linux") [
         device.asus-z00t.aarch64-linux               # Android
         device.asus-dumo.aarch64-linux               # Depthcharge
+        examples-demo-rootfs 
       ];
   in
   releaseTools.aggregate {

--- a/release.nix
+++ b/release.nix
@@ -13,6 +13,10 @@ in
 # By default, assume we eval only for currentSystem
 , systems ? [ builtins.currentSystem ]
 # nixpkgs is also an input, used as `<nixpkgs>` in the system configuration.
+
+# Some additional configuration will be made with this.
+# Mainly to work with some limitations (output size).
+, inNixOSHydra ? false
 }:
 
 let
@@ -83,6 +87,7 @@ let
     special = true;
     inherit name;
     config = {
+      mobile._internal.compressLargeArtifacts = inNixOSHydra;
       mobile.device.info = {};
       mobile.system.type = "none";
       mobile.hardware.soc = {

--- a/release.nix
+++ b/release.nix
@@ -83,20 +83,22 @@ let
     }
   ;
 
-  specialConfig = {name, buildingForSystem, system}: {
+  specialConfig = {name, buildingForSystem, system, config ? {}}: {
     special = true;
     inherit name;
-    config = {
-      mobile._internal.compressLargeArtifacts = inNixOSHydra;
-      mobile.device.info = {};
-      mobile.system.type = "none";
-      mobile.hardware.soc = {
-        x86_64-linux = "generic-x86_64";
-        aarch64-linux = "generic-aarch64";
-        armv7l-linux = "generic-armv7l";
-      }.${buildingForSystem};
-      nixpkgs.localSystem = knownSystems.${system};
-    };
+    config = lib.mkMerge [
+      config
+      {
+        mobile.device.info = {};
+        mobile.system.type = "none";
+        mobile.hardware.soc = {
+          x86_64-linux = "generic-x86_64";
+          aarch64-linux = "generic-aarch64";
+          armv7l-linux = "generic-armv7l";
+        }.${buildingForSystem};
+        nixpkgs.localSystem = knownSystems.${system};
+      }
+    ];
   };
 
   # Given a system builds run on, this will return a set of further systems
@@ -134,6 +136,9 @@ let
         name = "aarch64-linux";
         buildingForSystem = "aarch64-linux";
         system = "aarch64-linux";
+        config = {
+          mobile._internal.compressLargeArtifacts = inNixOSHydra;
+        };
       });
     in
     import ./examples/demo { inherit device; };


### PR DESCRIPTION
This will ensure Hydra builds everything required for the rootfs, making sure our demo rootfs keeps being buildable.

This will also provide a trustable source for the rootfs so end-users can use a somewhat usable system on their device even if they do not have a native aarch64-linux system to build from.

### TODO

 * [x] Compress rootfs image for hydra builds
 * [ ] Document usage pattern to build a full image using a pre-built rootfs.

Once merged:

 * Add `inNixOSHydra` `true` to the jobset.

* * *

The rootfs goes from 3.3GiB uncompressed to... 798MiB compressed! What a deal!