### PR TITLE
boot/gui: Use libffi rather than bespoke bindings

### DIFF
--- a/boot/error/main.rb
+++ b/boot/error/main.rb
@@ -66,9 +66,9 @@ class UI
     return unless file
 
     if @screen.get_height > @screen.get_width
-      LVGL::LVNanoSVG.resize_next_width(@screen.get_width)
+      LVGL::Hacks::LVNanoSVG.resize_next_width(@screen.get_width)
     else
-      LVGL::LVNanoSVG.resize_next_height(@screen.get_height)
+      LVGL::Hacks::LVNanoSVG.resize_next_height(@screen.get_height)
     end
 
     @sad_phone = LVGL::LVImage.new(@screen)

--- a/boot/gui/main.rb
+++ b/boot/gui/main.rb
@@ -241,7 +241,7 @@ ui = UI.new
 
 def run(*cmd)
   $stderr.puts " $ " + cmd.join(" ")
-  system(*cmd) unless LVGL::Hacks.simulator?
+  system(*cmd) unless LVGL::Introspection.simulator?
 end
 
 # TODO: wait ~0.3s for the animation before doing the button actions.

--- a/boot/gui/main.rb
+++ b/boot/gui/main.rb
@@ -200,13 +200,13 @@ class UI
       return
     end
     if @screen.get_height > @screen.get_width
-      LVGL::LVNanoSVG.resize_next_width((@screen.get_width_fit * 0.8).to_i)
+      LVGL::Hacks::LVNanoSVG.resize_next_width((@screen.get_width_fit * 0.8).to_i)
     else
       # Detecting the available space where the layout will stretch into is
       # apparently hard with lvgl, thus we rely on the vertical resolution.
       # Meh, that's not *so* bad.
       # While it's a crude approximation, for layouting it's fine.
-      LVGL::LVNanoSVG.resize_next_height((@screen.get_height * 0.15).to_i)
+      LVGL::Hacks::LVNanoSVG.resize_next_height((@screen.get_height * 0.15).to_i)
     end
 
     @logo = LVGL::LVImage.new(@screen)

--- a/boot/gui/simulator.nix
+++ b/boot/gui/simulator.nix
@@ -26,8 +26,9 @@ stdenv.mkDerivation {
 
   buildPhase = ''
     (PS4=" $ "; set -x
-    mrbc -o gui.mrb \
-      lib/*.rb main.rb
+    mrbc -g -o gui.mrb \
+      $(find lib -type f -name '*.rb' | sort) \
+      main.rb
     )
   '';
   installPhase = ''
@@ -38,8 +39,17 @@ stdenv.mkDerivation {
 
     mkdir -p $out/bin
     cat > $out/bin/simulator <<EOF
-     #!/bin/sh
-     ${loader}/bin/loader $out/libexec/gui.mrb "\$@"
+      #!/bin/sh
+      args=()
+      if [[ -n "\$DEBUGGER" ]]; then
+        args+=(\$DEBUGGER)
+      fi
+      args+=(
+        ${loader}/bin/loader
+        $out/libexec/gui.mrb
+        "\$@"
+      )
+      exec "\''${args[@]}"
     EOF
     chmod +x $out/bin/simulator
     )

--- a/boot/init/default.nix
+++ b/boot/init/default.nix
@@ -2,7 +2,6 @@
 , fetchurl
 , mrbgems
 , mruby
-, script-loader
 
 # Additional tasks
 , tasks ? []

--- a/boot/splash/main.rb
+++ b/boot/splash/main.rb
@@ -31,10 +31,10 @@ class UI
 
     if @screen.get_height > @screen.get_width
       # 80% of the width
-      LVGL::LVNanoSVG.resize_next_width((@screen.get_width * 0.8).to_i)
+      LVGL::Hacks::LVNanoSVG.resize_next_width((@screen.get_width * 0.8).to_i)
     else
       # 15% of the height
-      LVGL::LVNanoSVG.resize_next_height((@screen.get_height * 0.15).to_i)
+      LVGL::Hacks::LVNanoSVG.resize_next_height((@screen.get_height * 0.15).to_i)
     end
 
     @logo = LVGL::LVImage.new(@screen)

--- a/modules/initrd-boot-gui.nix
+++ b/modules/initrd-boot-gui.nix
@@ -40,6 +40,6 @@ in
   ];
   mobile.boot.stage-1.extraUtils = with pkgs; [
     # Used for `key-held.mrb`.
-    { package = pkgsStatic.evtest; }
+    { package = evtest; }
   ];
 }

--- a/overlay/mruby-builder/mrbgems/default.nix
+++ b/overlay/mruby-builder/mrbgems/default.nix
@@ -1,4 +1,4 @@
-{ stdenvNoCC, lib, fetchFromGitHub }:
+{ stdenvNoCC, lib, fetchFromGitHub, libffi }:
 
 let
   inherit (lib) licenses;
@@ -90,6 +90,21 @@ rec {
       rev = "b4415207ff6ea62360619c89a1cff83259dc4db0";
       sha256 = "12djcwjjw0fygai5kssxbfs3pzh3cpnq07h9m2h5b51jziw380xj";
     };
+
+    meta.license = licenses.mit;
+  };
+
+  mruby-fiddle = mkGem {
+    src = fetchFromGitHub {
+      repo = "mruby-fiddle";
+      owner = "mobile-nixos";
+      rev = "b8b7f82a98a24384995a38012b7e08c7bc6c630c";
+      sha256 = "1138vsk6pyqxw64xnic6a91ip9bxn9zxck4kcdx653ba5s0wzaz4";
+    };
+
+    gemBuildInputs = [
+      libffi
+    ];
 
     meta.license = licenses.mit;
   };

--- a/overlay/mruby-builder/mrbgems/mruby-lvgui/default.nix
+++ b/overlay/mruby-builder/mrbgems/mruby-lvgui/default.nix
@@ -17,8 +17,8 @@ mrbgems.mkGem {
   src = fetchFromGitHub {
     repo = "mruby-lvgui";
     owner = "mobile-nixos";
-    rev = "1c251ec97da1e4d3e99f0b9674b387c990211906";
-    sha256 = "03bhksn2rzixxl8dk7viw2avw5cv4zpfpkcijrxjy4cc76f1wkja";
+    rev = "eb6e40c81a63cc67b14740200966603463f426bf";
+    sha256 = "1zqlhg409xx3da2cgrcmz9p9zc9cni2q25yi5vcb3naahpylbff4";
   };
 
   gemBuildInputs = [
@@ -26,5 +26,9 @@ mrbgems.mkGem {
   ] ++ lvgui.buildInputs;
   gemNativeBuildInputs = [
     pkg-config
+  ];
+
+  requiredGems = with mrbgems; [
+    mruby-fiddle
   ];
 }

--- a/overlay/mruby-builder/mrbgems/mruby-lvgui/lvgui.nix
+++ b/overlay/mruby-builder/mrbgems/mruby-lvgui/lvgui.nix
@@ -30,8 +30,8 @@ in
       fetchSubmodules = true;
       repo = "lvgui";
       owner = "mobile-nixos";
-      rev = "a3412d9e2a8d1c7a23b48cf2cdf2c39cf4009651";
-      sha256 = "1ibdjnqjacw27wmdg1fir4isffq2v87ml382f4g76ldmi5za0n9l";
+      rev = "d98d5e59ba0f4a76b2f092ee957a198d9e749dfb";
+      sha256 = "1hn01mi44wmx12987va4h69ldnvjbvniwm9slnd5naib6j2n5rbw";
     };
 
     # Document `LVGL_ENV_SIMULATOR` in the built headers.
@@ -56,30 +56,11 @@ in
     ];
 
     makeFlags = [
+      "PREFIX=${placeholder "out"}"
     ]
     ++ optional withSimulator "LVGL_ENV_SIMULATOR=1"
     ++ optional (!withSimulator) "LVGL_ENV_SIMULATOR=0"
     ;
-
-    # TODO: `make install`...
-    installPhase = ''
-      mkdir -p $out/lib
-      cp -vr lib*.a $out/lib/
-
-      mkdir -p $out/include
-      find . -name '*.h' -exec install -vD '{}' $out/include/'{}' ';'
-
-      mkdir -p $out/lib/pkgconfig
-      cat <<EOF > $out/lib/pkgconfig/lvgui.pc
-      Name: lvgui
-      Description: LVGL-based GUI library
-      Version: $version
-      Requires: ${optionalString withSimulator "sdl2"} ${optionalString (!withSimulator) "libevdev"}
-
-      Cflags: -I$out/include
-      Libs: $out/lib/liblvgui.a
-      EOF
-    '';
 
     enableParallelBuilding = true;
   }

--- a/overlay/mruby-builder/mruby/builder.nix
+++ b/overlay/mruby-builder/mruby/builder.nix
@@ -40,6 +40,8 @@ in
     buildPackages.mruby
   ];
 
+  buildInputs = mruby.buildInputs;
+
   buildPhase = ''
     runHook preBuild
 

--- a/overlay/mruby-builder/mruby/default.nix
+++ b/overlay/mruby-builder/mruby/default.nix
@@ -94,8 +94,8 @@ let
   gems' = optionals useDefaults defaultGems ++ gemsForGems ++ gems;
   gemBoxes' = optionals useDefaults defaultGemBoxes ++ gemBoxes;
 
-  gemBuildInputs = concatGemAttr "gemBuildInputs" gems;
-  gemNativeBuildInputs = concatGemAttr "gemNativeBuildInputs" gems;
+  gemBuildInputs = concatGemAttr "gemBuildInputs" gems';
+  gemNativeBuildInputs = concatGemAttr "gemNativeBuildInputs" gems';
 
   shared-config = ''
       # Gemboxes


### PR DESCRIPTION
This is a mostly transparent change.

This uses the updated `mruby-lvgui` that uses `mruby-fiddle`, which uses `libffi` rather than writing bespoke bindings for LVGL.

Why make this change if it changes nothing? To reduce the surface of mistakes. I am not a C developer. Probably always be uneasy writing C. Some bits of the bindings already were iffy.

The only bit I'm not happy with, but I am satisfied with, is the struct bindings. Fiddle does not have a way to describe nested structs. (Neither does the ruby mainline Fiddle.) LVGL uses nested structs for styles. To work around the issue, accessor functions in C have been generated. It's not *clean*, but it's working in a correct manner, which for the best.

It already was an issue with the previous bindings, and still is with the Fiddle-based bindings, there is no proper deallocation / destruction for LVGL objects. Not much of an issue for what can be called "short lived applications", but *still* something to get fixed for correctness in the future.

But still, **why**? The code worked, and seemingly was right. Let's gloss over "seemingly", and go to a more useful reason. Using FFI bindings, rather than relying on a spaghetti mess of generated code for bespoke bindings, should allow us to more easily implement the missing functionality from LVGL, and doing it correctly.

Furthermore, having everything prepared for FFI bindings gives us freedom for *non-LVGL* related things. The `key-held` applet should be retooled to use FFI bindings on evdev, rather than rely on a hack using the `evtest` command.

* * *

### Other notable changes

#### Bloat?

The initrd doesn't use `pkgsStatic` anymore. Fiddle uses `dlsym` to discover symbols by name, and this doesn't work with a static musl libc.

This doesn't bloat the initrd, compressed or not. The compressed boot image for `asus-z00t` is now smaller.

```
before: 16148480
now:    16140288
saved:      8192
```

The main space consumer is systemd libraries, used by udev, which already were using "normal" glibc builds, so this is why there is no bloating; everything pretty much already was in there.
