### PR TITLE
doc: Add options listing and other fixes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -40,7 +40,7 @@ If the file does not exist, it will not fail.
 
 A sample `local.nix`:
 
-```
+```nix
 { lib, ... }:
 
 {

--- a/default.nix
+++ b/default.nix
@@ -40,27 +40,20 @@ let
     else deviceFromEnv
   ;
 
-  # Evaluates NixOS, mobile-nixos and the device config with the given
-  # additional modules.
-  # Note that we can receive a "special" configuration, used internally by
-  # `release.nix` and not part of the public API.
-  evalWith = modules: import ./lib/eval-config.nix {
-    modules =
-      (if device ? special
-      then [ device.config ]
-      else [ (import (./. + "/devices/${final_device}" )) ])
-      ++ modules
-      ++ [ additionalConfiguration ]
-    ;
-  };
+  inherit (import ./lib/release-tools.nix) evalWith;
 
   # The "default" eval.
-  eval = evalWith configuration;
+  eval = evalWith {
+    device = final_device;
+    modules = configuration;
+  };
 
   # This is used by the `-A installer` shortcut.
-  installer-eval = evalWith [
-    ./profiles/installer.nix
-  ];
+  installer-eval = evalWith {
+    modules = [
+      ./profiles/installer.nix
+    ];
+  };
 
   # Makes a mostly useless header.
   # This is mainly useful for batch evals.

--- a/doc/_support/common.inc
+++ b/doc/_support/common.inc
@@ -3,6 +3,7 @@
 :title: {doctitle} — Mobile NixOS
 :repo: NixOS/mobile-nixos
 :relative_prefix: doc
+:source-highlighter: rouge
 :docinfo: shared
 :docinfodir: _support/
 :toc: macro

--- a/doc/_support/converter/.gitignore
+++ b/doc/_support/converter/.gitignore
@@ -1,0 +1,2 @@
+vendor
+.bundle

--- a/doc/_support/converter/Gemfile
+++ b/doc/_support/converter/Gemfile
@@ -3,4 +3,5 @@
 source "https://rubygems.org"
 
 gem "asciidoctor"
+gem "rouge"
 #gem "tilt"

--- a/doc/_support/converter/Gemfile.lock
+++ b/doc/_support/converter/Gemfile.lock
@@ -2,12 +2,14 @@ GEM
   remote: https://rubygems.org/
   specs:
     asciidoctor (2.0.10)
+    rouge (3.17.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   asciidoctor
+  rouge
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/doc/_support/converter/gemset.nix
+++ b/doc/_support/converter/gemset.nix
@@ -9,4 +9,14 @@
     };
     version = "2.0.10";
   };
+  rouge = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0xl7k5paf66p57sphm4nfa4k86yf93lhdzzr0cv0l4divq12g2pr";
+      type = "gem";
+    };
+    version = "3.17.0";
+  };
 }

--- a/doc/_support/header.erb
+++ b/doc/_support/header.erb
@@ -7,8 +7,8 @@
         </h1>
       </li>
       <li><%= link("getting-started.html", "Getting Started") %></li>
+      <li><%= link("resources.html", "Resources") %></li>
       <li><%= link("devices/index.html", "Devices List") %></li>
-      <li><%= link("porting-guide.html", "Porting Guide") %></li>
     </ul>
   </nav>
 </header>

--- a/doc/_support/options/default.nix
+++ b/doc/_support/options/default.nix
@@ -1,0 +1,56 @@
+{ pkgs
+, glibcLocales
+, nixosOptionsDoc
+, runCommandNoCC
+, ruby
+}:
+
+let
+  # Release tools used to evaluate the devices metadata.
+  mobileReleaseTools = (import ../../../lib/release-tools.nix);
+  inherit (mobileReleaseTools) evalWith;
+  inherit (mobileReleaseTools.withPkgs pkgs) specialConfig;
+
+  dummyConfig = system: specialConfig {
+    name = system;
+    buildingForSystem = system;
+    system = system;
+    config = {};
+  };
+
+  dummyEval = evalWith {
+    device = (dummyConfig "aarch64-linux");
+    modules = [
+      {
+        disabledModules = [
+          # As of 2020-04-06 this module fails the evaluation. (ae6bdcc53584aaf20211ce1814bea97ece08a248)
+          # ⇒ Invalid package attribute path `nextcloud17'
+          <nixpkgs/nixos/modules/services/web-apps/nextcloud.nix>
+
+          # As of 2020-04-06 this module fails the evaluation. (ae6bdcc53584aaf20211ce1814bea97ece08a248)
+          # ⇒ Package ‘ceph-14.2.7’ in .../nixpkgs/pkgs/tools/filesystems/ceph/default.nix:178
+          #   is not supported on ‘aarch64-linux’, refusing to evaluate.
+          <nixpkgs/nixos/modules/services/network-filesystems/ceph.nix>
+        ];
+      }
+    ];
+  };
+
+  optionsJSON = (nixosOptionsDoc { options = dummyEval.options; }).optionsJSON;
+  systemTypesDir = ../../../modules/system-types;
+in
+
+runCommandNoCC "mobile-nixos-docs-options" {
+  nativeBuildInputs = [
+    ruby
+    glibcLocales
+  ];
+  optionsJSON = "${optionsJSON}/share/doc/nixos/options.json";
+  mobileNixOSRoot = toString ../../..;
+}
+''
+  mkdir -p $out/options
+  export LC_CTYPE=en_US.UTF-8
+  cp $optionsJSON $out/options/options.json
+  ruby ${./generate-options-listing.rb}
+''

--- a/doc/_support/options/generate-options-listing.rb
+++ b/doc/_support/options/generate-options-listing.rb
@@ -1,0 +1,93 @@
+require "json"
+
+$out = ENV["out"]
+$root = ENV["mobileNixOSRoot"]
+
+# We want `null` for `nil`s...
+# We already know it's *set* at this point.
+def as_nix(value)
+  if value.nil?
+    "null"
+  else
+    value.inspect
+  end
+end
+
+# Filter non-mobile-nixos options.
+options = JSON.parse(File.read(ENV["optionsJSON"]))
+  .select do |k, v|
+    v["declarations"].any? {|path| path.match(/^#{$root}/)}
+  end
+
+if options.keys.include?("nixpkgs.system")
+  $stderr.puts "The options listing unexpectedly contains NixOS options."
+  $stderr.puts "Bailing!"
+  exit 1
+end
+
+# Write the options listing.
+File.open(File.join($out, "options/index.adoc"), "w") do |file|
+  file.puts <<~EOF
+    = Mobile NixOS Options
+    include::_support/common.inc[]
+    :generated: true
+
+    The following list only includes the options defined by Mobile NixOS.
+
+    Refer to the link:https://nixos.org/nixos/options.html[NixOS options listing]
+    for more options.
+
+    == Options list
+
+  EOF
+
+  # "mobile.quirks.u-boot.initialGapSize"=>
+  #{"declarations"=>
+  #  [".../mobile-nixos/modules/system-types/u-boot"],
+  # "default"=>true, 
+  # "description"=>
+  #  "Size (in bytes) to keep reserved in front of the first partition.\n",
+  # "loc"=>["mobile", "quirks", "u-boot", "initialGapSize"],
+  # "readOnly"=>false,
+  # "type"=>"signed integer"},
+
+  file.puts <<~EOF
+    ++++
+    <dl class="options-list">
+  EOF
+  options.keys.sort.each do |path|
+    option = options[path]
+    file.puts <<~EOF
+    <div>
+      <dt>
+        <tt>
+          #{path}
+        </tt>
+      </dt>
+      <dd>
+        <dl class="option-definition">
+        <dt>Type:</dt>
+        <dd class="option-type">#{option["type"]}</dd>
+    #{
+      if option.has_key?("default")
+        <<~EOD
+        <dt>Default:</dt>
+        <dd class="option-default"><code>#{as_nix(option["default"])}</code></dd>
+        EOD
+      end
+    }
+        <dt>Description:</dt>
+        <dd class="option-description">
+    ++++
+    #{option["description"]}
+    ++++
+        </dd>
+      </dd>
+    </div>
+    EOF
+  end
+  file.puts <<~EOF
+    </dl>
+    ++++
+  EOF
+end

--- a/doc/_support/styles/index.less
+++ b/doc/_support/styles/index.less
@@ -14,6 +14,7 @@
 @import "theme";
 
 @import "asciidoc";
+@import "rouge";
 @import "layout";
 @import "news";
 @import "sitemap";

--- a/doc/_support/styles/rouge.less
+++ b/doc/_support/styles/rouge.less
@@ -1,0 +1,22 @@
+// https://github.com/rouge-ruby/rouge/wiki/List-of-tokens
+
+.rouge {
+	background: #f1f1f1;
+	color: #000;
+
+	.c {
+		color: #2D578E;
+	}
+
+	.k, .kd, .kn, .kp, .kr, .kt {
+		color: #AF5F00;
+	}
+
+	.kc, .s, .s2 {
+		color: #B00000;
+	}
+
+	.nv {
+		color: #058385
+	}
+}

--- a/doc/_support/styles/theme.less
+++ b/doc/_support/styles/theme.less
@@ -62,10 +62,6 @@ table.with-links {
 	}
 }
 
-dl dd p:last-child {
-	margin-bottom: 0;
-}
-
 .device-sidebar {
 	background-color: #fff;
 	#screen-sm-min({
@@ -102,4 +98,18 @@ dl dd p:last-child {
 
 	margin-bottom: @gutter;
 
+	dl dd > .paragraph:last-child p,
+	dl dd > p:last-child {
+		margin-bottom: 0;
+	}
+}
+
+.options-list {
+	dt > tt {
+		padding: 0;
+	}
+	& > div > dd {
+		border-left: @gutter/2 solid lighten(@color-blue-light, 20%);
+		padding-left: @gutter/2;
+	}
 }

--- a/doc/default.nix
+++ b/doc/default.nix
@@ -10,6 +10,9 @@ let
 
   # Asciidoc source for the devices section.
   devices = pkgs.callPackage ./_support/devices { };
+
+  # Asciidoc source for the options section.
+  options = pkgs.callPackage ./_support/options { };
 in
 
 stdenv.mkDerivation {
@@ -51,6 +54,9 @@ stdenv.mkDerivation {
 
     # Copies the generated asciidoc source for the devices.
     cp -prf ${devices}/devices devices
+
+    # Copies the generated asciidoc source for the options.
+    cp -prf ${options}/options options
 
     # Use our pipeline to process the docs.
     process-doc "**/*.adoc" "**/*.md" \

--- a/doc/getting-started.adoc
+++ b/doc/getting-started.adoc
@@ -95,6 +95,9 @@ As Mobile NixOS is a superset on top of NixOS, all NixOS options can be used in
 this configuration file, though take note that most NixOS options will only
 affect the stage-2 (rootfs, system.img) build.
 
+The <<options/index.adoc#,Options list>> page will be useful, as it provides an
+overview of all the Mobile NixOS specific options.
+
 
 == Contributing
 

--- a/doc/getting-started.adoc
+++ b/doc/getting-started.adoc
@@ -41,6 +41,37 @@ and mainly, installation steps.
 Fear not, look for your particular device on the <<devices/index.adoc#,devices list>>
 page, will likely contain the necessary instructions.
 
+=== Using a pre-built `system.img`
+
+When bootstrapping yourself up, without an aarch64-linux system, it may be
+easier to deal with some systems if you use a pre-built `rootfs` rather than
+rely on the dummy basic `rootfs`. For those systems, you can download a
+link:https://hydra.nixos.org/job/mobile-nixos/unstable/examples-demo.aarch64-linux.rootfs[pre-built rootfs],
+and configure the system build to use it. Assuming it is next to the
+`local.nix` file in your Mobile NixOS checkout.
+
+```nix
+# local.nix
+{ pkgs, ... }:
+
+let
+  fromPath = input: pkgs.runCommandNoCC "system.img" {
+    filename = "system.img";
+    filesystemType = "ext4";
+  } ''
+    mkdir -p "$out"
+    cp ${input} "$out/$filename"
+  '';
+in
+{
+  system.build.rootfs = fromPath ./system.img;
+}
+```
+
+Note that for Android-based devices, you can simply use the `system.img`. There
+is no need to configure it as such. This is most useful for _depthcharge_ and
+_u-boot_ systems.
+
 
 == Customizing
 

--- a/doc/getting-started.adoc
+++ b/doc/getting-started.adoc
@@ -91,6 +91,10 @@ A sample `local.nix`.
 }
 ```
 
+As Mobile NixOS is a superset on top of NixOS, all NixOS options can be used in
+this configuration file, though take note that most NixOS options will only
+affect the stage-2 (rootfs, system.img) build.
+
 
 == Contributing
 

--- a/doc/getting-started.adoc
+++ b/doc/getting-started.adoc
@@ -18,11 +18,15 @@ as link:https://github.com/NixOS/mobile-nixos[mobile-nixos].
 Depending on your configuration, for users with a GitHub account and the proper
 ssh configuration.
 
- git clone git@github.com:NixOS/mobile-nixos.git
+```
+$ git clone git@github.com:NixOS/mobile-nixos.git
+```
 
 Or, for everyone else.
 
- git clone https://github.com/NixOS/mobile-nixos.git
+```
+$ git clone https://github.com/NixOS/mobile-nixos.git
+```
 
 Nothing else! Everything required is self-contained.
 

--- a/doc/getting-started.adoc
+++ b/doc/getting-started.adoc
@@ -4,8 +4,8 @@ include::_support/common.inc[]
 This guide assumes the user knows how to prepare their device for development
 use. These instructions are device-dependent, but not specific to Mobile NixOS.
 
-Briefly said, the device's bootloader must be unlocked, allowing to run
-custom-built operating system images.
+Briefly said, the device's bootloader must be unlocked, meaning that it allows
+running custom-built operating system images.
 
 
 == Source Code
@@ -32,78 +32,14 @@ The link:https://help.github.com/en/github/collaborating-with-issues-and-pull-re
 GitHub help article] may help.
 
 
-== Compiling
+== Compiling and Running
 
 This is where it becomes harder to make a simple guide. These are different,
 heterogeneous, hardware platforms, with different quirks, compilation steps,
-and mainly, installation steps. Please also look at the documentation for your
-specific device as it may contain further or replacement instructions.
+and mainly, installation steps.
 
-=== Android devices
-
-To build a system image, you will need to build on the native target architecture.
-
-Building the boot image (`boot.img`) can be done through cross-compilation. The
-build tooling will automatically handle this.
-
-
- nix-build --argstr device "$DEVICE" -A build.android-bootimg
-
-Assuming `DEVICE` has been set to an appropriate device name.
-
-=== Depthcharge devices
-
-To build full image, you will need to build on the native target architecture.
-
-Though, it is possible to build the partition `depthcharge` will boot from,
-which holds the kernel and initrd, through cross-compilation. The build tooling
-will automatically handle this.
-
- nix-build --argstr device "$DEVICE" -A build.kpart
-
-
-== Running
-
-This is where the device-specific and platform-specific instructions will help
-you. Though, here's a quick overview. Again, look at the documentation for your
-specific device, as it may contain further or replacement instructions.
-
-=== Android
-
-Some, if not most, Android-based platforms will allow you to boot the boot image
-using `fastboot`.
-
-Luckily, running stage-1 through `fastboot` is enough to get started porting for
-the target system, as it will exercise the harder initial bootstrapping parts.
-That is, getting a system working with a minimal set of useful features.
-
-The device will need to be booted in its bootloader, or `fastboot`, mode. The
-instructions are device-dependent. The boot image can be run using the following
-command.
-
- fastboot boot result
-
-If you have a system image (`system.img`) built, you can use `fastboot` to flash
-it to the device. Note that it might be too big to fit over the `system`
-partition. In such case, it can be flashed on the `userdata` partition.
-
-WARNING: *This will erase everything on the partition*. Additionally, the common
-backups methods, e.g. TWRP, will *not* backup the `userdata` partition.
-
- fastboot flash userdata system.img
-
-=== Depthcharge
-
-This one is annoying to get started currently. Without a full Mobile NixOS
-build, you will need to fill in some gaps manually.
-
-The link:https://www.chromium.org/chromium-os/chromiumos-design-docs/disk-format[
-upstream documentation about the disk format] may help shed some light in getting
-this booting.
-
-On a Mobile NixOS-built disk image for a ; depthcharge` device, you can replace
-the partition with the newly built image, for the next boot. This is especially
-useful with USB devices or SD cards.
+Fear not, look for your particular device on the <<devices/index.adoc#,devices list>>
+page, will likely contain the necessary instructions.
 
 
 == Customizing

--- a/doc/getting-started.adoc
+++ b/doc/getting-started.adoc
@@ -45,6 +45,28 @@ and mainly, installation steps.
 Fear not, look for your particular device on the <<devices/index.adoc#,devices list>>
 page, will likely contain the necessary instructions.
 
+=== Using a known-good revision
+
+Things change, and sometimes things break. This is even more true with Mobile
+NixOS as the project depends on another moving target, NixOS.
+
+You can look at the
+link:https://hydra.nixos.org/job/mobile-nixos/unstable/tested/latest-finished#tabs-buildinputs[latest successful build's inputs]
+to see which _revisions_ were used for a successful build.
+
+You can then clone Nixpkgs somewhere, checkout that commit ID, and refer to it
+using `NIX_PATH`. The following is only an example of how one would do this.
+
+```
+$ cd ~/Projects/
+$ git clone https://github.com/NixOS/nixpkgs.git
+$ cd nixpkgs
+$ git checkout $revision
+$ cd ~/Projects/mobile-nixos/
+$ export NIX_PATH="nixpkgs=$HOME/Projects/nixpkgs"
+$ nix-build [...]
+```
+
 === Using a pre-built `system.img`
 
 When bootstrapping yourself up, without an aarch64-linux system, it may be

--- a/doc/in-depth/android/partitions.adoc
+++ b/doc/in-depth/android/partitions.adoc
@@ -30,10 +30,12 @@ Generating a partitions listing
 
 By adding this to `local.nix`, build an initramfs for your device and boot it.
 
-```
+```nix
+{
   mobile.boot.stage-1.extraUtils = with pkgs; [
     gptfdisk
   ];
+}
 ```
 
 Run this command:

--- a/doc/resources.adoc
+++ b/doc/resources.adoc
@@ -1,0 +1,12 @@
+= Resources
+include::_support/common.inc[]
+
+== User resources
+
+* <<options/index.adoc#,Options List>>
+* <<boot_process.adoc#,Boot Process>>
+
+== Developer resources
+
+* <<porting-guide.adoc#,Porting Guide>>
+* <<in-depth/index.adoc#,In-Depth Topics>>

--- a/doc/resources.adoc
+++ b/doc/resources.adoc
@@ -10,3 +10,7 @@ include::_support/common.inc[]
 
 * <<porting-guide.adoc#,Porting Guide>>
 * <<in-depth/index.adoc#,In-Depth Topics>>
+
+== Additional resources
+
+* <<README.adoc#,Repository `README`>>

--- a/lib/eval-config.nix
+++ b/lib/eval-config.nix
@@ -1,6 +1,2 @@
-{ baseModules ? import ../modules/module-list.nix
-, ...
-} @ args:
-import <nixpkgs/nixos/lib/eval-config.nix> (args // {
-  inherit baseModules;
-})
+# Simple proxy to the upstream Nixpkgs eval-config.nix
+import <nixpkgs/nixos/lib/eval-config.nix>

--- a/lib/release-tools.nix
+++ b/lib/release-tools.nix
@@ -6,6 +6,26 @@
     (builtins.attrNames (builtins.readDir ../devices))
   ;
 
+  # Evaluates NixOS, mobile-nixos and the device config with the given
+  # additional modules.
+  # Note that we can receive a "special" configuration, used internally by
+  # `release.nix` and not part of the public API.
+  evalWith =
+    { modules
+    , device
+    , additionalConfiguration ? {}
+    , baseModules ? ((import ../modules/module-list.nix) ++ [ ../modules/_nixos-integration.nix ])
+  }: import ./eval-config.nix {
+    inherit baseModules;
+    modules =
+      (if device ? special
+      then [ device.config ]
+      else [ (import (../. + "/devices/${device}" )) ])
+      ++ modules
+      ++ [ additionalConfiguration ]
+    ;
+  };
+
   # These can rely freely on lib, avoir depending on pkgs.
   withPkgs = pkgs:
     let

--- a/modules/_nixos-integration.nix
+++ b/modules/_nixos-integration.nix
@@ -1,0 +1,5 @@
+# Import the upstream module-list.
+# Do not add this file to `module-list.nix`.
+{
+  imports = import <nixpkgs/nixos/modules/module-list.nix>;
+}

--- a/modules/initrd-ssh.nix
+++ b/modules/initrd-ssh.nix
@@ -15,8 +15,9 @@ in
       type = types.bool;
       default = false;
       description = ''
-        Enables ssh.
-        CURRENT CONFIGURATION ALSO OPENS ACCESS TO ALL WITHOUT A PASSWORD NOR SSH KEY.
+        Enables ssh during stage-1.
+
+        **CURRENT CONFIGURATION ALSO OPENS ACCESS TO ALL WITHOUT A PASSWORD NOR SSH KEY.**
       '';
     };
   };

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -1,7 +1,3 @@
-# Import the upstream module-list.
-# FIXME : This won't allow importing `mobile-nixos` into /etc/configuration.nix
-(import <nixpkgs/nixos/modules/module-list.nix>) ++
-
 # Then add our additional modules.
 # Keep this list `:sort`ed.
 [

--- a/modules/quirks/qualcomm/framebuffer.nix
+++ b/modules/quirks/qualcomm/framebuffer.nix
@@ -10,19 +10,19 @@ in
     quirks.qualcomm.msm-fb-refresher.enable = mkOption {
       type = types.bool;
       default = false;
-      description = "
+      description = ''
         Enables use of `msm-fb-refresher`.
         Use sparingly, it is better to patch software to flip buffers instead.
-      ";
+      '';
     };
     quirks.qualcomm.msm-fb-handle.enable = mkOption {
       type = types.bool;
       default = false;
-      description = "
+      description = ''
         Enables use of `msm-fb-handle`.
         This tool keeps a dummy handle open to the framebuffer, useful for msm_mdss
         which clears and shuts display down when all handles are closed.
-      ";
+      '';
     };
   };
 

--- a/modules/system-types/depthcharge/device-notes.adoc.erb
+++ b/modules/system-types/depthcharge/device-notes.adoc.erb
@@ -1,0 +1,28 @@
+== Building
+
+This will build the default output for your _<%= info["fullName"] %>_.
+
+ $ nix-build --argstr device <%= info["identifier"] %> -A build.default
+
+The default output is a disk-image that can be written on a storage media that
+your device can boot from.
+
+== Installation
+
+This one is annoying to get started currently. Without a full Mobile NixOS
+build, you will need to fill in some gaps manually.
+
+The link:https://www.chromium.org/chromium-os/chromiumos-design-docs/disk-format[
+upstream documentation about the disk format] may help shed some light in
+understanding how these devices boot.
+
+One of the important thing to realise is that you will likely need to `dd` the
+image to a storage media, either external or internal.
+
+The `kpart` output can be used to build only the stage-1, which is helpful for
+updating the kernel and the stage-1 boot program.
+
+ $ nix-build --argstr device <%= info["identifier"] %> -A build.kpart
+
+This can be `dd`'d over the first partition on an existing storage media
+containing a Mobile NixOS installation.


### PR DESCRIPTION
This adds the options listing to the documentation.

This also reviews how modules are being handled a bit, but in the end it ended up not working like I wanted. Those changes are, thus, mostly useless, but were kept anyway. At least it clearly delineates the NixOS integration.

* * *

Added to the documentation:

 * Note about using a pre-built rootfs image

Upcoming:

 * [x] Note about using a known good revisions pair using Hydra
 * ~~Documentation for integration in the system configuration~~ Coming in another PR.