### PR TITLE
Fix Mobile NixOS regressions after the pkg-config changes in Nixpkgs

### DIFF
--- a/overlay/mruby-builder/mrbgems/mruby-lvgui/lvgui.nix
+++ b/overlay/mruby-builder/mrbgems/mruby-lvgui/lvgui.nix
@@ -24,14 +24,14 @@ let
 in
   stdenv.mkDerivation {
     pname = "mobile-nixos-early-boot-gui";
-    version = "2020-02-05";
+    version = "2020-07-02";
 
     src = fetchFromGitHub {
       fetchSubmodules = true;
       repo = "lvgui";
       owner = "mobile-nixos";
-      rev = "d98d5e59ba0f4a76b2f092ee957a198d9e749dfb";
-      sha256 = "1hn01mi44wmx12987va4h69ldnvjbvniwm9slnd5naib6j2n5rbw";
+      rev = "d531b45b19612e520eec26660029c49f223d8d3a";
+      sha256 = "0cyra0ji2sb48c9h2vafzzsfz3y26b6k37mfc6gnv0lfx0js52hs";
     };
 
     # Document `LVGL_ENV_SIMULATOR` in the built headers.

--- a/overlay/mruby-builder/mruby/default.nix
+++ b/overlay/mruby-builder/mruby/default.nix
@@ -18,6 +18,7 @@ in
 , file
 , mruby
 , writeText
+, writeShellScriptBin
 
 # When unset the default gembox will be used.
 # For a native build, use the default gembox
@@ -145,6 +146,16 @@ let
     end
     ''}
   '';
+
+  # Inspired from #91991
+  # https://github.com/NixOS/nixpkgs/pull/91991
+  # The mruby build would need to be patched in the future.
+  # As 2.2 will require other invasive changes, this is worked around until 2.2 is released.
+  # The default (without other inputs) mruby build does not use `pkg-config`,
+  # but its `#search_package` implementation does.
+  pkgconfig-helper = writeShellScriptBin "pkg-config" ''
+    exec ${buildPackages.pkgconfig}/bin/${buildPackages.pkgconfig.targetPrefix}pkg-config "$@"
+  '';
 in
 stdenv.mkDerivation rec {
   pname = "mruby";
@@ -163,7 +174,7 @@ stdenv.mkDerivation rec {
     ./bison-36-compat.patch
   ];
 
-  nativeBuildInputs = [ ruby bison rake ] ++ gemNativeBuildInputs;
+  nativeBuildInputs = [ pkgconfig-helper ruby bison rake ] ++ gemNativeBuildInputs;
   buildInputs = gemBuildInputs;
 
   # Necessary so it uses `gcc` instead of `ld` for linking.


### PR DESCRIPTION
The way Nixpkgs handles `pkg-config` during cross is by now using a prefixed binary name.

Many tools are not ready for such a thing, here I am fixing the Mobile NixOS specific issues.

Tested against Nixpkgs b3251e04ee470c20f81e75d5a6080ba92dc7ed3f, which currently fail.

Note that this breaks compatibility with Nixpkgs before that pkg-config change.

Fixes #176

@ingenieroariel, can you confirm that, at least on b3251e04ee470c20f81e75d5a6080ba92dc7ed3f, things work, and also that the changes look okay? Thanks!