### PR TITLE
oneplus-oneplus3: Minor polishing

### DIFF
--- a/devices/oneplus-oneplus3/default.nix
+++ b/devices/oneplus-oneplus3/default.nix
@@ -46,4 +46,6 @@
   mobile.usb.idProduct = "D001";
 
   mobile.system.type = "android";
+
+  mobile.quirks.qualcomm.dwc3-otg_switch.enable = true;
 }

--- a/devices/oneplus-oneplus3/kernel/0001-oneplus3-Configure-LEDs-using-kernel-triggers.patch
+++ b/devices/oneplus-oneplus3/kernel/0001-oneplus3-Configure-LEDs-using-kernel-triggers.patch
@@ -1,0 +1,46 @@
+From ea45dd6f43ad1504ded7f2e2813997fa7d24fcc8 Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Fri, 10 Apr 2020 21:22:49 -0400
+Subject: [PATCH] oneplus3: Configure LEDs using kernel triggers
+
+ * The green LED is default-on
+ * The red LED shows the device is being charged
+---
+ arch/arm64/boot/dts/15801_PVT/msm-pmi8994.dtsi | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/15801_PVT/msm-pmi8994.dtsi b/arch/arm64/boot/dts/15801_PVT/msm-pmi8994.dtsi
+index b137c2bd7a5b7..df6174bdf35b0 100644
+--- a/arch/arm64/boot/dts/15801_PVT/msm-pmi8994.dtsi
++++ b/arch/arm64/boot/dts/15801_PVT/msm-pmi8994.dtsi
+@@ -649,8 +649,7 @@
+ 				qcom,pause-hi = <1000>;
+ 
+ 				linux,name = "red";
+-				/*linux,default-trigger =
+-					"battery-charging";*/
++				linux,default-trigger = "battery-charging";
+ 				qcom,use-blink;
+ 			};
+ 
+@@ -661,7 +660,7 @@
+ 				pwms = <&pmi8994_pwm_2 0 0>;
+ 				qcom,pwm-us = <1000>;
+ 				qcom,max-current = <12>;
+-				qcom,default-state = "off";
++				qcom,default-state = "on";
+ 				qcom,duty-pcts = [00 05 0a 0f 14 1d 28 32 3c 4b 64];
+ 				qcom,duty-ms = <20>;
+ 				qcom,start-idx = <13>;
+@@ -673,7 +672,7 @@
+ 				qcom,pause-hi = <1000>;
+ 
+ 				linux,name = "green";
+-				/*linux,default-trigger = "battery-full";*/
++				linux,default-trigger = "default-on";
+ 				qcom,use-blink;
+ 			};
+ 
+-- 
+2.23.1
+

--- a/devices/oneplus-oneplus3/kernel/default.nix
+++ b/devices/oneplus-oneplus3/kernel/default.nix
@@ -24,6 +24,7 @@
     ./99_framebuffer.patch
     ./0001-Imports-drivers-input-changes-from-lineage-16.0.patch
     ./0001-s3320-Workaround-libinput-claiming-kernel-bug.patch
+    ./0001-oneplus3-Configure-LEDs-using-kernel-triggers.patch
   ];
 
   isModular = false;

--- a/modules/quirks/qualcomm/default.nix
+++ b/modules/quirks/qualcomm/default.nix
@@ -1,6 +1,7 @@
 {
   imports = [
     ./framebuffer.nix
+    ./msm-dwc3.nix
     ./wcnss-wlan.nix
   ];
 }

--- a/modules/quirks/qualcomm/msm-dwc3-otg_switch-task.rb
+++ b/modules/quirks/qualcomm/msm-dwc3-otg_switch-task.rb
@@ -1,0 +1,10 @@
+class Tasks::MsmDwc3OtgSwitch < SingletonTask
+  def initialize()
+    Targets[:SwitchRoot].add_dependency(:Task, self)
+    add_dependency(:Mount, "/sys")
+  end
+
+  def run()
+    System.write("/sys/module/dwc3_msm/parameters/otg_switch", "1")
+  end
+end

--- a/modules/quirks/qualcomm/msm-dwc3.nix
+++ b/modules/quirks/qualcomm/msm-dwc3.nix
@@ -1,0 +1,33 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.mobile.quirks.qualcomm;
+  inherit (lib) mkIf mkOption types;
+in
+{
+  options.mobile = {
+    quirks.qualcomm.dwc3-otg_switch.enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Enable this on a device which requires otg_switch to be
+        configured for OTG to work.
+      '';
+    };
+  };
+
+  config = mkIf (cfg.dwc3-otg_switch.enable) {
+    mobile.boot.stage-1.tasks = [ ./msm-dwc3-otg_switch-task.rb ];
+    systemd.services.dwc3-otg_switch = {
+      description = "Setup the DWC3 controller in OTG mode";
+      wantedBy = [ "multi-user.target" ];
+      script = ''
+        echo 1 > /sys/module/dwc3_msm/parameters/otg_switch
+      '';
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+      };
+    };
+  };
+}


### PR DESCRIPTION
Off the heels of #126, I started working on oneplus-oneplus3 polishing to figure out Wi-Fi.

The Wi-Fi efforts for now are on pause, but there is some polishing included here that is useful to upstream right now.

This closes #45 as it is functionally equivalent for stage-2 systems, ~~**but** with one caveat, there is no stage-1 task implemented yet here to do the equivalent.~~

#### TODO

 * [x] Stage-1 task for otg_switch

#### Unknowns

Does the LED thing apply to all oneplus3 models? What about the 3T? The device tree files in the repo are confusing.