### PR TITLE
stage-1: Handle (physical) keyboard input

### DIFF
--- a/boot/splash/lib/ui.rb
+++ b/boot/splash/lib/ui.rb
@@ -126,6 +126,8 @@ class UI
     @ta.set_pos(*center(@ta, 0, @unit * 14))
     # Always present, but initially hidden
     @ta.hide(skip_animation: true)
+    LVGUI.focus_group.add_obj(@ta)
+    LVGUI.focus_ring_disable()
   end
 
   def add_keyboard()

--- a/modules/initrd.nix
+++ b/modules/initrd.nix
@@ -201,7 +201,13 @@ let
     ];
   } ''
     mkdir initrd
-    (cd initrd; gzip -cd ${initrd}/initrd | cpio -i)
+    (
+    cd initrd
+    ${if config.mobile.boot.stage-1.compression == "gzip" then "gzip -cd ${initrd}/initrd"
+      else if config.mobile.boot.stage-1.compression == "xz" then "xz -cd ${initrd}/initrd"
+      else throw "Cannot decompress ${config.mobile.boot.stage-1.compression} for initrd-meta."
+    } | cpio -i
+    )
 
     mkdir -p $out
     ncdu -0x -o $out/initrd.ncdu ./initrd

--- a/overlay/mruby-builder/mrbgems/mruby-lvgui/default.nix
+++ b/overlay/mruby-builder/mrbgems/mruby-lvgui/default.nix
@@ -18,8 +18,8 @@ mrbgems.mkGem {
   src = fetchFromGitHub {
     repo = "mruby-lvgui";
     owner = "mobile-nixos";
-    rev = "07f6cce17a9819ec9c6da2adea012e3033cfd7b6";
-    sha256 = "0c47vv2slwh2n3996aw219likicpsmlk47ayx8xcl49kpmq674ns";
+    rev = "c82c82e5326540faa2ac47259adbf6254cd1994f";
+    sha256 = "11xpa1fvnv6h0wkjj7h5l4vsyjvbffz4mdcxcdv21nxsdgrsdzdl";
   };
 
   gemBuildInputs = [

--- a/overlay/mruby-builder/mrbgems/mruby-lvgui/lvgui.nix
+++ b/overlay/mruby-builder/mrbgems/mruby-lvgui/lvgui.nix
@@ -21,6 +21,43 @@ let
       pkgs.buildPackages.python3
     ];
   });
+  libxkbcommon = pkgs.callPackage (
+    { stdenv                                             
+    , libxkbcommon                             
+    , meson             
+    , ninja                                         
+    , pkgconfig               
+    , yacc                              
+    }:                            
+
+    libxkbcommon.overrideAttrs({...}: {
+      nativeBuildInputs = [ meson ninja pkgconfig yacc ];
+      buildInputs = [ ];                                     
+
+      mesonFlags = [   
+        "-Denable-wayland=false"
+        "-Denable-x11=false"             
+        "-Denable-docs=false"            
+
+        # This is because we're forcing uses of this build
+        # to define config and locale root; for stage-1 use.
+        # In stage-2, use the regular xkbcommon lib.
+        "-Dxkb-config-root=/NEEDS/OVERRIDE/etc/X11/xkb"
+        "-Dx-locale-root=/NEEDS/OVERRIDE/share/X11/locale"
+      ];
+
+      outputs = [ "out" "dev" ];
+
+      # Ensures we don't get any stray dependencies.
+      allowedReferences = [
+        "out"
+        "dev"
+        stdenv.cc.libc_lib
+      ];
+    })
+
+  ) {};
+
 in
   stdenv.mkDerivation {
     pname = "lvgui";
@@ -46,6 +83,7 @@ in
 
     buildInputs = [
       libevdev
+      libxkbcommon
     ]
     ++ optionals withSimulator simulatorDeps
     ;

--- a/overlay/mruby-builder/mrbgems/mruby-lvgui/lvgui.nix
+++ b/overlay/mruby-builder/mrbgems/mruby-lvgui/lvgui.nix
@@ -61,13 +61,13 @@ let
 in
   stdenv.mkDerivation {
     pname = "lvgui";
-    version = "2020-11-01";
+    version = "2020-11-20";
 
     src = fetchFromGitHub {
       repo = "lvgui";
       owner = "mobile-nixos";
-      rev = "4f8af498a81bd669d42ce3b370fc66fe4ec681b5";
-      sha256 = "00rik18c3c3l4glzh2azg90cwvp56s4wnski86rsn00bxslia5ma";
+      rev = "c94c3916012f5615af027389e77e7a974cc3e634";
+      sha256 = "16dfdky5v72jqs9v22h1k73g74bnif6fg52vhxw2k8sh6mw1cmzp";
     };
 
     # Document `LVGL_ENV_SIMULATOR` in the built headers.


### PR DESCRIPTION
With this change set, the physical keyboard can be used to input passphrases and such.

Note that this is currently hardcoded to the "us" keyboard, only because other layouts are expected to be implemented in unison with locale-aware on-screen keyboard. The irony is not lost on me, a non-"us" keyboard user implementing the "us" keyboard only.

In fact, the on-screen keyboard will be able to re-use xkbcommon's knowledge of keyboard layouts! Much better than re-implementing it all!

See, we'll simply build the keyboard from return values of the scancodes at their expected locations! We should even be able to support "3rd layer" (alt gr) this way in a trivial manner.

So let's not keep this improvement from landing, while the internationalized keyboard issue is scheduled to be handled at a later time.