### PR TITLE
doc: Add contributing notes

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,0 +1,41 @@
+= Contributing to Mobile NixOS
+
+You don't need to write code to help contributing with Mobile NixOS.
+
+As Mobile NixOS is a superset on top of NixOS, you should read the link:https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md[
+contributing guidelines] of the NixOS project. Many of the points apply just
+the same with Mobile NixOS.
+
+
+== Opening issues
+
+Issues you face when using or working with Mobile NixOS should be filed on
+link:https://github.com/NixOS/mobile-nixos/issues[the project's issue tracker].
+
+First verify an existing, open, and recent issue matching your exact problem
+doesn't already exist. In case of doubt, always open a new issue. Sometimes
+vaguely reported symptoms are from different sources and it is easier to manage
+when different issues are opened.
+
+When describing the issues you face, please provide the most information you
+can. For sharing logs, please share them as link:https://gist.github.com/[Gists]
+so the issue does not get bogged down.
+
+== Porting
+
+ifdef::env-github[]
+See the <<doc/porting-guide.adoc#,Device Porting Guide>>.
+endif::[]
+ifndef::env-github[]
+See the <<porting-guide.adoc#,Device Porting Guide>>.
+endif::[]
+
+Once a port has been made for a new device, link:https://github.com/NixOS/mobile-nixos/pulls[open a Pull Request].
+
+== Packaging software
+
+Unless it is related to the abstraction of device specifics, packaging should
+be done upstream at the link:https://github.com/NixOS/nixpkgs[Nixpkgs] project.
+
+Mobile NixOS is a superset of NixOS, all the software that is in NixOS is
+available for Mobile NixOS.

--- a/doc/default.nix
+++ b/doc/default.nix
@@ -38,6 +38,17 @@ stdenv.mkDerivation {
 
     EOF
 
+    # The title needs to be first
+    head -n1 ${../CONTRIBUTING.adoc} > contributing.adoc
+
+    # Then we're adding our common stuff
+    cat >> contributing.adoc <<EOF
+    include::_support/common.inc[]
+    EOF
+
+    # Then continuing with the file.
+    tail -n +2 ${../CONTRIBUTING.adoc} >> contributing.adoc
+
     if [ ! -e index.adoc ]; then
     cat >> index.adoc <<EOF
     = Main Page

--- a/doc/getting-started.adoc
+++ b/doc/getting-started.adoc
@@ -166,5 +166,11 @@ e-mail address, which you will find attached to commits I authored.
 
 Note that there are more in-depth guides about specific contribution topics.
 
+ifdef::env-github[]
+* <<../CONTRIBUTING.adoc#,Contributing Guide>>
+endif::[]
+ifndef::env-github[]
+* <<contributing.adoc#,Contributing Guide>>
+endif::[]
 * <<porting-guide.adoc#,Device Porting Guide>>
 


### PR DESCRIPTION
Implementation details time!

This uses the CONTRIBUTING.adoc well-known path, so GitHub intrinsically *knows* about the contributing guide.

This is why there are conditionals in the docs to link it up properly. We *are* moving things around when building the docs.

This also serves as a proof-of-concept to reduce the duplication of places to find information. That document ends up being a completely standard page of the site.