### PR TITLE
stage-1: Detect hung tasks and abort boot

### DIFF
--- a/boot/init/lib/dependencies.rb
+++ b/boot/init/lib/dependencies.rb
@@ -8,8 +8,18 @@ module Dependencies
       self.class.name
     end
 
+    # User-facing name
+    def pretty_name()
+      name
+    end
+
     def depends_on?(other)
       raise "#{self.class.name} has to implement #depends_on?"
+    end
+
+    # Same as name, but with the object_id appended.
+    def to_s()
+      name + "<0x#{object_id.to_s(16)}>"
     end
   end
 
@@ -30,6 +40,10 @@ module Dependencies
     def depends_on?(other)
       @instance.depends_on?(other)
     end
+
+    def name()
+      super + "(#{@instance.name})"
+    end
   end
 
   # When any of the dependencies given have been fulfilled, this dependency
@@ -45,6 +59,10 @@ module Dependencies
 
     def depends_on?(other)
       @dependencies.any? { |dependency| dependency.depends_on?(other) }
+    end
+
+    def name()
+      super + "(#{@dependencies.map(&:name).join(", ")})"
     end
   end
 
@@ -73,12 +91,29 @@ module Dependencies
     def depends_on?(other)
       false
     end
+
+    def name()
+      super + "(#{@patterns.join(", ")})"
+    end
+
+    def pretty_name()
+      if @patterns.length == 1
+        "File '#{@patterns.first}'"
+      else
+        "Files #{@patterns.map{|f| "'#{f}'"}.join(", ")}"
+      end
+    end
   end
 
   # Checks in sysfs for the given network interface names.
   class NetworkInterface < Files
     def initialize(*names)
+      @names = names
       super(*names.map { |name| File.join("/sys/class/net", name) })
+    end
+
+    def name()
+      super + "(#{@names.join(", ")})"
     end
   end
 
@@ -97,6 +132,10 @@ module Dependencies
 
     def task()
       Targets[@name]
+    end
+
+    def name()
+      super + "(#{@name})"
     end
   end
 end

--- a/boot/init/lib/dependencies.rb
+++ b/boot/init/lib/dependencies.rb
@@ -117,6 +117,16 @@ module Dependencies
     end
   end
 
+  class Devices < Files
+    def pretty_name()
+      if @patterns.length == 1
+        "Device '#{@patterns.first}'"
+      else
+        "Devices #{@patterns.map{|f| "'#{f}'"}.join(", ")}"
+      end
+    end
+  end
+
   class Target < BaseDependency
     def initialize(name)
       @name = name.to_sym

--- a/boot/init/lib/progress.rb
+++ b/boot/init/lib/progress.rb
@@ -96,6 +96,10 @@ module Progress
     value
   end
 
+  def self.kill()
+    Tasks::Splash.instance.kill()
+  end
+
   # Read one reply
   # If none are available, returns nil
   def self.read_reply()

--- a/boot/init/lib/system.rb
+++ b/boot/init/lib/system.rb
@@ -177,12 +177,14 @@ module System
     end
   end
 
-  def self.failure(code, message="(No details given)", color: "000000")
+  def self.failure(code, message="(No details given)", color: "000000", delay: Configuration["boot"]["fail"]["delay"])
+    Progress.kill()
     $logger.fatal("#{code}: #{message}")
     sad_phone(color, code, message)
     shell if respond_to?(:shell)
-    sleep(Configuration["boot"]["fail"]["delay"])
+    sleep(delay)
     hard_reboot if Configuration["boot"]["fail"]["reboot"]
+    exit 111
   end
 
   def self.hard_reboot()

--- a/boot/init/tasks/auto_resize.rb
+++ b/boot/init/tasks/auto_resize.rb
@@ -5,7 +5,7 @@ class Tasks::AutoResize < Task
   def initialize(device, type: )
     @device = device
     @type = type
-    add_dependency(:Files, @device)
+    add_dependency(:Devices, @device)
   end
 
   def run()

--- a/boot/init/tasks/luks.rb
+++ b/boot/init/tasks/luks.rb
@@ -28,7 +28,7 @@ class Tasks::Luks < Task
     @mapper = mapper
 
     add_dependency(:Task, Tasks::UDev.instance)
-    add_dependency(:Files, source)
+    add_dependency(:Devices, source)
     add_dependency(:Mount, "/run")
     add_dependency(:Target, :Environment)
     self.class.register(@mapper, self)

--- a/boot/init/tasks/mount.rb
+++ b/boot/init/tasks/mount.rb
@@ -33,7 +33,7 @@ class Tasks::Mount < Task
       # Only add a dependency for an absolute path.
       # Otherwise we would wait on the file "tmpfs" for tmpfs, and such.
       if source.match(%{^/})
-        add_dependency(:Files, source)
+        add_dependency(:Devices, source)
       end
     else
       @source = named[:type]

--- a/boot/init/tasks/mount.rb
+++ b/boot/init/tasks/mount.rb
@@ -77,5 +77,13 @@ module Dependencies
     def task()
       Tasks::Mount.registry[@mount_point]
     end
+
+    def name()
+      super + "(#{@mount_point})"
+    end
+
+    def pretty_name()
+      "Mounting '#{@mount_point}'"
+    end
   end
 end

--- a/boot/init/tasks/splash.rb
+++ b/boot/init/tasks/splash.rb
@@ -42,4 +42,9 @@ class Tasks::Splash < SingletonTask
       sleep(0.1)
     end
   end
+
+  # Use `quit` rather than kill!
+  def kill()
+    System.run("kill", "-9", @pid.to_s) if @pid
+  end
 end

--- a/doc/in-depth/stage-1.adoc
+++ b/doc/in-depth/stage-1.adoc
@@ -18,6 +18,7 @@ error has been codified as a background color.
 
  * Yellow (`0xFFFF00`) means that mounting the root filesystem was not possible.
  * Fuchsia (`0xFF00FF`) means that mounting succeeded, but no compatible generation was found to boot.
+ * Black (`0x000000`) means a dependency hung boot
  * Red (`0xFF0000`) means that executing (`exec`) and switching to the found generation's init failed.
  * Brown (`0x95681C`) means an uncontrolled abort happened.
 


### PR DESCRIPTION
*This builds on #234*

* * *

With this PR, the boot is aborted when no tasks can be run for a given amount of time.

The test case I used for this is to produce the `demo` image with a bad `filesystems."/".device`.

```diff
diff --git a/modules/rootfs.nix b/modules/rootfs.nix
index ff491e2c998f..7bf93a9526d2 100644
--- a/modules/rootfs.nix
+++ b/modules/rootfs.nix
@@ -78,7 +78,7 @@ in
 
   fileSystems = {
     "/" = lib.mkDefault {
-      device = "/dev/disk/by-label/${rootfsLabel}";
+      device = "/dev/disk/by-label/${rootfsLabel}_FAIL";
       fsType = "ext4";
       autoResize = true;
     };
```

This is representative enough of someone not flashing the rootfs on their device.

The user experience is as follows:

 - When in the situation of *hanging*, a message is shown on the progress display.
 - When it fails, the existing failure handler gets a more complete message.

![image](https://user-images.githubusercontent.com/132835/98196115-4f38b480-1ef1-11eb-998a-f38a03fa5e3b.png)


This is not ideal, it would be great to somehow be able to resolve this to better error messages, BUT, we have all the information right in there for the end-user. So while it's not the best UX possible, it's the better option, being totally transparent.