### PR TITLE
Boot GUI: only show relevant reboot options

### DIFF
--- a/examples/hello/app/windows/quit.rb
+++ b/examples/hello/app/windows/quit.rb
@@ -14,8 +14,6 @@ module GUI
 
       add_buttons([
         ["Reboot", ->() { run("reboot") }],
-        ["Reboot to recovery", ->() { run("reboot recovery") }],
-        ["Reboot to bootloader", ->() { run("reboot bootloader") }],
         ["Power off", ->() { run("poweroff") }],
       ])
 

--- a/modules/hardware.nix
+++ b/modules/hardware.nix
@@ -1,0 +1,23 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) types;
+in
+{
+  options = {
+    # All of this should stay internal.
+    mobile.HAL = {
+      boot = {
+        rebootModes = lib.mkOption {
+          type = types.listOf types.str;
+          internal = true;
+          default = [];
+          description = ''
+            Identifiers known by the boot menu to provide reboot options
+            that are hardware-dependent. E.g. reboot to bootloader.
+          '';
+        };
+      };
+    };
+  };
+}

--- a/modules/initrd.nix
+++ b/modules/initrd.nix
@@ -287,6 +287,9 @@ in
         boot = {
           inherit (config.mobile.boot.stage-1) fail crashToBootloader;
         };
+
+        # Transmit all of the mobile NixOS HAL options.
+        HAL = config.mobile.HAL;
       };
     };
   }

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -15,6 +15,7 @@
   ./hardware-rockchip.nix
   ./hardware-screen.nix
   ./hardware-soc.nix
+  ./hardware.nix
   ./initrd-base.nix
   ./initrd-boot-gui.nix
   ./initrd-fbterm.nix

--- a/modules/system-types/android/default.nix
+++ b/modules/system-types/android/default.nix
@@ -128,6 +128,11 @@ in
         default = android-device;
         inherit android-bootimg android-recovery android-device;
       };
+
+      mobile.HAL.boot.rebootModes = [
+        "Android.recovery"
+        "Android.bootloader"
+      ];
     })
 
     (lib.mkIf kernelPackage.isQcdt {


### PR DESCRIPTION
This adds a "HAL" options layer where we can describe some hardware-specific abstractions.

The only one implemented for now is the reboot modes list.

This list is interpreted by the boot GUI in an implementation-defined way. All of the implementation details are internal and could change at any time for now.

The goal is to make sure that, e.g. on the Pinephone, the reboot options that don't apply are not present.