### PR TITLE
Add firmware support to stage-1

### DIFF
--- a/devices/asus-dumo/default.nix
+++ b/devices/asus-dumo/default.nix
@@ -33,6 +33,11 @@
 
   mobile.system.type = "depthcharge";
 
+  mobile.device.firmware = pkgs.callPackage ./firmware {};
+  mobile.boot.stage-1.firmware = [
+    config.mobile.device.firmware
+  ];
+
   mobile.boot.stage-1.tasks = [
     # This hack unbinds and rebinds the currently problematic storage driver.
     # TODO: move into a generic "gru family" thing.

--- a/devices/asus-dumo/firmware/default.nix
+++ b/devices/asus-dumo/firmware/default.nix
@@ -1,0 +1,19 @@
+{ lib
+, runCommandNoCC
+, firmwareLinuxNonfree
+}:
+
+# The minimum set of firmware files required for the device.
+runCommandNoCC "asus-dumo-firmware" {
+  src = firmwareLinuxNonfree;
+} ''
+  for firmware in \
+    ath10k/QCA6174/hw3.0 \
+    qca/nvm_usb_00000302.bin \
+    qca/rampatch_usb_00000302.bin \
+    rockchip/dptx.bin \
+  ; do
+    mkdir -p "$(dirname $out/lib/firmware/$firmware)"
+    cp -vrf "$src/lib/firmware/$firmware" $out/lib/firmware/$firmware
+  done
+''

--- a/modules/initrd-firmware.nix
+++ b/modules/initrd-firmware.nix
@@ -1,0 +1,32 @@
+{ pkgs, lib, config, ... }:
+
+let
+  inherit (lib) types;
+  inherit (config.mobile.boot.stage-1) firmware;
+in
+{
+  options = {
+    mobile.boot.stage-1.firmware = lib.mkOption {
+      type = types.listOf types.package;
+      default = [];
+      description = ''
+        List of packages containing firmware files to be included in the
+        stage-1 for the device.
+      '';
+      apply = list: pkgs.buildEnv {
+        name = "firmware";
+        paths = list;
+        pathsToLink = [ "/lib/firmware" ];
+        ignoreCollisions = true;
+      };
+    };
+  };
+  config = {
+    mobile.boot.stage-1.contents = [
+      {
+        object = "${firmware}/lib/firmware";
+        symlink = "/lib/firmware";
+      }
+    ];
+  };
+}

--- a/modules/initrd.nix
+++ b/modules/initrd.nix
@@ -187,6 +187,7 @@ let
     nativeBuildInputs = with pkgs.buildPackages; [
       ncdu
       cpio
+      tree
     ];
   } ''
     mkdir initrd
@@ -194,6 +195,7 @@ let
 
     mkdir -p $out
     ncdu -0x -o $out/initrd.ncdu ./initrd
+    tree -a ./initrd > $out/tree
   '';
 in
   {

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -18,6 +18,7 @@
   ./initrd-boot-gui.nix
   ./initrd-fbterm.nix
   ./initrd-fail.nix
+  ./initrd-firmware.nix
   ./initrd-kernel.nix
   ./initrd-logs.nix
   ./initrd-network.nix


### PR DESCRIPTION
This adds proper support for adding firmware into stage-1.

This PR also adds an example usage of this with `asus-dumo`.

When providing firmware for use during stage-1, pare down the set as much as sensible for your device!