### PR TITLE
device: pinephone: Rebase to kernel 5.6.y to fix issue related to pkg…

### DIFF
--- a/devices/pine64-pinephone-braveheart/kernel/0001-dts-pinephone-Setup-default-on-and-panic-LEDs.patch
+++ b/devices/pine64-pinephone-braveheart/kernel/0001-dts-pinephone-Setup-default-on-and-panic-LEDs.patch
@@ -1,6 +1,6 @@
-From 32d81a88ad076538d4d1e4ac88dda01fc2165b30 Mon Sep 17 00:00:00 2001
-From: Samuel Dionne-Riel <samuel@dionne-riel.com>
-Date: Sat, 28 Mar 2020 01:33:16 -0400
+From a9c97de0e0465427653c302a03b6f1ba7bc78bdb Mon Sep 17 00:00:00 2001
+From: S Dao <si.dao@outlook.com>
+Date: Tue, 14 Jul 2020 17:34:13 +0700
 Subject: [PATCH] dts: pinephone: Setup default on and panic LEDs
 
  * The green LED defaults to on.
@@ -8,23 +8,26 @@ Subject: [PATCH] dts: pinephone: Setup default on and panic LEDs
 
 The green LED defaults to on for an expected transition through red,
 yellow and green during the different boot stages.
+
+Signed-off-by: S Dao <si.dao@outlook.com>
 ---
- arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dts | 2 ++
+ arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi | 2 ++
  1 file changed, 2 insertions(+)
 
-diff --git a/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dts b/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dts
-index 4981ffd8c945..54629960d48e 100644
---- a/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dts
-+++ b/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dts
-@@ -66,12 +66,14 @@
- 			label = "pinephone:green:user";
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi
+index 8376d6e8a9cc..e2b601dcc950 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi
+@@ -63,6 +63,7 @@ green {
+ 			color = <LED_COLOR_ID_GREEN>;
  			gpios = <&pio 3 18 GPIO_ACTIVE_HIGH>; /* PD18 */
  			retain-state-suspended;
 +			linux,default-trigger = "default-on";
  		};
  
  		red {
- 			label = "pinephone:red:user";
+@@ -70,6 +71,7 @@ red {
+ 			color = <LED_COLOR_ID_RED>;
  			gpios = <&pio 3 19 GPIO_ACTIVE_HIGH>; /* PD19 */
  			retain-state-suspended;
 +			panic-indicator;
@@ -32,5 +35,5 @@ index 4981ffd8c945..54629960d48e 100644
  	};
  
 -- 
-2.23.1
+2.25.4
 

--- a/devices/pine64-pinephone-braveheart/kernel/default.nix
+++ b/devices/pine64-pinephone-braveheart/kernel/default.nix
@@ -11,8 +11,8 @@
   src = fetchFromGitLab {
     owner = "pine64-org";
     repo = "linux";
-    rev = "94cf851f0f4443c771a926102dee497def319b49";
-    sha256 = "1a4ch2j8hla3xd7rv38ra6bnv14lsnj0srhlh1c8vxxvwywzg815";
+    rev = "14c4d9ddc15f60645bd262b315fc7d770a44a1c6";
+    sha256 = "137l1y6g3lfmqhxxixdph42cy72398nlmbwmk4690w2anlj76f3s";
   };
   patches = [
     ./0001-dts-pinephone-Setup-default-on-and-panic-LEDs.patch


### PR DESCRIPTION
…-config

  * Change `default.nix` to match kernel changeset, recalculate sha256 key
  * Change LEDs patch file since `sun50i-a64-pinephone.dts` is now replaced by `sun50i-a64-pinephone.dtsi`

Signed-off-by: S Dao <si.dao@outlook.com>