### PR TITLE
stage-0: Teardown gadget before kexec

### DIFF
--- a/boot/init/lib/system.rb
+++ b/boot/init/lib/system.rb
@@ -120,6 +120,22 @@ module System
     result
   end
 
+  # Deletes files or directories indiscriminately.
+  # Directories still need to be emptied beforehand.
+  def self.delete(*paths)
+    paths.each do |path|
+      # A symlink can be directory?() true, but won't `Dir.delete()`
+      # Thus the weird conditional.
+      if File.symlink?(path) || !File.directory?(path)
+        $logger.debug(" $ rm #{path.shellescape}")
+        File.delete(path)
+      else
+        $logger.debug(" $ rmdir #{path.shellescape}")
+        Dir.delete(path)
+      end
+    end
+  end
+
   # Mounts a filesystem of type +type+ on +dest+.
   #
   # The +source+ parameter is optional, though kept first to keep a coherent

--- a/boot/init/tasks/switch_root.rb
+++ b/boot/init/tasks/switch_root.rb
@@ -189,6 +189,12 @@ class Tasks::SwitchRoot < SingletonTask
     log("")
 
     if will_kexec?
+      if Tasks.constants.include?(:SetupGadgetMode)
+        Progress.exec_with_message("Tearing down USB Gadget mode") do
+          Tasks::SetupGadgetMode.instance.teardown()
+        end
+      end
+
       System.run(
         "kexec", "--load",
         generation_file("kernel"),


### PR DESCRIPTION
Fixes an issue where the USB controller is in a confusing state for the freshly booting kernel.

This adds a specialized code path into the kexec code path, but it's better than making the wrong abstraction.

We, *anyway* need to work on generic teardown later on.

Tested on an out-of-tree device.