### PR TITLE
Solution for USB3 flashing issue

### DIFF
--- a/devices/sony-pioneer/README.adoc
+++ b/devices/sony-pioneer/README.adoc
@@ -21,3 +21,33 @@ within Mobile NixOS, `sudo reboot bootloader`, or from an Android-based system
 using `adb reboot bootloader` or equivalent methods.
 
 Note that the LED will light up blue when in fastboot mode.
+
+=== Failure to `fastboot flash`
+
+It is possible that you might run into issues with this device when connected to a USB3 port with a USB3 cable. If that happens:
+
+. Check if there is a USB2 port on your computer or on the USB hub you are using. Connect your phone to the USB2 port for flashing instead.
+. If your USB hub only has USB3 ports, then connect the hub to PC with a USB2 data cable, and XA2 to the hub with any USB data cable ("USB Type-C" in the XA2 end).
+. If there are only USB3 ports available, you can force your USB3 ports to USB2 mode.
+
+==== Forcing USB3 ports to USB2 mode
+
+The following commands will force all USB3 ports to USB2 mode temporarily.
+
+----
+ $ nix-shell -p pciutils
+ [nix-shell:~]$ lspci -nn | grep USB | cut -d '[' -f3 | cut -d ']' -f1 | xargs -I@ sudo setpci -H1 -d @ d0.l=0
+----
+
+After which hopefully the procedure works. After successfully flashing, restart your computer to bring the USB3 ports to their normal mode.
+
+Alternatively, the following commands can be used to revert the change.
+
+----
+ $ nix-shell -p pciutils
+ [nix-shell:~]$ lspci -nn | grep USB | cut -d '[' -f3 | cut -d ']' -f1 | xargs -I@ sudo setpci -H1 -d @ d0.l=1
+----
+
+See also:
+
+* https://jolla.zendesk.com/hc/en-us/articles/360012031854-Flashing-Sailfish-to-Xperia-XA2-fails-Troubleshooting-


### PR DESCRIPTION
In some cases, you cannot flash a new firmware when using a USB3 cable.