### PR TITLE
Fix docs regression, and removes workarounds

### DIFF
--- a/doc/_support/options/default.nix
+++ b/doc/_support/options/default.nix
@@ -15,30 +15,19 @@ let
     name = system;
     buildingForSystem = system;
     system = system;
-    config = {};
+    config = {
+      nixpkgs.config = {
+        # Skip eval issues.
+        # This allows the documentation generation to work even though
+        # derivations won't pass through checkMeta.
+        handleEvalIssue = _reason: _details: true;
+      };
+    };
   };
 
   dummyEval = evalWith {
     device = (dummyConfig "aarch64-linux");
-    modules = [
-      {
-        disabledModules = [
-          # As of 2020-04-06 this module fails the evaluation. (ae6bdcc53584aaf20211ce1814bea97ece08a248)
-          # ⇒ Invalid package attribute path `nextcloud17'
-          <nixpkgs/nixos/modules/services/web-apps/nextcloud.nix>
-
-          # As of 2020-04-06 this module fails the evaluation. (ae6bdcc53584aaf20211ce1814bea97ece08a248)
-          # ⇒ Package ‘ceph-14.2.7’ in .../nixpkgs/pkgs/tools/filesystems/ceph/default.nix:178
-          #   is not supported on ‘aarch64-linux’, refusing to evaluate.
-          <nixpkgs/nixos/modules/services/network-filesystems/ceph.nix>
-
-          # As of 2020-07-03 this module fails the evaluation. (55668eb671b915b49bcaaeec4518cc49d8de0a99)
-          # ⇒ Package ‘blockbook-0.3.4’ in .../nixpkgs/pkgs/servers/blockbook/default.nix:71
-          #   is not supported on ‘aarch64-linux’, refusing to evaluate.
-          <nixpkgs/nixos/modules/services/networking/blockbook-frontend.nix>
-        ];
-      }
-    ];
+    modules = [];
   };
 
   optionsJSON = (nixosOptionsDoc { options = dummyEval.options; }).optionsJSON;

--- a/doc/pkgs.nix
+++ b/doc/pkgs.nix
@@ -1,4 +1,4 @@
-import (fetchTarball "channel:nixos-19.09") {
+import <nixpkgs> {
   overlays = [(self: super: {
     mobile-nixos-process-doc = self.callPackage ./_support/converter {};
   })];


### PR DESCRIPTION
The documentation could get stuck building from under our feet at any point a new option used the following form when defining an option default value.

```
default = "${pkgs.hello}";
```

* * *

"default" values in Nixpkgs manual can *somehow* be escaped by the
documentation back to their original string form.

The following ends up escaped into the manual as `"${pkgs.hello}"`.

```
default = "${pkgs.hello}";
```

The methods for this magic have not been found.

Instead, we just change the default strict `handleEvalIssue` so that it
does absolutely nothing and lets them through.

Anyway we won't be building them.

