### PR TITLE
boot/gui: Fix cross-compilation breakage

### DIFF
--- a/boot/gui/default.nix
+++ b/boot/gui/default.nix
@@ -1,24 +1,20 @@
-{ stdenv
+{ runCommand
 , lib
 , mruby
 }:
 
-stdenv.mkDerivation {
-  name = "boot-gui.mrb";
-
+# mkDerivation will append something like -aarch64-unknown-linux-gnu to the
+# derivation name with cross, which will break the mruby code loading.
+# Since we don't need anything from mkDerivation, really, let's use runCommand.
+runCommand "boot-gui.mrb" {
   src = lib.cleanSource ./.;
 
   nativeBuildInputs = [
     mruby
   ];
-
-  buildPhase = ''
-    mrbc -g -o gui.mrb \
-      $(find lib -type f -name '*.rb' | sort) \
-      main.rb
-  '';
-
-  installPhase = ''
-    mv -v gui.mrb $out
-  '';
-}
+} ''
+  mrbc \
+    -o $out \
+    $(find $src/lib -type f -name '*.rb' | sort) \
+    $src/main.rb
+''


### PR DESCRIPTION
Turns out that `mruby`'s require looks at the actual file name (not the
link) when deciding between loading bytecode or ruby code.

Cross-compilation appends the system to derivation names.

Fun ensues.

This fixes the issue by using `runCommand`, for which it doesn't happen.

* * *

Why didn't I catch this? I tested with QEMU! Native compilation!