### PR TITLE
Allow passing device definitions by path

### DIFF
--- a/bin/menuconfig
+++ b/bin/menuconfig
@@ -18,7 +18,14 @@ if other_args.empty?
 end
 
 DEVICE = other_args.shift
-FILE = Dir.glob(File.join(ROOT, "devices", DEVICE, "kernel", "config.*")).sort.first
+
+FILE =
+  # Is the device a path?
+  if DEVICE.match(%r{/})
+    Dir.glob(File.join(DEVICE, "kernel", "config.*")).sort.first
+  else
+    Dir.glob(File.join(Dir.pwd, "devices", DEVICE, "kernel", "config.*")).sort.first
+  end
 
 ONLY_SAVE = !!params.delete("--only-save")
 
@@ -27,22 +34,32 @@ unless params.empty?
   usage
   exit 1
 end
+
 unless other_args.empty?
   $stderr.puts "Unexpected arguments #{other_args.join(", ")}."
   usage
   exit 1
 end
-unless File.exists?(FILE)
+
+unless FILE
   $stderr.puts "Could not find kernel configuration file for #{DEVICE}."
   usage
   exit 1
 end
 
+arg =
+  # Is the device a path?
+  if DEVICE.match(%r{/})
+    ["--arg", "device", DEVICE]
+  else
+    ["--argstr", "device", DEVICE]
+  end
+
 Dir.chdir(ROOT) do
   tool = File.join(`#{[
     "nix-build",
     "--no-out-link",
-    "--argstr", "device", DEVICE,
+    *arg,
     "-A", "config.mobile.boot.stage-1.kernel.package.menuconfig"
   ].shelljoin}`.strip, "bin/nconf")
 

--- a/default.nix
+++ b/default.nix
@@ -64,6 +64,8 @@ in
     if device == null then (id: id) else
     if device ? special
     then header "Evaluating: ${device.name}"
+    else if (builtins.tryEval (builtins.isPath device && builtins.pathExists device)).value
+    then header "Evaluating device from path: ${toString device}"
     else header "Evaluating device: ${device}"
   )
 {

--- a/lib/release-tools.nix
+++ b/lib/release-tools.nix
@@ -20,6 +20,7 @@
     modules =
       (if device ? special
       then [ device.config ]
+      else if builtins.isPath device then [ { imports = [ device ]; } ]
       else [ { imports = [(../. + "/devices/${device}")]; } ])
       ++ modules
       ++ [ additionalConfiguration ]

--- a/modules/system-types/u-boot/default.nix
+++ b/modules/system-types/u-boot/default.nix
@@ -172,6 +172,7 @@ in
       };
       additionalCommands = mkOption {
         type = types.str;
+        default = "";
         description = ''
           Additional U-Boot commands to run.
         '';


### PR DESCRIPTION
Thus, facilitating external devices development.

See my [mobile-nixos-extra-devices](https://github.com/samueldr/mobile-nixos-extra-devices) for an example usage.

**NOTE:** This is *not* intended to create a rift where users need to make their devices external to this repository. Oh no, this is only intended to allow working with what shouldn't be in this repo. If you look at my example repo, this is used for a pinebook pro, which is definitely not a mobile device for this repo :).

* * *

This also fixes a small oversight in the u-boot system, where an option that should have been made optional was mandatory.

* * *

## TODO

 * [x] Fix `bin/menuconfig` into better supporting devices by path.