### PR TITLE
Fix evaluation failure where aarch64-linux outputs are accidentally x86_64-linux

### DIFF
--- a/.ci/instantiate-all.nix
+++ b/.ci/instantiate-all.nix
@@ -44,6 +44,9 @@ let
     ;
 
   flattened =
+    # If this fails, evaluations probably don't receive additional configuration
+    # configuring nixpkgs.localSystem.
+    assert devices."device.asus-z00t.aarch64-linux" != devices."device.asus-z00t.x86_64-linux";
     release //
     devices //
     # We could try and do something smart to unwrap two levels of attrsets

--- a/default.nix
+++ b/default.nix
@@ -46,6 +46,7 @@ let
   eval = evalWith {
     device = final_device;
     modules = configuration;
+    inherit additionalConfiguration;
   };
 
   # This is used by the `-A installer` shortcut.


### PR DESCRIPTION
Look at this eval:

 * https://hydra.nixos.org/eval/1580432#tabs-new

11 New jobs, 11 Removed jobs... Uh oh.

The explanation is in the System column.

Woopsie!

The change in the CI instantiation should prevent this from happening again in the future.