### PR TITLE
cross-workarounds: Disable udisks for cross-builds

### DIFF
--- a/modules/cross-workarounds.nix
+++ b/modules/cross-workarounds.nix
@@ -18,4 +18,7 @@ lib.mkIf isCross
   # building '/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-mesa-19.3.3-aarch64-unknown-linux-gnu.drv'...
   # meson.build:1537:2: ERROR: Dependency "wayland-scanner" not found, tried pkgconfig
   security.polkit.enable = false;
+
+  # udisks fails due to gobject-introspection being not cross-compilation friendly.
+  services.udisks2.enable = false;
 }


### PR DESCRIPTION
From https://hydra.nixos.org/eval/1581751

1580f35dfbb29a00dbf06110cf31824637ee8635 accidentally introduced udisks in the build.

A local test build of the default "dummy" system disk image wasn't done, thus the failure not found.