### PR TITLE
boot: LUKS errors are "controlled"

### DIFF
--- a/boot/init/tasks/luks.rb
+++ b/boot/init/tasks/luks.rb
@@ -55,7 +55,7 @@ class Tasks::Luks < Task
     end
 
     # We failed multiple times.
-    raise CouldNotUnlock.new("Could not unlock #{source}; tried #{TRIES} times.")
+    System.failure("CRYPTSETUP_FAILED_UNLOCK", "Failed to unlock", "Could not unlock #{source}.\n\nTried #{TRIES} times.", color: "000000", delay: 60)
   end
 
   def name()


### PR DESCRIPTION
This means that we shouldn't raise an exception, but rather fail outright. The background being black means that things *failed successfully*, as expected.

The big difference here is how the error will be shown.

Rather than being treated as things failing to run as expected from the `init` code, things fail with a really specific error message, about how it failed to unlock.