### PR TITLE
initrd-usb: provide modules required for gadgets in initrd

### DIFF
--- a/modules/initrd-usb.nix
+++ b/modules/initrd-usb.nix
@@ -69,7 +69,14 @@ in
     mobile.boot.stage-1 = lib.mkIf (cfg.usb.enable && (config.mobile.usb.mode != null)) {
       kernel.modules = [
         "configfs"
-      ];
+        "libcomposite"
+      ]
+      ++ optionals (config.mobile.usb.mode == "gadgetfs") (
+        forEach cfg.usb.features (feature:
+          let function = lib.head (lib.splitString "." gadgetfs.functions."${feature}");
+          in "usb_f_${function}"
+        )
+      );
 
       usb.features = []
         ++ optional cfg.networking.enable "rndis"


### PR DESCRIPTION
See the kernel documentation for configuring gadgets for more details.

https://www.kernel.org/doc/Documentation/usb/gadget_configfs.txt