### PR TITLE
Upgrade to kernel 5.6

### DIFF
--- a/devices/pine64-pinephone-braveheart/default.nix
+++ b/devices/pine64-pinephone-braveheart/default.nix
@@ -13,10 +13,11 @@
     screen = {
       width = 720; height = 1440;
     };
+    rev = if "" == builtins.getEnv "MOBILE_NIXOS_DEVICE_HW_REV" then "1.0" else builtins.getEnv "MOBILE_NIXOS_DEVICE_HW_REV";
   };
 
   mobile.boot.stage-1 = {
-    kernel.package = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; };
+    kernel.package = pkgs.callPackage ./kernel { kernelPatches = pkgs.defaultKernelPatches; hardware = config.mobile.hardware; };
   };
 
   boot.kernelParams = [

--- a/devices/pine64-pinephone-braveheart/kernel/0001-dts-pinephone-Setup-default-on-and-panic-LEDs.patch
+++ b/devices/pine64-pinephone-braveheart/kernel/0001-dts-pinephone-Setup-default-on-and-panic-LEDs.patch
@@ -1,6 +1,6 @@
-From 32d81a88ad076538d4d1e4ac88dda01fc2165b30 Mon Sep 17 00:00:00 2001
-From: Samuel Dionne-Riel <samuel@dionne-riel.com>
-Date: Sat, 28 Mar 2020 01:33:16 -0400
+From a9c97de0e0465427653c302a03b6f1ba7bc78bdb Mon Sep 17 00:00:00 2001
+From: S Dao <si.dao@outlook.com>
+Date: Tue, 14 Jul 2020 17:34:13 +0700
 Subject: [PATCH] dts: pinephone: Setup default on and panic LEDs
 
  * The green LED defaults to on.
@@ -8,23 +8,26 @@ Subject: [PATCH] dts: pinephone: Setup default on and panic LEDs
 
 The green LED defaults to on for an expected transition through red,
 yellow and green during the different boot stages.
+
+Signed-off-by: S Dao <si.dao@outlook.com>
 ---
- arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dts | 2 ++
+ arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi | 2 ++
  1 file changed, 2 insertions(+)
 
-diff --git a/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dts b/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dts
-index 4981ffd8c945..54629960d48e 100644
---- a/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dts
-+++ b/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dts
-@@ -66,12 +66,14 @@
- 			label = "pinephone:green:user";
+diff --git a/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi b/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi
+index 8376d6e8a9cc..e2b601dcc950 100644
+--- a/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi
++++ b/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtsi
+@@ -63,6 +63,7 @@ green {
+ 			color = <LED_COLOR_ID_GREEN>;
  			gpios = <&pio 3 18 GPIO_ACTIVE_HIGH>; /* PD18 */
  			retain-state-suspended;
 +			linux,default-trigger = "default-on";
  		};
  
  		red {
- 			label = "pinephone:red:user";
+@@ -70,6 +71,7 @@ red {
+ 			color = <LED_COLOR_ID_RED>;
  			gpios = <&pio 3 19 GPIO_ACTIVE_HIGH>; /* PD19 */
  			retain-state-suspended;
 +			panic-indicator;
@@ -32,5 +35,5 @@ index 4981ffd8c945..54629960d48e 100644
  	};
  
 -- 
-2.23.1
+2.25.4
 

--- a/devices/pine64-pinephone-braveheart/kernel/default.nix
+++ b/devices/pine64-pinephone-braveheart/kernel/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitLab
 , fetchpatch
 , kernelPatches ? [] # FIXME
+, hardware ? {}
 }:
 
 (mobile-nixos.kernel-builder {
@@ -21,8 +22,6 @@
   installTargets = [ "install" "dtbs" ];
   postInstall = postInstall + ''
     mkdir -p "$out/dtbs/allwinner"
-    cp -v "$buildRoot/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone-1.0.dtb" "$out/dtbs/allwinner/"
-    cp -v "$buildRoot/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone-1.1.dtb" "$out/dtbs/allwinner/"
-    cp -v "$buildRoot/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone-1.2.dtb" "$out/dtbs/allwinner/"
+    cp -v "$buildRoot/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone-${hardware.rev}.dtb" "$out/dtbs/allwinner/sun50i-a64-pinephone.dtb"
   '';
 })

--- a/devices/pine64-pinephone-braveheart/kernel/default.nix
+++ b/devices/pine64-pinephone-braveheart/kernel/default.nix
@@ -6,13 +6,13 @@
 }:
 
 (mobile-nixos.kernel-builder {
-  version = "5.5.0";
+  version = "5.6.0";
   configfile = ./config.aarch64;
   src = fetchFromGitLab {
     owner = "pine64-org";
     repo = "linux";
-    rev = "94cf851f0f4443c771a926102dee497def319b49";
-    sha256 = "1a4ch2j8hla3xd7rv38ra6bnv14lsnj0srhlh1c8vxxvwywzg815";
+    rev = "14c4d9ddc15f60645bd262b315fc7d770a44a1c6";
+    sha256 = "137l1y6g3lfmqhxxixdph42cy72398nlmbwmk4690w2anlj76f3s";
   };
   patches = [
     ./0001-dts-pinephone-Setup-default-on-and-panic-LEDs.patch
@@ -21,6 +21,6 @@
   installTargets = [ "install" "dtbs" ];
   postInstall = postInstall + ''
     mkdir -p "$out/dtbs/allwinner"
-    cp -v "$buildRoot/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone.dtb" "$out/dtbs/allwinner/"
+    cp -v "$buildRoot/arch/arm64/boot/dts/allwinner/sun50i-a64-pinephone*" "$out/dtbs/allwinner/"
   '';
 })

--- a/modules/hardware-rev.nix
+++ b/modules/hardware-rev.nix
@@ -1,0 +1,17 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) mkOption types;
+  cfg = config.mobile.hardware;
+in
+{
+  options.mobile.hardware = {
+    rev = mkOption {
+      # This is used to specify hardware revision if any.
+      type = types.str;
+      description = ''
+        Give the hardware revision for the device.
+      '';
+    };
+  };
+}

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -15,6 +15,7 @@
   ./hardware-rockchip.nix
   ./hardware-screen.nix
   ./hardware-soc.nix
+  ./hardware-rev.nix
   ./initrd-base.nix
   ./initrd-boot-gui.nix
   ./initrd-fbterm.nix


### PR DESCRIPTION
Upgrade to kernel 5.6
  * Change `default.nix` to match kernel changeset, recalculate sha256 key
  * Change LEDs patch file since `sun50i-a64-pinephone.dts` is now replaced by `sun50i-a64-pinephone.dtsi`
  * Add `rev` to hardware to specify hardware revision to build with (input by `MOBILE_NIXOS_DEVICE_HW_REV`)
   e.g `MOBILE_NIXOS_DEVICE_HW_REV="1.2" nix-build --argstr device pine64-pinephone-braveheart -A build.disk-image`

There is not much difference in term of kernel config between v5.5 and v5.6 therefore keeping kernel config as of now.