### PR TITLE
pine64-pinephone-braveheart: Add firmware package

### DIFF
--- a/devices/pine64-pinephone-braveheart/default.nix
+++ b/devices/pine64-pinephone-braveheart/default.nix
@@ -29,6 +29,9 @@
   ];
 
   mobile.system.type = "u-boot";
+
+  mobile.device.firmware = pkgs.callPackage ./firmware {};
+
   mobile.quirks.u-boot.package = pkgs.callPackage ./u-boot {};
   mobile.quirks.u-boot.additionalCommands = ''
     # Yellow LED.

--- a/devices/pine64-pinephone-braveheart/firmware/default.nix
+++ b/devices/pine64-pinephone-braveheart/firmware/default.nix
@@ -1,0 +1,18 @@
+{ lib
+, runCommandNoCC
+, fetchFromGitHub
+}:
+
+# The minimum set of firmware files required for the device.
+runCommandNoCC "pine64-pinephone-braveheart-firmware" {
+  src = fetchFromGitHub {
+    owner = "anarsoul";
+    repo = "rtl8723bt-firmware";
+    rev = "28ad3584927c0fe1f321176f73a7fd42cccec56f";
+    sha256 = "0ccdifninnqpvrqg4f4b5vgy3d5g7n6xx6qny7by9aramsd94l17";
+  };
+  meta.license = lib.licenses.unfreeRedistributable;
+} ''
+  mkdir -p "$out/lib/firmware"
+  cp -vrf "$src/rtl_bt" $out/lib/firmware/
+''


### PR DESCRIPTION
The firmware is limited to bluetooth only, nothing else (for now)
requires a discrete firmware file.

It looks like the touchscreen can get one, but it is not required, and
seemingly no one provides one.

* * *

cc @masipcat

This was tested on top of `master`.

Note that since it's unfree, even though it's redistributable, it's not part of the default configuration. (I'll need to consult to know what to do about unfree redistributable).

For now, you'll need to build the initrd using the following config:

```
{ config, ... }:
{
  mobile.boot.stage-1.firmware = [
    config.mobile.device.firmware
  ];
}
```

It can also, and probably also should, be added to `hardware.firmware` (the same way).

* * *

What was done:

Using `examples/demo`, verified it could pair with a bluetooth headset.

It wasn't verified as playing media, as the pulseaudio setup is not setup in a way where it should be expected to work. So there was no sink to use. Though the device did pair successfully.