### PR TITLE
initrd: handle systemd-udevd being a symlink to udevadm

### DIFF
--- a/modules/initrd.nix
+++ b/modules/initrd.nix
@@ -158,11 +158,11 @@ let
       in
         ''
           # Copy udev.
-          copy_bin_and_libs ${udev}/lib/systemd/systemd-udevd
           copy_bin_and_libs ${udev}/bin/udevadm
           for BIN in ${udev}/lib/udev/*_id; do
             copy_bin_and_libs $BIN
           done
+          ln -sf udevadm $out/bin/systemd-udevd
         ''
       ;
     }]


### PR DESCRIPTION
Mirrors https://github.com/NixOS/nixpkgs/commit/7361f6f25266e8bc104f9bafaec860e67ea45c65

Tested with pinephone: now boots to graphical "Mobile NixOS" splash on screen / login prompt on serial.