### PR TITLE
Remove messy `device.info` option

### DIFF
--- a/devices/asus-dumo/default.nix
+++ b/devices/asus-dumo/default.nix
@@ -7,11 +7,6 @@
     manufacturer = "Asus";
   };
 
-  mobile.device.info = {
-    # TODO : move kernel outside of the basic device details
-    kernel = pkgs.callPackage ./kernel {};
-  };
-
   mobile.hardware = {
     soc = "rockchip-op1";
     ram = 1024 * 4;
@@ -20,8 +15,12 @@
     };
   };
 
+  mobile.boot.stage-1 = {
+    kernel.package = pkgs.callPackage ./kernel {};
+  };
+
   mobile.system.depthcharge.kpart = {
-    dtbs = "${config.mobile.device.info.kernel}/dtbs/rockchip";
+    dtbs = "${config.mobile.boot.stage-1.kernel.package}/dtbs/rockchip";
   };
 
   # Serial console on ttyS2, using a suzyqable or equivalent.

--- a/devices/asus-dumo/default.nix
+++ b/devices/asus-dumo/default.nix
@@ -2,9 +2,12 @@
 
 {
   mobile.device.name = "asus-dumo";
-  mobile.device.info = rec {
+  mobile.device.identity = {
     name = "Chromebook Tablet CT100PA";
     manufacturer = "Asus";
+  };
+
+  mobile.device.info = rec {
     # Serial console on ttyS2, using a suzyqable or equivalent.
     kernel_cmdline = lib.concatStringsSep " " [
       "console=ttyS2,115200n8"

--- a/devices/asus-dumo/default.nix
+++ b/devices/asus-dumo/default.nix
@@ -7,18 +7,21 @@
     manufacturer = "Asus";
   };
 
-  mobile.device.info = rec {
+  mobile.device.info = {
     # TODO : move kernel outside of the basic device details
     kernel = pkgs.callPackage ./kernel {};
-    # This could be further pared down to only the required dtb files.
-    dtbs = "${kernel}/dtbs/rockchip";
   };
+
   mobile.hardware = {
     soc = "rockchip-op1";
     ram = 1024 * 4;
     screen = {
       width = 1536; height = 2048;
     };
+  };
+
+  mobile.system.depthcharge.kpart = {
+    dtbs = "${config.mobile.device.info.kernel}/dtbs/rockchip";
   };
 
   # Serial console on ttyS2, using a suzyqable or equivalent.

--- a/devices/asus-dumo/default.nix
+++ b/devices/asus-dumo/default.nix
@@ -3,12 +3,8 @@
 {
   mobile.device.name = "asus-dumo";
   mobile.device.info = rec {
-    format_version = "0";
     name = "Chromebook Tablet CT100PA";
     manufacturer = "Asus";
-    arch = "aarch64";
-    keyboard = false;
-    external_storage = true;
     # Serial console on ttyS2, using a suzyqable or equivalent.
     kernel_cmdline = lib.concatStringsSep " " [
       "console=ttyS2,115200n8"

--- a/devices/asus-dumo/default.nix
+++ b/devices/asus-dumo/default.nix
@@ -8,13 +8,6 @@
   };
 
   mobile.device.info = rec {
-    # Serial console on ttyS2, using a suzyqable or equivalent.
-    kernel_cmdline = lib.concatStringsSep " " [
-      "console=ttyS2,115200n8"
-      "earlyprintk=ttyS2,115200n8"
-      "loglevel=8"
-      "vt.global_cursor_default=0"
-    ];
     # TODO : move kernel outside of the basic device details
     kernel = pkgs.callPackage ./kernel {};
     # This could be further pared down to only the required dtb files.
@@ -27,6 +20,14 @@
       width = 1536; height = 2048;
     };
   };
+
+  # Serial console on ttyS2, using a suzyqable or equivalent.
+  boot.kernelParams = [
+    "console=ttyS2,115200n8"
+    "earlyprintk=ttyS2,115200n8"
+    "loglevel=8"
+    "vt.global_cursor_default=0"
+  ];
 
   mobile.system.type = "depthcharge";
 

--- a/devices/asus-flo/default.nix
+++ b/devices/asus-flo/default.nix
@@ -10,19 +10,24 @@
   mobile.device.info = {
     # TODO : make kernel part of options.
     kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
-    dtb = "";
-    flash_offset_base = "0x80200000";
-    flash_offset_kernel = "0x00008000";
-    flash_offset_ramdisk = "0x02000000";
-    flash_offset_second = "0x00f00000";
-    flash_offset_tags = "0x00000100";
-    flash_pagesize = "2048";
   };
+
   mobile.hardware = {
     soc = "qualcomm-apq8064-1aa";
     ram = 1024 * 2;
     screen = {
       width = 1200; height = 1920;
+    };
+  };
+
+  mobile.system.android.bootimg = {
+    flash = {
+      offset_base = "0x80200000";
+      offset_kernel = "0x00008000";
+      offset_ramdisk = "0x02000000";
+      offset_second = "0x00f00000";
+      offset_tags = "0x00000100";
+      pagesize = "2048";
     };
   };
 

--- a/devices/asus-flo/default.nix
+++ b/devices/asus-flo/default.nix
@@ -2,11 +2,14 @@
 
 {
   mobile.device.name = "asus-flo";
+  mobile.device.identity = {
+    name = "Nexus 7 2013 Wifi";
+    manufacturer = "Asus";
+  };
+
   mobile.device.info = {
     # TODO : make kernel part of options.
     kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
-    name = "Nexus 7 2013 Wifi";
-    manufacturer = "Asus";
     dtb = "";
     flash_offset_base = "0x80200000";
     kernel_cmdline = "xxxxxxxxxxxxxxxxxxxxxxxxxxconsole=ttyMSM0,115200,n8 user_debug=31 msm_rtb.filter=0x3F ehci-hcd.park=3 vmalloc=340M";

--- a/devices/asus-flo/default.nix
+++ b/devices/asus-flo/default.nix
@@ -12,7 +12,6 @@
     kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
     dtb = "";
     flash_offset_base = "0x80200000";
-    kernel_cmdline = "xxxxxxxxxxxxxxxxxxxxxxxxxxconsole=ttyMSM0,115200,n8 user_debug=31 msm_rtb.filter=0x3F ehci-hcd.park=3 vmalloc=340M";
     flash_offset_kernel = "0x00008000";
     flash_offset_ramdisk = "0x02000000";
     flash_offset_second = "0x00f00000";
@@ -26,6 +25,21 @@
       width = 1200; height = 1920;
     };
   };
+
+  boot.kernelParams = lib.mkMerge [
+    # This is a hack to work around the fact that the bootloader ignores some
+    # of the initial bytes of the kernel command line.
+    (lib.mkOrder 0 [
+      "xxxxxxxxxxxxxxxxxxxxxxxxxx"
+    ])
+    [
+      "console=ttyMSM0,115200,n8"
+      "user_debug=31"
+      "msm_rtb.filter=0x3F"
+      "ehci-hcd.park=3"
+      "vmalloc=340M"
+    ]
+  ];
 
   mobile.system.type = "android";
 }

--- a/devices/asus-flo/default.nix
+++ b/devices/asus-flo/default.nix
@@ -5,22 +5,9 @@
   mobile.device.info = {
     # TODO : make kernel part of options.
     kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
-    format_version = "0";
     name = "Nexus 7 2013 Wifi";
     manufacturer = "Asus";
-    date = "";
-    keyboard = false;
-    nonfree = "????";
     dtb = "";
-    modules = "";
-    modules_initfs = "";
-    external_storage = false;
-    flash_method = "fastboot";
-    arch = "armhf";
-    dev_touchscreen = "/dev/input/event1";
-    screen_width = "1200";
-    screen_height = "1920";
-    generate_bootimg = true;
     flash_offset_base = "0x80200000";
     kernel_cmdline = "xxxxxxxxxxxxxxxxxxxxxxxxxxconsole=ttyMSM0,115200,n8 user_debug=31 msm_rtb.filter=0x3F ehci-hcd.park=3 vmalloc=340M";
     flash_offset_kernel = "0x00008000";

--- a/devices/asus-flo/default.nix
+++ b/devices/asus-flo/default.nix
@@ -7,17 +7,16 @@
     manufacturer = "Asus";
   };
 
-  mobile.device.info = {
-    # TODO : make kernel part of options.
-    kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
-  };
-
   mobile.hardware = {
     soc = "qualcomm-apq8064-1aa";
     ram = 1024 * 2;
     screen = {
       width = 1200; height = 1920;
     };
+  };
+
+  mobile.boot.stage-1 = {
+    kernel.package = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
   };
 
   mobile.system.android.bootimg = {

--- a/devices/asus-z00t/default.nix
+++ b/devices/asus-z00t/default.nix
@@ -8,7 +8,6 @@
   };
 
   mobile.device.info = rec {
-    kernel_cmdline = "androidboot.hardware=qcom ehci-hcd.park=3 androidboot.bootdevice=7824900.sdhci lpm_levels.sleep_disabled=1 androidboot.selinux=permissive";
     bootimg_qcdt = true;
     flash_offset_base = "0x10000000";
     flash_offset_kernel = "0x00008000";
@@ -34,6 +33,14 @@
       width = 1080; height = 1920;
     };
   };
+
+  boot.kernelParams = [
+    "androidboot.hardware=qcom"
+    "ehci-hcd.park=3"
+    "androidboot.bootdevice=7824900.sdhci"
+    "lpm_levels.sleep_disabled=1"
+    "androidboot.selinux=permissive"
+  ];
 
   mobile.usb.mode = "android_usb";
   # Google

--- a/devices/asus-z00t/default.nix
+++ b/devices/asus-z00t/default.nix
@@ -7,23 +7,12 @@
     manufacturer = "Asus";
   };
 
-  mobile.device.info = rec {
-    bootimg_qcdt = true;
-    flash_offset_base = "0x10000000";
-    flash_offset_kernel = "0x00008000";
-    flash_offset_ramdisk = "0x02000000";
-    flash_offset_second = "0x00f00000";
-    flash_offset_tags = "0x00000100";
-    flash_pagesize = "2048";
-
+  mobile.device.info = {
     # TODO : make kernel part of options.
     kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
-    firmware = pkgs.callPackage ./firmware {};
-    dtb = "${kernel}/dtbs/asus-z00t.img";
   };
 
   mobile.hardware = {
-    # This could also be pre-built option types?
     soc = "qualcomm-msm8939";
     # 3GB for the specific revision supported.
     # When this will be actually used, this may be dropped to 2, and/or
@@ -31,6 +20,20 @@
     ram = 1024 * 3;
     screen = {
       width = 1080; height = 1920;
+    };
+  };
+
+  mobile.device.firmware = pkgs.callPackage ./firmware {};
+
+  mobile.system.android.bootimg = {
+    dt = "${config.mobile.device.info.kernel}/dtbs/asus-z00t.img";
+    flash = {
+      offset_base = "0x10000000";
+      offset_kernel = "0x00008000";
+      offset_ramdisk = "0x02000000";
+      offset_second = "0x00f00000";
+      offset_tags = "0x00000100";
+      pagesize = "2048";
     };
   };
 

--- a/devices/asus-z00t/default.nix
+++ b/devices/asus-z00t/default.nix
@@ -2,9 +2,12 @@
 
 {
   mobile.device.name = "asus-z00t";
-  mobile.device.info = rec {
+  mobile.device.identity = {
     name = "Zenfone 2 Laser/Selfie (1080p)";
     manufacturer = "Asus";
+  };
+
+  mobile.device.info = rec {
     kernel_cmdline = "androidboot.hardware=qcom ehci-hcd.park=3 androidboot.bootdevice=7824900.sdhci lpm_levels.sleep_disabled=1 androidboot.selinux=permissive";
     bootimg_qcdt = true;
     flash_offset_base = "0x10000000";
@@ -19,6 +22,7 @@
     firmware = pkgs.callPackage ./firmware {};
     dtb = "${kernel}/dtbs/asus-z00t.img";
   };
+
   mobile.hardware = {
     # This could also be pre-built option types?
     soc = "qualcomm-msm8939";

--- a/devices/asus-z00t/default.nix
+++ b/devices/asus-z00t/default.nix
@@ -7,11 +7,6 @@
     manufacturer = "Asus";
   };
 
-  mobile.device.info = {
-    # TODO : make kernel part of options.
-    kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
-  };
-
   mobile.hardware = {
     soc = "qualcomm-msm8939";
     # 3GB for the specific revision supported.
@@ -23,10 +18,14 @@
     };
   };
 
+  mobile.boot.stage-1 = {
+    kernel.package = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
+  };
+
   mobile.device.firmware = pkgs.callPackage ./firmware {};
 
   mobile.system.android.bootimg = {
-    dt = "${config.mobile.device.info.kernel}/dtbs/asus-z00t.img";
+    dt = "${config.mobile.boot.stage-1.kernel.package}/dtbs/asus-z00t.img";
     flash = {
       offset_base = "0x10000000";
       offset_kernel = "0x00008000";

--- a/devices/asus-z00t/default.nix
+++ b/devices/asus-z00t/default.nix
@@ -3,22 +3,9 @@
 {
   mobile.device.name = "asus-z00t";
   mobile.device.info = rec {
-    format_version = "0";
     name = "Zenfone 2 Laser/Selfie (1080p)";
     manufacturer = "Asus";
-    date = "";
-    modules_initfs = "";
-    arch = "aarch64";
-    keyboard = false;
-    external_storage = true;
-    screen_width = "1080";
-    screen_height = "1920";
-    dev_touchscreen = "";
-    dev_touchscreen_calibration = "";
-    dev_keyboard = "";
-    flash_method = "fastboot";
     kernel_cmdline = "androidboot.hardware=qcom ehci-hcd.park=3 androidboot.bootdevice=7824900.sdhci lpm_levels.sleep_disabled=1 androidboot.selinux=permissive";
-    generate_bootimg = true;
     bootimg_qcdt = true;
     flash_offset_base = "0x10000000";
     flash_offset_kernel = "0x00008000";
@@ -26,7 +13,6 @@
     flash_offset_second = "0x00f00000";
     flash_offset_tags = "0x00000100";
     flash_pagesize = "2048";
-    pm_name = "asus-z00t";
 
     # TODO : make kernel part of options.
     kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };

--- a/devices/google-marlin/default.nix
+++ b/devices/google-marlin/default.nix
@@ -12,19 +12,6 @@
     kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
     dtb = "";
 
-    kernel_cmdline = lib.concatStringsSep " " [
-      "console=ttyHSL0,115200,n8"
-      "androidboot.console=ttyHSL0"
-      "androidboot.hardware=marlin"
-      "user_debug=31"
-      "ehci-hcd.park=3"
-      "lpm_levels.sleep_disabled=1"
-      "cma=32M@0-0xffffffff"
-      "loop.max_part=7"
-      "buildvariant=eng"
-      "firmware_class.path=/vendor/firmware"
-    ];
-
     bootimg_qcdt = false;
     flash_offset_base = "0x80000000";
     flash_offset_kernel = "0x00008000";
@@ -47,6 +34,19 @@
       width = 1440; height = 2880;
     };
   };
+
+  boot.kernelParams = [
+    "console=ttyHSL0,115200,n8"
+    "androidboot.console=ttyHSL0"
+    "androidboot.hardware=marlin"
+    "user_debug=31"
+    "ehci-hcd.park=3"
+    "lpm_levels.sleep_disabled=1"
+    "cma=32M@0-0xffffffff"
+    "loop.max_part=7"
+    "buildvariant=eng"
+    "firmware_class.path=/vendor/firmware"
+  ];
 
   mobile.usb.mode = "android_usb";
   # Google

--- a/devices/google-marlin/default.nix
+++ b/devices/google-marlin/default.nix
@@ -7,24 +7,9 @@
     manufacturer = "Google";
   };
 
-  mobile.device.info = rec {
+  mobile.device.info = {
     # TODO : make kernel part of options.
     kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
-    dtb = "";
-
-    bootimg_qcdt = false;
-    flash_offset_base = "0x80000000";
-    flash_offset_kernel = "0x00008000";
-    flash_offset_ramdisk = "0x01000000";
-    flash_offset_second = "0x00f00000";
-    flash_offset_tags = "0x00000100";
-    flash_pagesize = "4096";
-
-    # This device adds skip_initramfs to cmdline for normal boots
-    boot_as_recovery = true;
-
-    ab_partitions = true;
-    vendor_partition = "/dev/disk/by-partlabel/vendor_a";
   };
 
   mobile.hardware = {
@@ -34,6 +19,22 @@
       width = 1440; height = 2880;
     };
   };
+
+  mobile.system.android = {
+    # This device has an A/B partition scheme
+    ab_partitions = true;
+
+    bootimg.flash = {
+      offset_base = "0x80000000";
+      offset_kernel = "0x00008000";
+      offset_ramdisk = "0x01000000";
+      offset_second = "0x00f00000";
+      offset_tags = "0x00000100";
+      pagesize = "4096";
+    };
+  };
+
+  mobile.system.vendor.partition = "/dev/disk/by-partlabel/vendor_a";
 
   boot.kernelParams = [
     "console=ttyHSL0,115200,n8"

--- a/devices/google-marlin/default.nix
+++ b/devices/google-marlin/default.nix
@@ -7,17 +7,16 @@
     manufacturer = "Google";
   };
 
-  mobile.device.info = {
-    # TODO : make kernel part of options.
-    kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
-  };
-
   mobile.hardware = {
     soc = "qualcomm-msm8996";
     ram = 1024 * 4;
     screen = {
       width = 1440; height = 2880;
     };
+  };
+
+  mobile.boot.stage-1 = {
+    kernel.package = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
   };
 
   mobile.system.android = {

--- a/devices/google-marlin/default.nix
+++ b/devices/google-marlin/default.nix
@@ -7,21 +7,8 @@
     # TODO : make kernel part of options.
     kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
 
-    format_version = "0";
     manufacturer = "Google";
-    codename = "google-marlin";
-    date = "";
     dtb = "";
-    modules_initfs = "";
-    arch = "aarch64";
-    keyboard = "false";
-    external_storage = "true";
-    screen_width = "1440";
-    screen_height = "2880";
-    dev_touchscreen = "";
-    dev_touchscreen_calibration = "";
-    dev_keyboard = "";
-    flash_method = "fastboot";
 
     kernel_cmdline = lib.concatStringsSep " " [
       "console=ttyHSL0,115200,n8"
@@ -36,7 +23,6 @@
       "firmware_class.path=/vendor/firmware"
     ];
 
-    generate_bootimg = true;
     bootimg_qcdt = false;
     flash_offset_base = "0x80000000";
     flash_offset_kernel = "0x00008000";

--- a/devices/google-marlin/default.nix
+++ b/devices/google-marlin/default.nix
@@ -2,12 +2,14 @@
 
 {
   mobile.device.name = "google-marlin";
-  mobile.device.info = rec {
+  mobile.device.identity = {
     name = "Google Pixel XL";
+    manufacturer = "Google";
+  };
+
+  mobile.device.info = rec {
     # TODO : make kernel part of options.
     kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
-
-    manufacturer = "Google";
     dtb = "";
 
     kernel_cmdline = lib.concatStringsSep " " [

--- a/devices/google-walleye/default.nix
+++ b/devices/google-walleye/default.nix
@@ -2,12 +2,15 @@
 
 {
   mobile.device.name = "google-walleye";
-  mobile.device.info = rec {
+  mobile.device.identity = {
     name = "Pixel 2";
+    manufacturer = "Google";
+  };
+
+  mobile.device.info = rec {
     # TODO : make kernel part of options.
     kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
 
-    manufacturer = "Google";
     dtb = "";
 
     kernel_cmdline = lib.concatStringsSep " " [

--- a/devices/google-walleye/default.nix
+++ b/devices/google-walleye/default.nix
@@ -13,26 +13,6 @@
 
     dtb = "";
 
-    kernel_cmdline = lib.concatStringsSep " " [
-      # From TWRP
-      "androidboot.hardware=walleye"
-      "androidboot.console=ttyMSM0"
-      "lpm_levels.sleep_disabled=1"
-      "user_debug=31"
-      "msm_rtb.filter=0x37"
-      "ehci-hcd.park=3"
-      "service_locator.enable=1"
-      "swiotlb=2048"
-      "firmware_class.path=/vendor/firmware"
-      "loop.max_part=7"
-      "raid=noautodetect"
-      "androidboot.fastboot=1"
-      "buildvariant=eng"
-
-      # Using `quiet` fixes early framebuffer init, for stage-1
-      "quiet"
-    ];
-
     bootimg_qcdt = false;
     flash_offset_base = "0x00000000";
     flash_offset_kernel = "0x00008000";
@@ -60,6 +40,26 @@
       width = 1080; height = 1920;
     };
   };
+
+  boot.kernelParams = [
+    # From TWRP
+    "androidboot.hardware=walleye"
+    "androidboot.console=ttyMSM0"
+    "lpm_levels.sleep_disabled=1"
+    "user_debug=31"
+    "msm_rtb.filter=0x37"
+    "ehci-hcd.park=3"
+    "service_locator.enable=1"
+    "swiotlb=2048"
+    "firmware_class.path=/vendor/firmware"
+    "loop.max_part=7"
+    "raid=noautodetect"
+    "androidboot.fastboot=1"
+    "buildvariant=eng"
+
+    # Using `quiet` fixes early framebuffer init, for stage-1
+    "quiet"
+  ];
 
   mobile.system.type = "android";
 

--- a/devices/google-walleye/default.nix
+++ b/devices/google-walleye/default.nix
@@ -7,30 +7,9 @@
     manufacturer = "Google";
   };
 
-  mobile.device.info = rec {
+  mobile.device.info = {
     # TODO : make kernel part of options.
     kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
-
-    dtb = "";
-
-    bootimg_qcdt = false;
-    flash_offset_base = "0x00000000";
-    flash_offset_kernel = "0x00008000";
-    flash_offset_ramdisk = "0x01000000";
-    flash_offset_second = "0x00f00000";
-    flash_offset_tags = "0x00000100";
-    flash_pagesize = "4096";
-
-    # This device adds skip_initramfs to cmdline for normal boots
-    boot_as_recovery = true;
-
-    ab_partitions = true;
-    vendor_partition = "/dev/disk/by-partlabel/vendor_a";
-    gadgetfs.functions = {
-      rndis = "gsi.rndis";
-      # FIXME: This is the right function name, but doesn't work.
-      # adb = "ffs.usb0";
-    };
   };
 
   mobile.hardware = {
@@ -40,6 +19,22 @@
       width = 1080; height = 1920;
     };
   };
+
+  mobile.system.android = {
+    # This device has an A/B partition scheme
+    ab_partitions = true;
+
+    bootimg.flash = {
+      offset_base = "0x00000000";
+      offset_kernel = "0x00008000";
+      offset_ramdisk = "0x01000000";
+      offset_second = "0x00f00000";
+      offset_tags = "0x00000100";
+      pagesize = "4096";
+    };
+  };
+
+  mobile.system.vendor.partition = "/dev/disk/by-partlabel/vendor_a";
 
   boot.kernelParams = [
     # From TWRP
@@ -68,4 +63,10 @@
   mobile.usb.idVendor = "18D1";
   # "Nexus 4"
   mobile.usb.idProduct = "D001";
+
+  mobile.usb.gadgetfs.functions = {
+    rndis = "gsi.rndis";
+    # FIXME: This is the right function name, but doesn't work.
+    # adb = "ffs.usb0";
+  };
 }

--- a/devices/google-walleye/default.nix
+++ b/devices/google-walleye/default.nix
@@ -7,21 +7,8 @@
     # TODO : make kernel part of options.
     kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
 
-    format_version = "0";
     manufacturer = "Google";
-    codename = "google-walleye";
-    date = "";
     dtb = "";
-    modules_initfs = "";
-    arch = "aarch64";
-    keyboard = "false";
-    external_storage = "true";
-    screen_width = "1080";
-    screen_height = "1920";
-    dev_touchscreen = "";
-    dev_touchscreen_calibration = "";
-    dev_keyboard = "";
-    flash_method = "fastboot";
 
     kernel_cmdline = lib.concatStringsSep " " [
       # From TWRP
@@ -43,7 +30,6 @@
       "quiet"
     ];
 
-    generate_bootimg = "true";
     bootimg_qcdt = false;
     flash_offset_base = "0x00000000";
     flash_offset_kernel = "0x00008000";

--- a/devices/google-walleye/default.nix
+++ b/devices/google-walleye/default.nix
@@ -7,17 +7,16 @@
     manufacturer = "Google";
   };
 
-  mobile.device.info = {
-    # TODO : make kernel part of options.
-    kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
-  };
-
   mobile.hardware = {
     soc = "qualcomm-msm8998";
     ram = 1024 * 4;
     screen = {
       width = 1080; height = 1920;
     };
+  };
+
+  mobile.boot.stage-1 = {
+    kernel.package = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
   };
 
   mobile.system.android = {

--- a/devices/motorola-addison/default.nix
+++ b/devices/motorola-addison/default.nix
@@ -2,9 +2,12 @@
 
 {
   mobile.device.name = "motorola-addison";
-  mobile.device.info = rec {
+  mobile.device.identity = {
     name = "Moto Z Play";
     manufacturer = "Motorola";
+  };
+
+  mobile.device.info = rec {
     kernel_cmdline = lib.concatStringsSep " " [
       "androidboot.console=ttyHSL0"
       "androidboot.hardware=qcom"

--- a/devices/motorola-addison/default.nix
+++ b/devices/motorola-addison/default.nix
@@ -7,23 +7,28 @@
     manufacturer = "Motorola";
   };
 
-  mobile.device.info = rec {
-    bootimg_qcdt = true;
-    flash_offset_base = "0x80000000";
-    flash_offset_kernel = "0x00008000";
-    flash_offset_ramdisk = "0x01000000";
-    flash_offset_second = "0x00f00000";
-    flash_offset_tags = "0x00000100";
-    flash_pagesize = "2048";
+  mobile.device.info = {
     # TODO : make kernel part of options.
     kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
-    dtb = "${kernel}/dtbs/motorola-addison.img";
   };
+
   mobile.hardware = {
     soc = "qualcomm-msm8953";
     ram = 1024 * 3;
     screen = {
       width = 1080; height = 1920;
+    };
+  };
+
+  mobile.system.android.bootimg = {
+    dt = "${config.mobile.device.info.kernel}/dtbs/motorola-addison.img";
+    flash = {
+      offset_base = "0x80000000";
+      offset_kernel = "0x00008000";
+      offset_ramdisk = "0x01000000";
+      offset_second = "0x00f00000";
+      offset_tags = "0x00000100";
+      pagesize = "2048";
     };
   };
 

--- a/devices/motorola-addison/default.nix
+++ b/devices/motorola-addison/default.nix
@@ -3,20 +3,8 @@
 {
   mobile.device.name = "motorola-addison";
   mobile.device.info = rec {
-    format_version = "0";
     name = "Moto Z Play";
     manufacturer = "Motorola";
-    date = "";
-    modules_initfs = "";
-    arch = "aarch64";
-    keyboard = false;
-    external_storage = true;
-    screen_width = "1080";
-    screen_height = "1920";
-    dev_touchscreen = "";
-    dev_touchscreen_calibration = "";
-    dev_keyboard = "";
-    flash_method = "fastboot";
     kernel_cmdline = lib.concatStringsSep " " [
       "androidboot.console=ttyHSL0"
       "androidboot.hardware=qcom"
@@ -28,7 +16,6 @@
       "vmalloc=350M"
       "buildvariant=userdebug"
     ];
-    generate_bootimg = true;
     bootimg_qcdt = true;
     flash_offset_base = "0x80000000";
     flash_offset_kernel = "0x00008000";

--- a/devices/motorola-addison/default.nix
+++ b/devices/motorola-addison/default.nix
@@ -8,17 +8,6 @@
   };
 
   mobile.device.info = rec {
-    kernel_cmdline = lib.concatStringsSep " " [
-      "androidboot.console=ttyHSL0"
-      "androidboot.hardware=qcom"
-      "user_debug=30"
-      "msm_rtb.filter=0x237"
-      "ehci-hcd.park=3"
-      "androidboot.bootdevice=7824900.sdhci"
-      "lpm_levels.sleep_disabled=1"
-      "vmalloc=350M"
-      "buildvariant=userdebug"
-    ];
     bootimg_qcdt = true;
     flash_offset_base = "0x80000000";
     flash_offset_kernel = "0x00008000";
@@ -37,6 +26,18 @@
       width = 1080; height = 1920;
     };
   };
+
+  boot.kernelParams = [
+    "androidboot.console=ttyHSL0"
+    "androidboot.hardware=qcom"
+    "user_debug=30"
+    "msm_rtb.filter=0x237"
+    "ehci-hcd.park=3"
+    "androidboot.bootdevice=7824900.sdhci"
+    "lpm_levels.sleep_disabled=1"
+    "vmalloc=350M"
+    "buildvariant=userdebug"
+  ];
 
   mobile.usb.mode = "android_usb";
   # Google

--- a/devices/motorola-addison/default.nix
+++ b/devices/motorola-addison/default.nix
@@ -7,11 +7,6 @@
     manufacturer = "Motorola";
   };
 
-  mobile.device.info = {
-    # TODO : make kernel part of options.
-    kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
-  };
-
   mobile.hardware = {
     soc = "qualcomm-msm8953";
     ram = 1024 * 3;
@@ -20,8 +15,12 @@
     };
   };
 
+  mobile.boot.stage-1 = {
+    kernel.package = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
+  };
+
   mobile.system.android.bootimg = {
-    dt = "${config.mobile.device.info.kernel}/dtbs/motorola-addison.img";
+    dt = "${config.mobile.boot.stage-1.kernel.package}/dtbs/motorola-addison.img";
     flash = {
       offset_base = "0x80000000";
       offset_kernel = "0x00008000";

--- a/devices/oneplus-oneplus3/default.nix
+++ b/devices/oneplus-oneplus3/default.nix
@@ -7,17 +7,16 @@
     manufacturer = "OnePlus";
   };
 
-  mobile.device.info = {
-    # TODO : make kernel part of options.
-    kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
-  };
-
   mobile.hardware = {
     soc = "qualcomm-msm8996";
     ram = 1024 * 6;
     screen = {
       width = 1080; height = 1920;
     };
+  };
+
+  mobile.boot.stage-1 = {
+    kernel.package = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
   };
 
   mobile.system.android.bootimg = {

--- a/devices/oneplus-oneplus3/default.nix
+++ b/devices/oneplus-oneplus3/default.nix
@@ -9,7 +9,6 @@
 
   mobile.device.info = rec {
     dtb = "";
-    kernel_cmdline = "androidboot.hardware=qcom user_debug=31 msm_rtb.filter=0x237 ehci-hcd.park=3 lpm_levels.sleep_disabled=1 cma=32M@0-0xffffffff androidboot.selinux=permissive buildvariant=eng";
     flash_offset_base = "0x80000000";
     flash_offset_kernel = "0x00008000";
     flash_offset_ramdisk = "0x01000000";
@@ -28,6 +27,17 @@
       width = 1080; height = 1920;
     };
   };
+
+  boot.kernelParams = [
+    "androidboot.hardware=qcom"
+    "user_debug=31"
+    "msm_rtb.filter=0x237"
+    "ehci-hcd.park=3"
+    "lpm_levels.sleep_disabled=1"
+    "cma=32M@0-0xffffffff"
+    "androidboot.selinux=permissive"
+    "buildvariant=eng"
+  ];
 
   mobile.usb.mode = "android_usb";
   # Google

--- a/devices/oneplus-oneplus3/default.nix
+++ b/devices/oneplus-oneplus3/default.nix
@@ -7,15 +7,7 @@
     manufacturer = "OnePlus";
   };
 
-  mobile.device.info = rec {
-    dtb = "";
-    flash_offset_base = "0x80000000";
-    flash_offset_kernel = "0x00008000";
-    flash_offset_ramdisk = "0x01000000";
-    flash_offset_second = "0x00f00000";
-    flash_offset_tags = "0x00000100";
-    flash_pagesize = "4096";
-
+  mobile.device.info = {
     # TODO : make kernel part of options.
     kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
   };
@@ -25,6 +17,17 @@
     ram = 1024 * 6;
     screen = {
       width = 1080; height = 1920;
+    };
+  };
+
+  mobile.system.android.bootimg = {
+    flash = {
+      offset_base = "0x80000000";
+      offset_kernel = "0x00008000";
+      offset_ramdisk = "0x01000000";
+      offset_second = "0x00f00000";
+      offset_tags = "0x00000100";
+      pagesize = "4096";
     };
   };
 

--- a/devices/oneplus-oneplus3/default.nix
+++ b/devices/oneplus-oneplus3/default.nix
@@ -3,23 +3,10 @@
 {
   mobile.device.name = "oneplus-oneplus3";
   mobile.device.info = rec {
-    format_version = "0";
     name = "OnePlus 3";
     manufacturer = "OnePlus";
-    date = "";
     dtb = "";
-    modules_initfs = "";
-    arch = "aarch64";
-    keyboard = false;
-    external_storage = true;
-    screen_width = "1080";
-    screen_height = "1920";
-    dev_touchscreen = "";
-    dev_touchscreen_calibration = "";
-    dev_keyboard = "";
-    flash_method = "fastboot";
     kernel_cmdline = "androidboot.hardware=qcom user_debug=31 msm_rtb.filter=0x237 ehci-hcd.park=3 lpm_levels.sleep_disabled=1 cma=32M@0-0xffffffff androidboot.selinux=permissive buildvariant=eng";
-    generate_bootimg = true;
     flash_offset_base = "0x80000000";
     flash_offset_kernel = "0x00008000";
     flash_offset_ramdisk = "0x01000000";

--- a/devices/oneplus-oneplus3/default.nix
+++ b/devices/oneplus-oneplus3/default.nix
@@ -2,9 +2,12 @@
 
 {
   mobile.device.name = "oneplus-oneplus3";
-  mobile.device.info = rec {
+  mobile.device.identity = {
     name = "OnePlus 3";
     manufacturer = "OnePlus";
+  };
+
+  mobile.device.info = rec {
     dtb = "";
     kernel_cmdline = "androidboot.hardware=qcom user_debug=31 msm_rtb.filter=0x237 ehci-hcd.park=3 lpm_levels.sleep_disabled=1 cma=32M@0-0xffffffff androidboot.selinux=permissive buildvariant=eng";
     flash_offset_base = "0x80000000";

--- a/devices/pine64-pinephone-braveheart/default.nix
+++ b/devices/pine64-pinephone-braveheart/default.nix
@@ -7,8 +7,7 @@
     manufacturer = "Pine64";
   };
 
-  mobile.device.info = rec {
-    # Serial console on ttyS0, using the serial headphone adapter.
+  mobile.device.info = {
     # TODO : make kernel part of options.
     kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
   };
@@ -22,6 +21,7 @@
   };
 
   boot.kernelParams = [
+    # Serial console on ttyS0, using the serial headphone adapter.
     "console=ttyS0,115200"
     "vt.global_cursor_default=0"
     "earlycon=uart,mmio32,0x01c28000"

--- a/devices/pine64-pinephone-braveheart/default.nix
+++ b/devices/pine64-pinephone-braveheart/default.nix
@@ -2,10 +2,12 @@
 
 {
   mobile.device.name = "pine64-pinephone-braveheart";
-  mobile.device.info = rec {
+  mobile.device.identity = {
     name = "PinePhone “BraveHeart”";
     manufacturer = "Pine64";
+  };
 
+  mobile.device.info = rec {
     # Serial console on ttyS0, using the serial headphone adapter.
     kernel_cmdline = lib.concatStringsSep " " [
       "console=ttyS0,115200"

--- a/devices/pine64-pinephone-braveheart/default.nix
+++ b/devices/pine64-pinephone-braveheart/default.nix
@@ -9,13 +9,6 @@
 
   mobile.device.info = rec {
     # Serial console on ttyS0, using the serial headphone adapter.
-    kernel_cmdline = lib.concatStringsSep " " [
-      "console=ttyS0,115200"
-      "vt.global_cursor_default=0"
-      "earlycon=uart,mmio32,0x01c28000"
-      "panic=10"
-      "consoleblank=0"
-    ];
     # TODO : make kernel part of options.
     kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
   };
@@ -27,6 +20,14 @@
       width = 720; height = 1440;
     };
   };
+
+  boot.kernelParams = [
+    "console=ttyS0,115200"
+    "vt.global_cursor_default=0"
+    "earlycon=uart,mmio32,0x01c28000"
+    "panic=10"
+    "consoleblank=0"
+  ];
 
   mobile.system.type = "u-boot";
   mobile.quirks.u-boot.package = pkgs.callPackage ./u-boot {};

--- a/devices/pine64-pinephone-braveheart/default.nix
+++ b/devices/pine64-pinephone-braveheart/default.nix
@@ -7,17 +7,16 @@
     manufacturer = "Pine64";
   };
 
-  mobile.device.info = {
-    # TODO : make kernel part of options.
-    kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
-  };
-
   mobile.hardware = {
     soc = "allwinner-a64";
     ram = 1024 * 2;
     screen = {
       width = 720; height = 1440;
     };
+  };
+
+  mobile.boot.stage-1 = {
+    kernel.package = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
   };
 
   boot.kernelParams = [

--- a/devices/pine64-pinephone-braveheart/default.nix
+++ b/devices/pine64-pinephone-braveheart/default.nix
@@ -3,15 +3,8 @@
 {
   mobile.device.name = "pine64-pinephone-braveheart";
   mobile.device.info = rec {
-    format_version = "0";
     name = "PinePhone “BraveHeart”";
     manufacturer = "Pine64";
-    arch = "aarch64";
-    keyboard = false;
-    external_storage = true;
-
-    screen_width = "720";
-    screen_height = "1440";
 
     # Serial console on ttyS0, using the serial headphone adapter.
     kernel_cmdline = lib.concatStringsSep " " [

--- a/devices/qemu-x86_64/default.nix
+++ b/devices/qemu-x86_64/default.nix
@@ -8,9 +8,6 @@ let
   splash = config.mobile.boot.stage-1.splash.enable;
 
   kernel = pkgs.linuxPackages_5_4.kernel;
-  device_info = {
-   name = "QEMU (x86_64)";
-  };
 
   modules = [
     # Disk images
@@ -42,7 +39,12 @@ let
 in
 {
   mobile.device.name = "qemu-x86_64";
-  mobile.device.info = device_info // {
+  mobile.device.identity = {
+   name = "(x86_64)";
+   manufacturer = "QEMU";
+  };
+
+  mobile.device.info = {
     # TODO : make kernel part of options.
     inherit kernel;
     kernel_cmdline = lib.concatStringsSep " " ([

--- a/devices/qemu-x86_64/default.nix
+++ b/devices/qemu-x86_64/default.nix
@@ -7,11 +7,6 @@
    manufacturer = "QEMU";
   };
 
-  mobile.device.info = {
-    # TODO : make kernel part of options.
-    kernel = pkgs.linuxPackages_5_4.kernel;
-  };
-
   mobile.hardware = {
     soc = "generic-x86_64";
 
@@ -34,6 +29,7 @@
 
   mobile.boot.stage-1 = {
     kernel = {
+      package = pkgs.linuxPackages_5_4.kernel;
       modular = true;
       modules = [
         # Disk images

--- a/devices/qemu-x86_64/default.nix
+++ b/devices/qemu-x86_64/default.nix
@@ -1,42 +1,5 @@
 { config, lib, pkgs, ... }:
 
-let
-  # This device description is a bit configurable through
-  # mobile options...
-
-  # Enabling the splash changes some settings.
-  splash = config.mobile.boot.stage-1.splash.enable;
-
-  kernel = pkgs.linuxPackages_5_4.kernel;
-
-  modules = [
-    # Disk images
-    "ata_piix"
-    "sd_mod"
-
-    # Networking
-    "e1000"
-
-    # Keyboard
-    "hid_generic"
-    "pcips2" "atkbd" "i8042"
-
-    # Mouse
-    "mousedev"
-
-    # Input within X11
-    "uinput" "evdev"
-
-    # USB
-    "usbcore" "usbhid" "ehci_pci" "ehci_hcd"
-
-    # x86 RTC needed by the stage 2 init script.
-    "rtc_cmos"
-
-    # Video
-    "bochs_drm"
-  ];
-in
 {
   mobile.device.name = "qemu-x86_64";
   mobile.device.identity = {
@@ -46,7 +9,7 @@ in
 
   mobile.device.info = {
     # TODO : make kernel part of options.
-    inherit kernel;
+    kernel = pkgs.linuxPackages_5_4.kernel;
   };
 
   mobile.hardware = {
@@ -68,10 +31,37 @@ in
   ];
 
   mobile.system.type = "qemu-startscript";
+
   mobile.boot.stage-1 = {
     kernel = {
       modular = true;
-      inherit modules;
+      modules = [
+        # Disk images
+        "ata_piix"
+        "sd_mod"
+
+        # Networking
+        "e1000"
+
+        # Keyboard
+        "hid_generic"
+        "pcips2" "atkbd" "i8042"
+
+        # Mouse
+        "mousedev"
+
+        # Input within X11
+        "uinput" "evdev"
+
+        # USB
+        "usbcore" "usbhid" "ehci_pci" "ehci_hcd"
+
+        # x86 RTC needed by the stage 2 init script.
+        "rtc_cmos"
+
+        # Video
+        "bochs_drm"
+      ];
     };
   };
 }

--- a/devices/qemu-x86_64/default.nix
+++ b/devices/qemu-x86_64/default.nix
@@ -47,12 +47,6 @@ in
   mobile.device.info = {
     # TODO : make kernel part of options.
     inherit kernel;
-    kernel_cmdline = lib.concatStringsSep " " ([
-      "console=tty1"
-      "console=ttyS0"
-      "vt.global_cursor_default=0"
-      "quiet"
-    ]);
   };
 
   mobile.hardware = {
@@ -65,6 +59,13 @@ in
     };
     ram = 1024 * 2;
   };
+
+  boot.kernelParams = [
+    "console=tty1"
+    "console=ttyS0"
+    "vt.global_cursor_default=0"
+    "quiet"
+  ];
 
   mobile.system.type = "qemu-startscript";
   mobile.boot.stage-1 = {

--- a/devices/xiaomi-lavender/default.nix
+++ b/devices/xiaomi-lavender/default.nix
@@ -5,17 +5,8 @@
   mobile.device.info = rec {
     # TODO : make kernel part of options.
     kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
-    format_version = "0";
     name = "Redmi Note 7";
     manufacturer = "Xiaomi";
-    codename = "xiaomi-lavender";
-    modules_initfs = "";
-    arch = "aarch64";
-    keyboard = "false";
-    external_storage = "true";
-    screen_width = "1080";
-    screen_height = "2340";
-    flash_method = "fastboot";
     kernel_cmdline = lib.concatStringsSep " " [
       "earlycon=msm_serial_dm,0xc170000"
       "androidboot.hardware=qcom"
@@ -32,7 +23,6 @@
       "androidboot.selinux=permissive"
       "buildvariant=userdebug"
     ];
-    generate_bootimg = "true";
     bootimg_qcdt = false;
     flash_offset_base = "0x00000000";
     flash_offset_kernel = "0x00008000";

--- a/devices/xiaomi-lavender/default.nix
+++ b/devices/xiaomi-lavender/default.nix
@@ -7,30 +7,11 @@
     manufacturer = "Xiaomi";
   };
 
-  mobile.device.info = rec {
+  mobile.device.info = {
     # TODO : make kernel part of options.
     kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
-    bootimg_qcdt = false;
-    flash_offset_base = "0x00000000";
-    flash_offset_kernel = "0x00008000";
-    flash_offset_ramdisk = "0x01000000";
-    flash_offset_second = "0x00f00000";
-    flash_offset_tags = "0x00000100";
-    flash_pagesize = "4096";
-
-    # This device adds skip_initramfs to cmdline for normal boots
-    boot_as_recovery = true;
-    # Though this device has "boot_as_recovery", it still has a classic
-    # recovery partition for recovery. Go figure.
-    has_recovery_partition = true;
-
-    vendor_partition = "/dev/disk/by-partlabel/vendor";
-    gadgetfs.functions = {
-      rndis = "rndis_bam.rndis";
-      # FIXME: This is likely the right function name, but doesn't work.
-      # adb = "ffs.usb0";
-    };
   };
+
   mobile.hardware = {
     soc = "qualcomm-sdm660";
     # 4GB for the specific revision supported.
@@ -41,6 +22,26 @@
       width = 1080; height = 2340;
     };
   };
+
+  mobile.system.android = {
+    # This device adds skip_initramfs to cmdline for normal boots
+    boot_as_recovery = true;
+
+    # Though this device has "boot_as_recovery", it still has a classic
+    # recovery partition for recovery. Go figure.
+    has_recovery_partition = true;
+
+    bootimg.flash = {
+      offset_base = "0x00000000";
+      offset_kernel = "0x00008000";
+      offset_ramdisk = "0x01000000";
+      offset_second = "0x00f00000";
+      offset_tags = "0x00000100";
+      pagesize = "4096";
+    };
+  };
+
+  mobile.system.vendor.partition = "/dev/disk/by-partlabel/vendor";
 
   boot.kernelParams = [
     "earlycon=msm_serial_dm,0xc170000"
@@ -59,10 +60,16 @@
     "buildvariant=userdebug"
   ];
 
+  mobile.system.type = "android";
+
   mobile.usb.mode = "gadgetfs";
   # FIXME: attribute to sources.
   mobile.usb.idVendor  = "2717"; # Xiaomi Communications Co., Ltd.
   mobile.usb.idProduct = "FF80"; # Mi/Redmi series (RNDIS)
 
-  mobile.system.type = "android";
+  mobile.usb.gadgetfs.functions = {
+    rndis = "rndis_bam.rndis";
+    # FIXME: This is likely the right function name, but doesn't work.
+    # adb = "ffs.usb0";
+  };
 }

--- a/devices/xiaomi-lavender/default.nix
+++ b/devices/xiaomi-lavender/default.nix
@@ -10,22 +10,6 @@
   mobile.device.info = rec {
     # TODO : make kernel part of options.
     kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
-    kernel_cmdline = lib.concatStringsSep " " [
-      "earlycon=msm_serial_dm,0xc170000"
-      "androidboot.hardware=qcom"
-      "user_debug=31"
-      "msm_rtb.filter=0x37"
-      "ehci-hcd.park=3"
-      "lpm_levels.sleep_disabled=1"
-      "sched_enable_hmp=1"
-      "sched_enable_power_aware=1"
-      "service_locator.enable=1"
-      "swiotlb=1"
-      "firmware_class.path=/vendor/firmware_mnt/image"
-      "loop.max_part=7"
-      "androidboot.selinux=permissive"
-      "buildvariant=userdebug"
-    ];
     bootimg_qcdt = false;
     flash_offset_base = "0x00000000";
     flash_offset_kernel = "0x00008000";
@@ -57,6 +41,23 @@
       width = 1080; height = 2340;
     };
   };
+
+  boot.kernelParams = [
+    "earlycon=msm_serial_dm,0xc170000"
+    "androidboot.hardware=qcom"
+    "user_debug=31"
+    "msm_rtb.filter=0x37"
+    "ehci-hcd.park=3"
+    "lpm_levels.sleep_disabled=1"
+    "sched_enable_hmp=1"
+    "sched_enable_power_aware=1"
+    "service_locator.enable=1"
+    "swiotlb=1"
+    "firmware_class.path=/vendor/firmware_mnt/image"
+    "loop.max_part=7"
+    "androidboot.selinux=permissive"
+    "buildvariant=userdebug"
+  ];
 
   mobile.usb.mode = "gadgetfs";
   # FIXME: attribute to sources.

--- a/devices/xiaomi-lavender/default.nix
+++ b/devices/xiaomi-lavender/default.nix
@@ -2,11 +2,14 @@
 
 {
   mobile.device.name = "xiaomi-lavender";
+  mobile.device.identity = {
+    name = "Redmi Note 7";
+    manufacturer = "Xiaomi";
+  };
+
   mobile.device.info = rec {
     # TODO : make kernel part of options.
     kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
-    name = "Redmi Note 7";
-    manufacturer = "Xiaomi";
     kernel_cmdline = lib.concatStringsSep " " [
       "earlycon=msm_serial_dm,0xc170000"
       "androidboot.hardware=qcom"

--- a/devices/xiaomi-lavender/default.nix
+++ b/devices/xiaomi-lavender/default.nix
@@ -7,11 +7,6 @@
     manufacturer = "Xiaomi";
   };
 
-  mobile.device.info = {
-    # TODO : make kernel part of options.
-    kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
-  };
-
   mobile.hardware = {
     soc = "qualcomm-sdm660";
     # 4GB for the specific revision supported.
@@ -21,6 +16,10 @@
     screen = {
       width = 1080; height = 2340;
     };
+  };
+
+  mobile.boot.stage-1 = {
+    kernel.package = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
   };
 
   mobile.system.android = {

--- a/devices/xiaomi-tissot/default.nix
+++ b/devices/xiaomi-tissot/default.nix
@@ -1,7 +1,6 @@
 { config, lib, pkgs, ... }:
-let
-  inherit (config.mobile.device) name;
-in {
+
+{
   mobile.device.name = "xiaomi-tissot";
   mobile.device.identity = {
     name = "A1";
@@ -9,20 +8,26 @@ in {
   };
 
   mobile.device.info = {
-    flash_offset_base = "0x80000000";
-    flash_offset_kernel = "0x00008000";
-    flash_offset_second = "0x00f00000";
-    flash_offset_ramdisk = "0x01000000";
-    flash_offset_tags = "0x00000100";
-    flash_pagesize = "2048";
+    # TODO : make kernel part of options.
     kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
-    #dtb = "${kernel}/dtbs/msm8953-qrd-sku3-tissot.dtb";
   };
+
   mobile.hardware = {
     soc = "qualcomm-msm8953";
     ram = 1024 * 4;
     screen = {
       width = 1080; height = 1920;
+    };
+  };
+
+  mobile.system.android = {
+    bootimg.flash = {
+      offset_base = "0x80000000";
+      offset_kernel = "0x00008000";
+      offset_second = "0x00f00000";
+      offset_ramdisk = "0x01000000";
+      offset_tags = "0x00000100";
+      pagesize = "2048";
     };
   };
 

--- a/devices/xiaomi-tissot/default.nix
+++ b/devices/xiaomi-tissot/default.nix
@@ -9,7 +9,6 @@ in {
   };
 
   mobile.device.info = {
-    kernel_cmdline = "androidboot.hardware=qcom msm_rtb.filter=0x237 ehci-hcd.park=3 lpm_levels.sleep_disabled=1 androidboot.bootdevice=7824900.sdhci earlycon=msm_hsl_uart,0x78af000 androidboot.selinux=permissive buildvariant=eng";
     flash_offset_base = "0x80000000";
     flash_offset_kernel = "0x00008000";
     flash_offset_second = "0x00f00000";
@@ -26,6 +25,17 @@ in {
       width = 1080; height = 1920;
     };
   };
+
+  boot.kernelParams = [
+    "androidboot.hardware=qcom"
+    "msm_rtb.filter=0x237"
+    "ehci-hcd.park=3"
+    "lpm_levels.sleep_disabled=1"
+    "androidboot.bootdevice=7824900.sdhci"
+    "earlycon=msm_hsl_uart,0x78af000"
+    "androidboot.selinux=permissive"
+    "buildvariant=eng"
+  ];
 
   mobile.system.type = "android";
 }

--- a/devices/xiaomi-tissot/default.nix
+++ b/devices/xiaomi-tissot/default.nix
@@ -3,9 +3,12 @@ let
   inherit (config.mobile.device) name;
 in {
   mobile.device.name = "xiaomi-tissot";
-  mobile.device.info = {
+  mobile.device.identity = {
     name = "A1";
     manufacturer = "Xiaomi";
+  };
+
+  mobile.device.info = {
     kernel_cmdline = "androidboot.hardware=qcom msm_rtb.filter=0x237 ehci-hcd.park=3 lpm_levels.sleep_disabled=1 androidboot.bootdevice=7824900.sdhci earlycon=msm_hsl_uart,0x78af000 androidboot.selinux=permissive buildvariant=eng";
     flash_offset_base = "0x80000000";
     flash_offset_kernel = "0x00008000";

--- a/devices/xiaomi-tissot/default.nix
+++ b/devices/xiaomi-tissot/default.nix
@@ -7,17 +7,16 @@
     manufacturer = "Xiaomi";
   };
 
-  mobile.device.info = {
-    # TODO : make kernel part of options.
-    kernel = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
-  };
-
   mobile.hardware = {
     soc = "qualcomm-msm8953";
     ram = 1024 * 4;
     screen = {
       width = 1080; height = 1920;
     };
+  };
+
+  mobile.boot.stage-1 = {
+    kernel.package = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
   };
 
   mobile.system.android = {

--- a/devices/xiaomi-tissot/default.nix
+++ b/devices/xiaomi-tissot/default.nix
@@ -6,8 +6,6 @@ in {
   mobile.device.info = {
     name = "A1";
     manufacturer = "Xiaomi";
-    screen_width = 1080;
-    screen_height = 1920;
     kernel_cmdline = "androidboot.hardware=qcom msm_rtb.filter=0x237 ehci-hcd.park=3 lpm_levels.sleep_disabled=1 androidboot.bootdevice=7824900.sdhci earlycon=msm_hsl_uart,0x78af000 androidboot.selinux=permissive buildvariant=eng";
     flash_offset_base = "0x80000000";
     flash_offset_kernel = "0x00008000";

--- a/lib/release-tools.nix
+++ b/lib/release-tools.nix
@@ -20,7 +20,7 @@
     modules =
       (if device ? special
       then [ device.config ]
-      else [ (import (../. + "/devices/${device}" )) ])
+      else [ { imports = [(../. + "/devices/${device}")]; } ])
       ++ modules
       ++ [ additionalConfiguration ]
     ;

--- a/modules/devices-metadata.nix
+++ b/modules/devices-metadata.nix
@@ -2,10 +2,9 @@
 
 let
   inherit (config) mobile;
-  inherit (mobile.device) info;
+  inherit (mobile.device) identity;
 in
 {
-
   # The device-metadata output is used internally by the documentation
   # generation to generate the per-device pages.
   # Assume this format is fluid and will change.
@@ -13,18 +12,13 @@ in
     name = "${mobile.device.name}-metadata";
     destination = "/${mobile.device.name}.json";
     text = (builtins.toJSON {
-      inherit (info) name;
+      inherit (identity) name manufacturer;
       inherit (mobile) hardware;
       system = {
         inherit (mobile.system) type system;
       };
-
-      manufacturer = if info ? manufacturer then info.manufacturer else "N/A";
       identifier = mobile.device.name;
-
-      fullName = if info ? manufacturer
-        then "${info.manufacturer} ${info.name}"
-        else info.name;
+      fullName = "${identity.manufacturer} ${identity.name}";
     });
   };
 }

--- a/modules/initrd-kernel.nix
+++ b/modules/initrd-kernel.nix
@@ -10,11 +10,13 @@ let
   modulesClosure = pkgs.makeModulesClosure {
     inherit kernel;
     allowMissing = true;
-    rootModules = cfg.modules ++ cfg.additional_modules;
+    rootModules = cfg.modules ++ cfg.additionalModules;
     firmware = cfg.firmwares;
   };
 in
 {
+  # Note: These options are provided  *instead* of `boot.initrd.*`, as we are
+  # not re-using the `initrd` options.
   options.mobile.boot.stage-1.kernel = {
     modular = mkOption {
       type = types.bool;
@@ -34,7 +36,7 @@ in
         They will be modprobed.
       '';
     };
-    additional_modules = mkOption {
+    additionalModules = mkOption {
       type = types.listOf types.str;
       default = [
       ];

--- a/modules/initrd-usb.nix
+++ b/modules/initrd-usb.nix
@@ -3,7 +3,7 @@
 with lib;
 
 let
-  device_info = config.mobile.device.info;
+  inherit (config.mobile.usb) gadgetfs;
   cfg = config.mobile.boot.stage-1;
   device_name = device_config.name;
   device_config = config.mobile.device;
@@ -47,6 +47,12 @@ in
         The USB gadget implementation the device uses.
       '';
     };
+    gadgetfs.functions = mkOption {
+      type = types.attrs;
+      description = ''
+        Mapping of logical gadgetfs functions to their implementation names.
+      '';
+    };
   };
 
   config = lib.mkIf (config.mobile.usb.mode != null && cfg.usb.enable) {
@@ -73,8 +79,8 @@ in
       ];
       bootConfig = {
         boot.usb.features = cfg.usb.features;
-        boot.usb.functions = mkIf (device_info ? gadgetfs) (builtins.listToAttrs (
-          builtins.map (feature: { name = feature; value = device_info.gadgetfs.functions."${feature}"; }) cfg.usb.features
+        boot.usb.functions = mkIf (config.mobile.usb.mode == "gadgetfs") (builtins.listToAttrs (
+          builtins.map (feature: { name = feature; value = gadgetfs.functions."${feature}"; }) cfg.usb.features
         ));
         usb = {
           inherit (config.mobile.usb) idVendor idProduct mode;

--- a/modules/initrd.nix
+++ b/modules/initrd.nix
@@ -261,9 +261,6 @@ in
       mobile.boot.stage-1.bootConfig = {
         device = {
           inherit (device_config) name;
-          boot_as_recovery = if device_config.info ? boot_as_recovery
-            then device_config.info.boot_as_recovery
-            else false;
         };
         kernel = {
           inherit (config.mobile.boot.stage-1.kernel) modules;

--- a/modules/mobile-device.nix
+++ b/modules/mobile-device.nix
@@ -9,13 +9,6 @@ with lib;
       description = "The device's codename. Must match the device folder.";
     };
 
-    info.kernel = mkOption {
-      # FIXME: drop this option
-      # This is only kept *currently* for the commit to still build.
-      # This will be dealt with in the coming commits.
-      internal = true;
-    };
-
     identity = {
       name = mkOption {
         type = types.str;

--- a/modules/mobile-device.nix
+++ b/modules/mobile-device.nix
@@ -26,5 +26,21 @@ with lib;
         description = "The device's manufacturer name.";
       };
     };
+
+    firmware = mkOption {
+      type = types.package;
+      description = ''
+        Informal option that the end-user can use to get their device's firmware package
+
+        The device configuration may provide this option so the user can simply
+        use `hardware.firmware = [ config.mobile.device.firmware ];`.
+
+        Note that not all devices provide a firmware bundle, in this case the
+        user should not add the previous example to their configuration.
+
+        This is not added automatically to the system firmwares as most device
+        firmware bundles will be unredistributable.
+      '';
+    };
   };
 }

--- a/modules/mobile-device.nix
+++ b/modules/mobile-device.nix
@@ -3,17 +3,20 @@
 with lib;
 
 {
-  options.mobile = {
-    device.name = mkOption {
+  options.mobile.device = {
+    name = mkOption {
       type = types.str;
       description = "The device's codename. Must match the device folder.";
     };
-    device.info = mkOption {
-      #type = types.attrSet;
-      description = "system type specific informations";
-      # This probably should be `internal`.
+
+    info.kernel = mkOption {
+      # FIXME: drop this option
+      # This is only kept *currently* for the commit to still build.
+      # This will be dealt with in the coming commits.
+      internal = true;
     };
-    device.identity = {
+
+    identity = {
       name = mkOption {
         type = types.str;
         description = "The device's name as advertised by the manufacturer.";

--- a/modules/mobile-device.nix
+++ b/modules/mobile-device.nix
@@ -6,11 +6,22 @@ with lib;
   options.mobile = {
     device.name = mkOption {
       type = types.str;
+      description = "The device's codename. Must match the device folder.";
     };
     device.info = mkOption {
       #type = types.attrSet;
       description = "system type specific informations";
       # This probably should be `internal`.
+    };
+    device.identity = {
+      name = mkOption {
+        type = types.str;
+        description = "The device's name as advertised by the manufacturer.";
+      };
+      manufacturer = mkOption {
+        type = types.str;
+        description = "The device's manufacturer name.";
+      };
     };
   };
 }

--- a/modules/system-types/android/bootimg.nix
+++ b/modules/system-types/android/bootimg.nix
@@ -1,51 +1,39 @@
-{ device_config
-, initrd
+{ lib
 , pkgs
-, name ? "boot.img"
+, name
+
+# mkbootimg specific values
+, kernel
+, initrd
 , cmdline
+, bootimg
 }:
+
 let
+  inherit (lib) optionalString;
   inherit (pkgs) buildPackages;
-  inherit (device_info) kernel dtb;
-  device_name = device_config.name;
-  device_info = device_config.info;
-
-  with_qcdt = device_info ? bootimg_qcdt && device_info.bootimg_qcdt;
-  kernel_file = if device_info ? kernel_file then device_info.kernel_file else "${kernel}/${kernel.file}";
 in
-pkgs.stdenv.mkDerivation {
-  name = "mobile-nixos_${device_name}_${name}";
-
-  src = builtins.filterSource (path: type: false) ./.;
-  unpackPhase = "true";
-
-  nativeBuildInputs = [
-    buildPackages.mkbootimg
-    buildPackages.dtbTool
+pkgs.runCommandNoCC name {
+  nativeBuildInputs = with buildPackages; [
+    mkbootimg
+    dtbTool
   ];
-
-  installPhase = ''
-	echo Using kernel: ${kernel_file}
-(
-PS4=" $ "
-set -x
-    mkbootimg \
-      --kernel  ${kernel_file} \
-      ${
-        if with_qcdt then
-          "--dt ${dtb}"
-        else
-          ""
-      } \
-      --ramdisk ${initrd} \
-      --cmdline       "${cmdline}" \
-      --base           ${device_info.flash_offset_base   } \
-      --kernel_offset  ${device_info.flash_offset_kernel } \
-      --second_offset  ${device_info.flash_offset_second } \
-      --ramdisk_offset ${device_info.flash_offset_ramdisk} \
-      --tags_offset    ${device_info.flash_offset_tags   } \
-      --pagesize       ${device_info.flash_pagesize      } \
-      -o $out
-)
-  '';
-}
+} ''
+  echo Using kernel: ${kernel}
+  (
+  PS4=" $ "
+  set -x
+  mkbootimg \
+    --kernel  ${kernel} \
+    ${optionalString (bootimg.dt != null) "--dt ${bootimg.dt}"} \
+    --ramdisk ${initrd} \
+    --cmdline       "${cmdline}" \
+    --base           ${bootimg.flash.offset_base   } \
+    --kernel_offset  ${bootimg.flash.offset_kernel } \
+    --second_offset  ${bootimg.flash.offset_second } \
+    --ramdisk_offset ${bootimg.flash.offset_ramdisk} \
+    --tags_offset    ${bootimg.flash.offset_tags   } \
+    --pagesize       ${bootimg.flash.pagesize      } \
+    -o $out
+  )
+''

--- a/modules/system-types/android/bootimg.nix
+++ b/modules/system-types/android/bootimg.nix
@@ -2,6 +2,7 @@
 , initrd
 , pkgs
 , name ? "boot.img"
+, cmdline
 }:
 let
   inherit (pkgs) buildPackages;
@@ -11,9 +12,6 @@ let
 
   with_qcdt = device_info ? bootimg_qcdt && device_info.bootimg_qcdt;
   kernel_file = if device_info ? kernel_file then device_info.kernel_file else "${kernel}/${kernel.file}";
-
-  # TODO : Allow appending / prepending
-  cmdline = device_info.kernel_cmdline;
 in
 pkgs.stdenv.mkDerivation {
   name = "mobile-nixos_${device_name}_${name}";

--- a/modules/system-types/android/default.nix
+++ b/modules/system-types/android/default.nix
@@ -11,6 +11,7 @@ let
   recovery = (import ../../../lib/eval-config.nix {
     inherit baseModules;
     modules = modules ++ [{
+      mobile.system.android.bootimg.name = "recovery.img";
       mobile.boot.stage-1.bootConfig = {
         is_recovery = true;
       };
@@ -39,16 +40,13 @@ let
 
   inherit (config.system.build) rootfs;
 
-  android-recovery = pkgs.callPackage ./bootimg.nix {
-    inherit device_config;
-    initrd = recovery.system.build.initrd;
-    name = "recovery.img";
-  };
-
   android-bootimg = pkgs.callPackage ./bootimg.nix {
     inherit device_config;
+    inherit (config.mobile.system.android.bootimg) name;
     initrd = config.system.build.initrd;
   };
+
+  android-recovery = recovery.system.build.android-bootimg;
 
   # Note:
   # The flash scripts, by design, are not using nix-provided paths for
@@ -77,6 +75,19 @@ let
   '';
 in
 {
+  options = {
+    mobile.system.android = {
+      bootimg = {
+        name = lib.mkOption {
+          type = lib.types.str;
+          description = "Suffix for the image name. Use it to distinguish speciality boot images.";
+          default = "boot.img";
+          internal = true;
+        };
+      };
+    };
+  };
+
   config = lib.mkMerge [
     { mobile.system.types = [ "android" ]; }
 

--- a/modules/system-types/android/default.nix
+++ b/modules/system-types/android/default.nix
@@ -1,7 +1,9 @@
 { config, pkgs, lib, modules, baseModules, ... }:
 
 let
-  inherit (lib) optionalString;
+  inherit (lib) concatStringsSep optionalString;
+
+  cmdline = concatStringsSep " " config.boot.kernelParams;
 
   # In the future, this pattern should be extracted.
   # We're basically subclassing the main config, just like nesting does in
@@ -41,7 +43,7 @@ let
   inherit (config.system.build) rootfs;
 
   android-bootimg = pkgs.callPackage ./bootimg.nix {
-    inherit device_config;
+    inherit cmdline device_config;
     inherit (config.mobile.system.android.bootimg) name;
     initrd = config.system.build.initrd;
   };

--- a/modules/system-types/android/default.nix
+++ b/modules/system-types/android/default.nix
@@ -128,5 +128,13 @@ in
         mobile-installer = throw "No installer yet...";
       };
     })
+
+    {
+      mobile.boot.stage-1.bootConfig = {
+        device = {
+          inherit (config.mobile.system.android) boot_as_recovery;
+        };
+      };
+    }
   ];
 }

--- a/modules/system-types/android/default.nix
+++ b/modules/system-types/android/default.nix
@@ -2,9 +2,11 @@
 
 let
   inherit (lib) concatStringsSep optionalString types;
+  inherit (config.mobile) device;
   inherit (config.mobile.system.android) ab_partitions boot_as_recovery has_recovery_partition;
+  inherit (config.mobile.boot) stage-1;
+  kernelPackage = stage-1.kernel.package;
 
-  device_config = config.mobile.device;
   enabled = config.mobile.system.type == "android";
 
   # In the future, this pattern should be extracted.
@@ -28,8 +30,8 @@ let
     inherit (config.mobile.system.android) bootimg;
     inherit cmdline;
     initrd = config.system.build.initrd;
-    name = "mobile-nixos_${device_config.name}_${bootimg.name}";
-    kernel = "${device_config.info.kernel}/${device_config.info.kernel.file}";
+    name = "mobile-nixos_${device.name}_${bootimg.name}";
+    kernel = "${kernelPackage}/${kernelPackage.file}";
   };
 
   android-recovery = recovery.system.build.android-bootimg;
@@ -42,7 +44,7 @@ let
   # This is because this output should have no refs. A simple tarball of this
   # output should be usable even on systems without Nix.
   # TODO: Embed device-specific fastboot instructions as `echo` in the script.
-  android-device = pkgs.runCommandNoCC "android-device-${device_config.name}" {} ''
+  android-device = pkgs.runCommandNoCC "android-device-${device.name}" {} ''
     mkdir -p $out
     cp -v ${rootfs}/${rootfs.filename} $out/system.img
     cp -v ${android-bootimg} $out/boot.img

--- a/modules/system-types/depthcharge/default.nix
+++ b/modules/system-types/depthcharge/default.nix
@@ -2,15 +2,16 @@
 
 let
   inherit (lib) types;
+  inherit (config.mobile.boot) stage-1;
   enabled = config.mobile.system.type == "depthcharge";
 
   build = pkgs.callPackage ./depthcharge-build.nix {
-    inherit (config.mobile.device.info) kernel;
     inherit (config.mobile.system.depthcharge.kpart) dtbs;
     device_name = config.mobile.device.name;
     initrd = config.system.build.initrd;
     system = config.system.build.rootfs;
     cmdline = lib.concatStringsSep " " config.boot.kernelParams;
+    kernel = stage-1.kernel.package;
     arch = lib.strings.removeSuffix "-linux" config.mobile.system.system;
   };
 in

--- a/modules/system-types/depthcharge/default.nix
+++ b/modules/system-types/depthcharge/default.nix
@@ -1,11 +1,13 @@
 { config, pkgs, lib, ... }:
 
 let
-  device_config = config.mobile.device;
+  inherit (lib) types;
   enabled = config.mobile.system.type == "depthcharge";
 
   build = pkgs.callPackage ./depthcharge-build.nix {
-    inherit device_config;
+    inherit (config.mobile.device.info) kernel;
+    inherit (config.mobile.system.depthcharge.kpart) dtbs;
+    device_name = config.mobile.device.name;
     initrd = config.system.build.initrd;
     system = config.system.build.rootfs;
     cmdline = lib.concatStringsSep " " config.boot.kernelParams;
@@ -13,6 +15,19 @@ let
   };
 in
 {
+  options = {
+    mobile.system.depthcharge = {
+      kpart = {
+        dtbs = lib.mkOption {
+          type = types.path;
+          default = null;
+          description = "Path to a directory with device trees, to be put in the kpart image";
+          internal = true;
+        };
+      };
+    };
+  };
+
   config = lib.mkMerge [
     { mobile.system.types = [ "depthcharge" ]; }
 

--- a/modules/system-types/depthcharge/default.nix
+++ b/modules/system-types/depthcharge/default.nix
@@ -8,6 +8,8 @@ let
     inherit device_config;
     initrd = config.system.build.initrd;
     system = config.system.build.rootfs;
+    cmdline = lib.concatStringsSep " " config.boot.kernelParams;
+    arch = lib.strings.removeSuffix "-linux" config.mobile.system.system;
   };
 in
 {

--- a/modules/system-types/depthcharge/depthcharge-build.nix
+++ b/modules/system-types/depthcharge/depthcharge-build.nix
@@ -1,12 +1,14 @@
-{ device_config
+{ lib
 , fetchurl
 , runCommandNoCC
 , initrd
 , system
 , imageBuilder
-, lib
 , cmdline
 , arch
+, dtbs
+, kernel
+, device_name
 
 , dtc
 , ubootTools
@@ -32,11 +34,6 @@ let
     LINUX_DATA         = "EBD0A0A2-B9E5-4433-87C0-68B6B72699C7";
     LINUX_FS           = "0FC63DAF-8483-4772-8E79-3D69D8477DE4";
   };
-
-  inherit (device_info) kernel dtbs;
-
-  device_info = device_config.info;
-  device_name = device_config.name;
 
   # Kernel used in kpart.
   kernel_file = "${kernel}/${kernel.file}";

--- a/modules/system-types/depthcharge/depthcharge-build.nix
+++ b/modules/system-types/depthcharge/depthcharge-build.nix
@@ -5,6 +5,8 @@
 , system
 , imageBuilder
 , lib
+, cmdline
+, arch
 
 , dtc
 , ubootTools
@@ -31,7 +33,7 @@ let
     LINUX_FS           = "0FC63DAF-8483-4772-8E79-3D69D8477DE4";
   };
 
-  inherit (device_info) arch kernel kernel_cmdline dtbs;
+  inherit (device_info) kernel dtbs;
 
   device_info = device_config.info;
   device_name = device_config.name;
@@ -42,7 +44,7 @@ let
   # Kernel command line for vbutil_kernel.
   kpart_config = writeTextFile {
     name = "kpart-config-${device_name}";
-    text = kernel_cmdline;
+    text = cmdline;
   };
 
   # Name used for some image file output.

--- a/modules/system-types/qemu-startscript/default.nix
+++ b/modules/system-types/qemu-startscript/default.nix
@@ -10,6 +10,7 @@ let
   qemu-startscript = pkgs.callPackage ./qemu-startscript-build.nix {
     inherit device_config hardware_config;
     initrd = config.system.build.initrd;
+    cmdline = lib.concatStringsSep " " config.boot.kernelParams;
   };
 
   system = pkgs.linkFarm "${device_config.name}-build" [

--- a/modules/system-types/qemu-startscript/qemu-startscript-build.nix
+++ b/modules/system-types/qemu-startscript/qemu-startscript-build.nix
@@ -1,33 +1,14 @@
-{
-  device_config
-  , hardware_config
-  , initrd
-  , pkgs
-  , cmdline
+{ runCommandNoCC
+, name
+, initrd
+, ram
+, cmdline
+, kernel
 }:
-with pkgs;
-let
-  inherit (hardware_config) ram;
-  device_name = device_config.name;
-  device_info = device_config.info;
-  linux = device_info.kernel;
-  kernel = "${linux}/*Image*";
-in
-stdenv.mkDerivation {
-  name = "mobile-nixos_${device_name}-qemu-startscript";
-
-  src = builtins.filterSource (path: type: false) ./.;
-  unpackPhase = "true";
-
-  buildInputs = [
-    linux
-  ];
-
-  installPhase = ''
-      mkdir -p $out/
-      cp ${kernel} $out/kernel
-      cp ${initrd} $out/initrd
-      echo -n "${cmdline}" > $out/cmdline.txt
-      echo -n "${toString ram}" > $out/ram.txt
-  '';
-}
+runCommandNoCC "mobile-nixos_${name}-qemu-startscript" {} ''
+  mkdir -p $out/
+  cp ${kernel}/*Image* $out/kernel
+  cp ${initrd} $out/initrd
+  echo -n "${cmdline}" > $out/cmdline.txt
+  echo -n "${toString ram}" > $out/ram.txt
+''

--- a/modules/system-types/qemu-startscript/qemu-startscript-build.nix
+++ b/modules/system-types/qemu-startscript/qemu-startscript-build.nix
@@ -3,6 +3,7 @@
   , hardware_config
   , initrd
   , pkgs
+  , cmdline
 }:
 with pkgs;
 let
@@ -11,9 +12,6 @@ let
   device_info = device_config.info;
   linux = device_info.kernel;
   kernel = "${linux}/*Image*";
-
-  # TODO : Allow appending / prepending
-  cmdline = device_info.kernel_cmdline;
 in
 stdenv.mkDerivation {
   name = "mobile-nixos_${device_name}-qemu-startscript";

--- a/modules/system-types/u-boot/default.nix
+++ b/modules/system-types/u-boot/default.nix
@@ -40,7 +40,7 @@ let
     echo Built for ${deviceName}
     echo
 
-    setenv bootargs ${config.boot.kernelParams}
+    setenv bootargs ${lib.concatStringsSep " " config.boot.kernelParams}
 
     ${cfg.additionalCommands}
 

--- a/modules/system-types/u-boot/default.nix
+++ b/modules/system-types/u-boot/default.nix
@@ -6,7 +6,7 @@ let
   cfg = config.mobile.quirks.u-boot;
   inherit (cfg) soc;
   inherit (config) system;
-  inherit (device_info) kernel dtb kernel_cmdline;
+  inherit (device_info) kernel dtb;
   deviceName = config.mobile.device.name;
   device_info = config.mobile.device.info;
   kernel_file = if device_info ? kernel_file then device_info.kernel_file else "${kernel}/${kernel.file}";
@@ -40,7 +40,7 @@ let
     echo Built for ${deviceName}
     echo
 
-    setenv bootargs ${kernel_cmdline}
+    setenv bootargs ${config.boot.kernelParams}
 
     ${cfg.additionalCommands}
 

--- a/modules/system-types/u-boot/default.nix
+++ b/modules/system-types/u-boot/default.nix
@@ -6,10 +6,10 @@ let
   cfg = config.mobile.quirks.u-boot;
   inherit (cfg) soc;
   inherit (config) system;
-  inherit (device_info) kernel dtb;
   deviceName = config.mobile.device.name;
   device_info = config.mobile.device.info;
-  kernel_file = if device_info ? kernel_file then device_info.kernel_file else "${kernel}/${kernel.file}";
+  kernel = config.mobile.boot.stage-1.kernel.package;
+  kernel_file = "${kernel}/${kernel.file}";
 
   # Look-up table to translate from targetPlatform to U-Boot names.
   ubootPlatforms = {


### PR DESCRIPTION
Rather, remove unused options, and then add proper options or use existing NixOS options.

* * *

This gives us working `boot.kernelParams` support for stage-1 builds. Configuration can now add and remove to the kernel parameters.

This also reduces the risks of doing something wrong with the untyped mess of options that was present previously.