### PR TITLE
kernel-builder: Strip another troublesome config

### DIFF
--- a/overlay/mobile-nixos/kernel/builder.nix
+++ b/overlay/mobile-nixos/kernel/builder.nix
@@ -287,6 +287,7 @@ stdenv.mkDerivation (inputArgs // {
             -e 's;CONFIG_GCC_VERSION=.*;CONFIG_GCC_VERSION=;' \
             -e 's;CONFIG_LD_VERSION=.*;CONFIG_LD_VERSION=;' \
             -e 's;CONFIG_CLANG_VERSION=.*;CONFIG_CLANG_VERSION=;' \
+            -e '/CONFIG_DEBUG_INFO_SPLIT/d;' \
             $f > .tmp$f
         done
         )


### PR DESCRIPTION
This config currently breaks the build for native aarch64 pinephone
kernel builds, as it does not appear with cross-compilation.