### PR TITLE
Add "fb notify" quirk, fixing motorola-addison touch with boot GUI

### DIFF
--- a/devices/motorola-addison/default.nix
+++ b/devices/motorola-addison/default.nix
@@ -50,4 +50,6 @@
   mobile.usb.idProduct = "D001";
 
   mobile.system.type = "android";
+
+  mobile.quirks.qualcomm.fb-notify.enable = true;
 }

--- a/modules/quirks/qualcomm/default.nix
+++ b/modules/quirks/qualcomm/default.nix
@@ -2,6 +2,7 @@
   imports = [
     ./framebuffer.nix
     ./msm-dwc3.nix
+    ./msm-fb-notify.nix
     ./wcnss-wlan.nix
   ];
 }

--- a/modules/quirks/qualcomm/msm-fb-notify-task.rb
+++ b/modules/quirks/qualcomm/msm-fb-notify-task.rb
@@ -1,0 +1,10 @@
+class Tasks::MsmFbNotify < SingletonTask
+  def initialize()
+    Targets[:SwitchRoot].add_dependency(:Task, self)
+    add_dependency(:Mount, "/sys")
+  end
+
+  def run()
+    System.write("/sys/class/graphics/fb0/blank", "0")
+  end
+end

--- a/modules/quirks/qualcomm/msm-fb-notify.nix
+++ b/modules/quirks/qualcomm/msm-fb-notify.nix
@@ -1,0 +1,24 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.mobile.quirks.qualcomm;
+  inherit (lib) mkIf mkOption types;
+in
+{
+  options.mobile = {
+    quirks.qualcomm.fb-notify.enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Enable this on a device which requires the framebuffer
+        to be notified for some components to work right.
+
+        The most likely thing this fixes is touch input.
+      '';
+    };
+  };
+
+  config = mkIf (cfg.fb-notify.enable) {
+    mobile.boot.stage-1.tasks = [ ./msm-fb-notify-task.rb ];
+  };
+}


### PR DESCRIPTION
Quite simply, `motorola-addison`'s touch input will not work if the display has not been properly "awakened".

Touching `.../blank` ends up causing `fb_notifier_call_chain` to be called, which ends up causing `rmi4_data->panel_nb.notifier_call` to be called, causing `synaptics_dsx_panel_cb` to be called. This, finally, puts the touch panel active. (`grep` the vendor kernel tree for those names.)

* * *

X11 touch input was working fine. It must be doing things *just right* to wake up the framebuffer. LVGL does not, which means the boot GUI did not work.