### PR TITLE
initrd-vendor: mount vendor read-only

### DIFF
--- a/modules/initrd-vendor.nix
+++ b/modules/initrd-vendor.nix
@@ -24,7 +24,7 @@ lib.mkMerge [
       "/vendor" = {
         device = vendor_device;
         fsType = "ext4";
-        options = [ "nosuid" "noexec" "nodev" ];
+        options = [ "ro" "nosuid" "noexec" "nodev" ];
       };
     };
   })


### PR DESCRIPTION
For `google-marlin`, at least.