### PR TITLE
mruby-builder: Fix `passthru` being required for mruby builder

### DIFF
--- a/overlay/mruby-builder/mruby/builder.nix
+++ b/overlay/mruby-builder/mruby/builder.nix
@@ -25,7 +25,7 @@ in
 { src
 , gems ? []
 , buildPhase
-, passthru
+, passthru ? {}
 , ...
 }@ attrs:
 let


### PR DESCRIPTION
Tested with:

```
 $ nix-build --argstr device qemu-x86_64 -A pkgs.hello-mruby
```