### PR TITLE
initrd: Provide firmwares through the specific option

### DIFF
--- a/modules/initrd-kernel.nix
+++ b/modules/initrd-kernel.nix
@@ -70,9 +70,9 @@ in
   };
 
   config.mobile.boot.stage-1 = (mkIf cfg.modular {
+    firmware = [ modulesClosure ];
     contents = [
       { object = "${modulesClosure}/lib/modules"; symlink = "/lib/modules"; }
-      { object = "${modulesClosure}/lib/firmware"; symlink = "/lib/firmware"; }
     ];
     kernel.modules = [
       # Basic always-needed kernel modules.


### PR DESCRIPTION
The upstream NixOS make-initrd doesn't handle multiple content linking
to the same location.

This fixes a regression introduced in #158 affecting the QEMU VM build, by using the feature added in that PR.