### PR TITLE
kernel-builder: Work around kernels getting compiled two times

### DIFF
--- a/devices/asus-flo/kernel/default.nix
+++ b/devices/asus-flo/kernel/default.nix
@@ -26,4 +26,7 @@ mobile-nixos.kernel-builder-gcc6 {
 
   enableCompilerGcc6Quirk = true;
   isModular = false;
+
+  # mv: cannot stat 'arch/arm/boot/compressed/.misc.o.tmp': No such file or directory
+  enableCombiningBuildAndInstallQuirk = false;
 }

--- a/doc/in-depth/kernel-builder.adoc
+++ b/doc/in-depth/kernel-builder.adoc
@@ -85,6 +85,24 @@ This effectively replaces the Tux logo.
 
 By default an appropriate file is provided by Mobile NixOS.
 
+=== `enableCompilerGcc6Quirk`
+
+When enabled, building and installing is done in one single step. Some kernels,
+mainly prior to 4.4, will rebuild the kernel from scratch when installing. Work
+around the issue by using only one make invocation.
+
+This defaults to `true` for kernel versions prior to 4.4.
+
+Using the wrong value can either:
+
+ * be a no-op
+ * make the build take twice as long
+ * fail the build in obvious ways
+
+There have been no _weird side-effects_ observed when using the wrong value.
+Touching this value, other than outright failing the build, will not make a
+kernel that doesn't boot otherwise boot.
+
 
 == Making a new port
 


### PR DESCRIPTION
It looks like this is not a regression from the latest changes to the kernel builder. Testing on top of ffdba8fecbb2aee6fb79e4a1cde5e06035ef407b exhibits the same issue.

This change works around the issue by doing it with one invocation of `make`, rather than doing it twice.

It has not been figured out at which exact version of the kernel this stops being an issue, and if it is an issue from mainline Linux outright, or something that came from Android-specific modifications.

Though it has been verified that for 3.18, both Qualcomm and Mediatek source trees exhibit the same issue.

Fixes #216

* * *

#### TODO:

 - [x] figure out why it fails for asus-flo