### PR TITLE
Fix regressions coming from Nixpkgs upgrades

### DIFF
--- a/lib/release-tools.nix
+++ b/lib/release-tools.nix
@@ -39,7 +39,6 @@
         config = lib.mkMerge [
           config
           {
-            mobile.device.info = {};
             mobile.system.type = "none";
             mobile.hardware.soc = {
               x86_64-linux = "generic-x86_64";

--- a/modules/_nixos-disintegration/default.nix
+++ b/modules/_nixos-disintegration/default.nix
@@ -20,7 +20,6 @@
       # And here the installation-device profile is a bit annoying.
       # Let's ultra-diable the documentation and nixos manual.
       documentation.enable            = lib.mkOverride 10 false;
-      services.nixosManual.showManual = lib.mkOverride 10 false;
     }
   ];
 }


### PR DESCRIPTION
Two distinct issues:

* * *

The option has been removed.

https://github.com/NixOS/nixpkgs/commit/aebf9a4709215c230e5841d60e2bce6aa6627ac8

* * *

Using an removed option, now detected due to stricter checking in the modules system.