### PR TITLE
uefi-x86_64: Drop "quiet" kernel command line option

### DIFF
--- a/devices/uefi-x86_64/default.nix
+++ b/devices/uefi-x86_64/default.nix
@@ -18,7 +18,6 @@
 
   boot.kernelParams = [
     "vt.global_cursor_default=0"
-    "quiet"
   ];
 
   mobile.system.type = "uefi";


### PR DESCRIPTION
This, in turn, causes the kernel to go to console level 4. Not ideal
when a user tries to set it to something else. Leave this to
boot.consoleLogLevel.