### PR TITLE
fix build failure by providing kernel filename to internal NixOS option

### DIFF
--- a/modules/initrd-kernel.nix
+++ b/modules/initrd-kernel.nix
@@ -103,6 +103,10 @@ in
     else (pkgs.recurseIntoAttrs (pkgs.linuxPackagesFor cfg.package))
   );
 
+  config.system.boot.loader.kernelFile = mkIf (cfg.package != null && cfg.package ? file) (
+    mkDefault cfg.package.file
+  );
+
   # Disable kernel config checks as it's EXTREMELY nixpkgs-kernel centric.
   # We're duplicating that good work for the time being.
   config.system.requiredKernelConfig = lib.mkForce [];


### PR DESCRIPTION
The update from 29a10085f313904516992684f1d0fd647fb2ad6d caused the
uncompressed kernel to not be installed anymore into the kernel output.

This meant that building the top-level argument failed as a file assumed
to exist wasn't there anymore.

We now provide the appropriate filename when we know it.