### PR TITLE
README: Add note about unstable branch

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -15,6 +15,16 @@ ifndef::env-github[]
 Read more: <<about.adoc#,About Mobile NixOS>>.
 endif::[]
 
+ifdef::env-github[]
+⚠️ **Note**: Mobile NixOS is only expected to build succesfully against the **unstable** branch of Nixpkgs.
+endif::[]
+ifndef::env-github[]
+[NOTE]
+====
+Mobile NixOS is only expected to build succesfully against the **unstable** branch of Nixpkgs.
+====
+endif::[]
+
 == Documentation
 
  * link:https://mobile.nixos.org/[The Mobile NixOS website] hosts the rendered link:https://github.com/NixOS/mobile-nixos/tree/master/doc[doc folder] for Mobile NixOS documentation.


### PR DESCRIPTION
The conditional it so work around an issue where one-line admonitions in GitHub are ugly.

![image](https://user-images.githubusercontent.com/132835/84944739-3b142800-b0b4-11ea-98ab-8cec33744cf5.png)

This README is *mainly* for consumption on GitHub.

Should help prevent against #166 or similar.

#168 would be an actual *solution* rather than documentation.