### PR TITLE
kernel-builder/menuconfig: Use pkg-config wrapper

### DIFF
--- a/overlay/mobile-nixos/kernel/builder.nix
+++ b/overlay/mobile-nixos/kernel/builder.nix
@@ -17,6 +17,7 @@
 , buildPackages
 
 , writeTextFile
+, writeShellScriptBin
 
 , perl
 , bc
@@ -87,6 +88,12 @@ let
       cp -av $3 $4
     '';
   };
+
+  # Inspired from #91991
+  # https://github.com/NixOS/nixpkgs/pull/91991
+  pkgconfig-helper = writeShellScriptBin "pkg-config" ''
+    exec ${buildPackages.pkgconfig}/bin/${buildPackages.pkgconfig.targetPrefix}pkg-config "$@"
+  '';
 
   # Shortcuts
   inherit (stdenv.lib) optionals optional optionalString;
@@ -235,7 +242,7 @@ let kernel = stdenv.mkDerivation {
     menuconfig = kernel.overrideAttrs({nativeBuildInputs ? [] , ...}: {
       nativeBuildInputs = nativeBuildInputs ++ [
         ncurses
-        pkgconfig
+        pkgconfig-helper
       ];
       buildFlags = [ "nconfig" "V=1" ];
 


### PR DESCRIPTION
This works around an issue with upstream Nixpkgs and the way pkg-config
is now (admitedly rightly so) prefixed.

In actuality, the kernel build should be fixed upstream, but this would
be a non-trivial thing to get into the kernel.

This was verified with:

 * pine64-pinephone-braveheart
 * asus-dumo
 * asus-z00t (should be a no-op)
 * motorola-addison (should be a no-op)

cc @s1ng0c