### PR TITLE
kernel-builder: Call either of install or zinstall

### DIFF
--- a/overlay/mobile-nixos/kernel/builder.nix
+++ b/overlay/mobile-nixos/kernel/builder.nix
@@ -337,10 +337,8 @@ stdenv.mkDerivation (inputArgs // {
   # no-op buildPhase if we combine build and install steps
   buildPhase = if enableCombiningBuildAndInstallQuirk then ":" else null;
 
-  installTargets = [
-    "install"
-  ]
-    ++ optional (isCompressed != false) "zinstall"
+  installTargets =
+    if isCompressed != false then [ "zinstall" ] else [ "install" ]
     ++ installTargets
   ;
 


### PR DESCRIPTION
It seems that under specific conditions:

 - 2a5 hardware
 - -j22

the call to `make install zinstall` (simplified here) may break, with
the installation of `System.map` happening in a manner where it fails
the build. It was not trivial to reproduce elsewhere than on a 2a5
machine, for unknown reasons.

It was also only observed on google-walleye, but there is no reason is
shouldn't be failing on other devices too.

Odd.

* * *

More details:

 - https://logs.nix.samueldr.com/nixos-dev/2020-12-30#1609366884-1609368903;
 - https://logs.nix.samueldr.com/nixos-dev/2020-12-31#1609375219-1609376210;