### PR TITLE
system-types/u-boot: Use GPT for partitions + add partitions

### DIFF
--- a/devices/pine64-pinephone/u-boot/default.nix
+++ b/devices/pine64-pinephone/u-boot/default.nix
@@ -40,6 +40,7 @@ in
     # This is because we re-invest the 2s in our own menu.
     CONFIG_AUTOBOOT_KEYED_CTRLC=y
     CONFIG_BOOTDELAY=0
+    CONFIG_REGEX=y
   '';
 }).overrideAttrs(old: rec {
   version = "2020.07";

--- a/modules/system-types/u-boot/default.nix
+++ b/modules/system-types/u-boot/default.nix
@@ -101,6 +101,26 @@ let
     }
   ;
 
+  miscPartition = {
+    # Used as a BCB.
+    name = "misc";
+    partitionLabel = "misc";
+    partitionUUID = "5A7FA69C-9394-8144-A74C-6726048B129D";
+    length = imageBuilder.size.MiB 1;
+    partitionType = "EF32A33B-A409-486C-9141-9FFB711F6266";
+    filename = "/dev/null";
+  };
+
+  persistPartition = imageBuilder.fileSystem.makeExt4 {
+    # To work more like Android-based systems.
+    name = "persist";
+    partitionLabel = "persist";
+    partitionID = "5553F4AD-53E1-2645-94BA-2AFC60C12D38";
+    partitionUUID = "5553F4AD-53E1-2645-94BA-2AFC60C12D39";
+    size = imageBuilder.size.MiB 16;
+    partitionType = "EBC597D0-2053-4B15-8B64-E0AAC75F4DB1";
+  };
+
   # Without bootloader means "without u-boot"
   withoutBootloader = imageBuilder.diskImage.makeMBR {
     name = "mobile-nixos";
@@ -110,6 +130,8 @@ let
     # This is not ideal... an alternative solution should be figured out.
     partitions = [
       (imageBuilder.gap cfg.initialGapSize)
+      miscPartition
+      persistPartition
 
       config.system.build.boot-partition
 

--- a/modules/system-types/u-boot/default.nix
+++ b/modules/system-types/u-boot/default.nix
@@ -47,9 +47,13 @@ let
     if load ''${devtype} ''${devnum}:''${bootpart} ''${kernel_addr_r} /mobile-nixos/boot/kernel; then
       setenv boot_type boot
     else
-      load ''${devtype} ''${devnum}:''${bootpart} ''${kernel_addr_r} /mobile-nixos/recovery/kernel
-      setenv boot_type recovery
-      setenv bootargs ''${bootargs} is_recovery
+      if load ''${devtype} ''${devnum}:''${bootpart} ''${kernel_addr_r} /mobile-nixos/recovery/kernel; then
+        setenv boot_type recovery
+        setenv bootargs ''${bootargs} is_recovery
+      else
+        echo "!!! Failed to load either of the normal and recovery kernels !!!"
+        exit
+      fi
     fi
 
     if load ''${devtype} ''${devnum}:''${bootpart} ''${fdt_addr_r} /mobile-nixos/''${boot_type}/dtbs/''${fdtfile}; then

--- a/modules/system-types/u-boot/default.nix
+++ b/modules/system-types/u-boot/default.nix
@@ -54,6 +54,42 @@ let
     echo === end of the debug information ===
     echo
 
+    if test "$mmc_bootdev" != ""; then
+      echo ":: Detected mmc booting"
+      devtype="mmc"
+    else
+      echo "!!! Could not detect devtype !!!"
+      exit
+    fi
+
+    if test "$devtype" = "mmc"; then
+      devnum="$mmc_bootdev"
+      echo ":: Booting from mmc $devnum"
+    fi
+
+    bootpart=""
+    echo part number $devtype $devnum boot bootpart
+    part number $devtype $devnum boot bootpart
+    echo $bootpart
+
+    # To stay compatible with the previous scheme, and more importantly, the
+    # default assumptions from U-Boot, detect the bootable legacy flag.
+    if test "$bootpart" = ""; then
+      echo "Could not find a partition with the partlabel 'boot'."
+      echo "(looking at partitions marked bootable)"
+      part list ''${devtype} ''${devnum} -bootable bootpart
+      # This may print out an error message when there is only one result.
+      # Though it still is fine.
+      setexpr bootpart gsub ' .*' "" "$bootpart"
+    fi
+
+    if test "$bootpart" = ""; then
+      echo "!!! Could not find 'boot' partition on $devtype $devnum !!!"
+      exit
+    fi
+
+    echo ":: Booting from partition $bootpart"
+
     if load ''${devtype} ''${devnum}:''${bootpart} ''${kernel_addr_r} /mobile-nixos/boot/kernel; then
       setenv boot_type boot
     else

--- a/modules/system-types/u-boot/default.nix
+++ b/modules/system-types/u-boot/default.nix
@@ -77,7 +77,9 @@ let
   boot-partition =
     imageBuilder.fileSystem.makeExt4 {
       name = "mobile-nixos-boot";
+      partitionLabel = "boot";
       partitionID = "ED3902B6-920A-4971-BC07-966D4E021683";
+      partitionUUID = "CFB21B5C-A580-DE40-940F-B9644B4466E1";
       # Let's give us a *bunch* of space to play around.
       # And let's not forget we have the kernel and stage-1 twice.
       size = imageBuilder.size.MiB 128;
@@ -122,19 +124,17 @@ let
   };
 
   # Without bootloader means "without u-boot"
-  withoutBootloader = imageBuilder.diskImage.makeMBR {
+  withoutBootloader = imageBuilder.diskImage.makeGPT {
     name = "mobile-nixos";
     diskID = "01234567";
+    headerHole = cfg.initialGapSize;
 
     # This has to follow the same order as defined in the u-boot bootloaders...
     # This is not ideal... an alternative solution should be figured out.
     partitions = [
-      (imageBuilder.gap cfg.initialGapSize)
       miscPartition
       persistPartition
-
       config.system.build.boot-partition
-
       config.system.build.rootfs
     ];
   };

--- a/modules/system-types/u-boot/default.nix
+++ b/modules/system-types/u-boot/default.nix
@@ -44,6 +44,16 @@ let
 
     ${cfg.additionalCommands}
 
+    echo
+    echo === debug information ===
+    printenv bootargs
+    echo
+    printenv kernel_addr_r
+    printenv fdt_addr_r
+    printenv ramdisk_addr_r
+    echo === end of the debug information ===
+    echo
+
     if load ''${devtype} ''${devnum}:''${bootpart} ''${kernel_addr_r} /mobile-nixos/boot/kernel; then
       setenv boot_type boot
     else


### PR DESCRIPTION
This is how it should have been done from the beginning.

What this gives us:

 * Ability to make more than 4 partitions.
 * Somewhat shield the Allwinner bootloader
 * Partition labels

We don't really need more than 4 partitions. Though now we have the ability for it. We would need it if we were able to put the Allwinner bootloader at a location inside the usable space.

Though, shielding the bootloader from haphazard partitioning is nice.

Finally, partition labels are not strictly needed; we were doing just fine without. But this is more what I had in mind originally for a well-designed system.

#### Now, what's up with `misc` and `persist`??

They're partitions that are going to be used basically like the Android-common ones.

The `misc` partition is a mebibyte of bytes that can be used for dialoguing from system to bootloader to system. This is how e.g. Android asks that a boot goes into recovery for flashing something or for erasing the system. The search term for it is **BCB**. Right now it's not in use. I don't know if it will be, but if it is going to be used by the stage-1 system at any point, we better prepare the systems.

The `persist` partition is used by Android to... well... persist some informations outside of the userdata. Here it's not used for now, but there are plans to start using it.

First, it would be nice if we had a compatible scheme with Android and Android-based recoveries for some things.

This would be helpful to setup the clock on Qualcomm-based hardware, see #127. If stage-1 knows about the scheme Android uses, we're going to be able to have proper [UTC] time at the first boot! Additionally, if stage-2 knows about it and on shut down syncs it, we have a full "hwclock-like" setup for that quirky platform.

Next, we can *also* use it for our own persistent data! Nothing has been sketched out publicly yet, but the thought is to fill in *declara-statefully* information from stage-2 into persist. The information would things like the keyboard map, and i18n options. I'm sure other useful things could be figured out. All in the goal to make the stage-1 image more generic, and configure it on-device rather than having to rebuild it.

Sure, right now it's 17MiB of "wasted" space for misc and persist, but I call it future-proofing.

#### More partitions on the horizon?

I'm not sure there is value in it, but rather than saving the boot information on the partition for both boot and recovery, we now have the leeway to make `boot_a` and `boot_b` and play with an A/B scheme for u-boot platforms.