### PR TITLE
boot: A few updates to LVGUI

### DIFF
--- a/boot/init/tasks/graphics.rb
+++ b/boot/init/tasks/graphics.rb
@@ -1,7 +1,27 @@
 # Ensures graphics have been initialized and are ready to be used.
-#
-# Currently this only handles the "legacy fbdev" style of framebuffers.
 class Tasks::Graphics < SingletonTask
+  def initialize()
+    add_dependency(
+      :Any,
+      Dependencies::Task.new(FBDev.instance),
+      Dependencies::Task.new(DRM.instance),
+    )
+
+    # Make the Graphics target depend on this task.
+    Targets[:Graphics].add_dependency(:Task, self)
+  end
+
+  def run()
+    # no-op
+  end
+
+  def ux_priority()
+    -100
+  end
+end
+
+# Handles the "legacy fbdev" style of framebuffers.
+class Tasks::Graphics::FBDev < SingletonTask
   def initialize()
     add_dependency(
       :Files,
@@ -11,15 +31,32 @@ class Tasks::Graphics < SingletonTask
     # This is only incidental to the fact that /dev/fb0 wouldn't exist for
     # users of the "Graphics" dependency.
     add_dependency(:Mount, "/dev")
-
-    # Make the Graphics target depend on this task.
-    Targets[:Graphics].add_dependency(:Task, self)
   end
 
   def run()
     mode = File.read("/sys/class/graphics/fb0/modes")
     log("Setting framebuffer mode to: #{mode}")
     System.write("/sys/class/graphics/fb0/mode", mode)
+  end
+
+  def ux_priority()
+    -100
+  end
+end
+
+# Handles DRM
+# (Does nothing, only handles dependencies)
+class Tasks::Graphics::DRM < SingletonTask
+  def initialize()
+    add_dependency(
+      :Files,
+      "/dev/dri/card0",
+    )
+    add_dependency(:Mount, "/dev")
+  end
+
+  def run()
+    # no-op
   end
 
   def ux_priority()

--- a/boot/lib/lvgui/lvgl/ffi.rb
+++ b/boot/lib/lvgui/lvgl/ffi.rb
@@ -99,6 +99,12 @@ module LVGL::FFI
   ], type: :uint8_t)
   typealias("lv_res_t", "LV_RES")
 
+  enum!(:LV_ANIM, [
+    :OFF,
+    :ON,
+  ])
+  typealias("lv_anim_enable_t", "LV_ANIM")
+
   extern "lv_obj_t * lv_obj_create(lv_obj_t *, const lv_obj_t *)"
   extern "const lv_style_t * lv_obj_get_style(const lv_obj_t *)"
   extern "void lv_obj_set_style(lv_obj_t *, const lv_style_t *)"
@@ -199,6 +205,24 @@ module LVGL::FFI
   extern "lv_obj_t * lv_img_create(lv_obj_t *, const lv_obj_t *)"
   extern "void lv_img_set_src(lv_obj_t *, const void *)"
 
+  # lvgl/src/lv_objx/lv_sw.h
+  enum!(:LV_SW_STYLE, [
+    :BG,
+    :INDIC,
+    :KNOB_OFF,
+    :KNOB_ON,
+  ], type: "uint8_t")
+  typealias("lv_sw_style_t", "LV_SW_STYLE")
+
+  extern "lv_obj_t *lv_sw_create(lv_obj_t *, const lv_obj_t *)"
+  extern "void lv_sw_on(lv_obj_t *, lv_anim_enable_t)"
+  extern "void lv_sw_off(lv_obj_t *, lv_anim_enable_t)"
+  extern "void lv_sw_toggle(lv_obj_t *, lv_anim_enable_t)"
+  extern "void lv_sw_set_style(lv_obj_t *, lv_sw_style_t , const lv_style_t *)"
+  extern "void lv_sw_set_anim_time(lv_obj_t *, uint16_t)"
+  extern "bool lv_sw_get_state(const lv_obj_t *)"
+  extern "uint16_t lv_sw_get_anim_time(const lv_obj_t *)"
+
   # lvgl/src/lv_objx/lv_label.h
   enum!(:LV_LABEL_LONG, [
     :EXPAND,     #< Expand the object size to the text size*/
@@ -231,11 +255,6 @@ module LVGL::FFI
   extern "void lv_label_set_align(lv_obj_t *, lv_label_align_t)"
 
   # lvgl/src/lv_objx/lv_page.h
-  enum!(:LV_ANIM, [
-    :OFF,
-    :ON,
-  ])
-  typealias("lv_anim_enable_t", "LV_ANIM")
   enum!(:LV_PAGE_STYLE, [
     :BG,
     :SCRL,

--- a/boot/lib/lvgui/lvgl/ffi.rb
+++ b/boot/lib/lvgui/lvgl/ffi.rb
@@ -470,8 +470,9 @@ module LVGL::FFI
     # Pick from our registry, until we can rehydrate the object type with Fiddle.
     instance = LVGL::LVGroup::REGISTRY[group_p.to_i]
     instance.instance_exec do
-      if @focus_handler_proc
-        @focus_handler_proc.call()
+      prc = @focus_handler_proc_stack.last
+      if prc
+        prc.call()
       end
     end
   end

--- a/boot/lib/lvgui/lvgl/ffi.rb
+++ b/boot/lib/lvgui/lvgl/ffi.rb
@@ -292,6 +292,10 @@ module LVGL::FFI
   extern "void lv_page_glue_obj(lv_obj_t *, bool)"
   extern "void lv_page_set_style(lv_obj_t *, lv_page_style_t, const lv_style_t *)"
   extern "void lv_page_focus(lv_obj_t *, const lv_obj_t *, lv_anim_enable_t)"
+  extern "void lv_page_set_scrl_width(lv_obj_t *, lv_coord_t)"
+  extern "void lv_page_set_scrl_height(lv_obj_t *, lv_coord_t)"
+  extern "lv_coord_t lv_page_get_scrl_width(const lv_obj_t *)"
+  extern "lv_coord_t lv_page_get_scrl_height(const lv_obj_t *)"
 
 
   # lvgl/src/lv_objx/lv_kb.h

--- a/boot/lib/lvgui/lvgl/ffi.rb
+++ b/boot/lib/lvgui/lvgl/ffi.rb
@@ -153,10 +153,22 @@ module LVGL::FFI
   bound_method! :handle_lv_event, "void handle_lv_event_(struct _lv_obj_t *, lv_event_t)"
 
   # lvgl/src/lv_objx/lv_btn.h
+
+  enum!(:LV_BTN_STYLE, [
+    :REL,
+    :PR,
+    :TGL_REL,
+    :TGL_PR,
+    :INA,
+  ])
+  typealias("lv_btn_style_t", "LV_BTN_STYLE")
+
   extern "lv_obj_t * lv_btn_create(lv_obj_t *, const lv_obj_t *)"
   extern "void lv_btn_set_ink_in_time(lv_obj_t *, uint16_t)"
   extern "void lv_btn_set_ink_wait_time(lv_obj_t *, uint16_t)"
   extern "void lv_btn_set_ink_out_time(lv_obj_t *, uint16_t)"
+  extern "void lv_btn_set_style(lv_obj_t *, lv_btn_style_t, const lv_style_t *)"
+  extern "const lv_style_t * lv_btn_get_style(const lv_obj_t *, lv_btn_style_t)"
 
   # lvgl/src/lv_objx/lv_cont.h
   #typedef uint8_t lv_layout_t;

--- a/boot/lib/lvgui/lvgl/ffi.rb
+++ b/boot/lib/lvgui/lvgl/ffi.rb
@@ -213,6 +213,9 @@ module LVGL::FFI
   extern "lv_disp_t *lv_disp_get_default()"
   extern "lv_obj_t *lv_scr_act()"
 
+  extern "lv_obj_t * lv_layer_top()"
+  extern "lv_obj_t * lv_layer_sys()"
+
   # lvgl/src/lv_objx/lv_img.h
   extern "lv_obj_t * lv_img_create(lv_obj_t *, const lv_obj_t *)"
   extern "void lv_img_set_src(lv_obj_t *, const void *)"

--- a/boot/lib/lvgui/lvgl/ffi.rb
+++ b/boot/lib/lvgui/lvgl/ffi.rb
@@ -145,8 +145,8 @@ module LVGL::FFI
     # Pick from our registry, until we can rehydrate the object type with Fiddle.
     instance = LVGL::LVObject::REGISTRY[obj_p.to_i]
     instance.instance_exec do
-      if @event_handler_proc
-        @event_handler_proc.call(event)
+      if @__event_handler_proc
+        @__event_handler_proc.call(event)
       end
     end
   end

--- a/boot/lib/lvgui/lvgl/ffi.rb
+++ b/boot/lib/lvgui/lvgl/ffi.rb
@@ -44,6 +44,7 @@ module LVGL::FFI
   extern "bool lv_introspection_is_simulator()"
   extern "bool lv_introspection_is_debug()"
   extern "bool lv_introspection_use_assert_style()"
+  extern "const char * lv_introspection_display_driver()"
 
   # lvgl/src/lv_misc/lv_task.h
   enum!(:LV_TASK_PRIO, [

--- a/boot/lib/lvgui/lvgl/ffi.rb
+++ b/boot/lib/lvgui/lvgl/ffi.rb
@@ -436,6 +436,9 @@ module LVGL::FFI
   extern "void lv_anim_set_path_cb(lv_anim_t *, lv_anim_path_cb_t)"
   extern "void lv_anim_set_values(lv_anim_t *, lv_anim_value_t, lv_anim_value_t)"
 
+  # Colors
+  extern "lv_color_t lv_color_mix(lv_color_t, lv_color_t, uint8_t)"
+
   # Focus groups
   typedef "lv_group_focus_cb_t", "void (*lv_group_focus_cb_t)(struct _lv_group_t *)"
   extern "void lv_anim_core_init()"

--- a/boot/lib/lvgui/lvgl/introspection.rb
+++ b/boot/lib/lvgui/lvgl/introspection.rb
@@ -8,4 +8,7 @@ module LVGL::Introspection
   def self.use_assert_style?()
     LVGL::FFI.lv_introspection_use_assert_style != 0
   end
+  def self.display_driver()
+    LVGL::FFI.lv_introspection_display_driver
+  end
 end

--- a/boot/lib/lvgui/lvgl/lvgl.rb
+++ b/boot/lib/lvgui/lvgl/lvgl.rb
@@ -1,6 +1,7 @@
 module LVGL
   [
     :ANIM,
+    :BTN_STYLE,
     :CONT_STYLE,
     :CURSOR,
     :EVENT,
@@ -251,6 +252,18 @@ module LVGL
 
   class LVButton < LVContainer
     LV_TYPE = :btn
+
+    def get_style(style_type)
+      style = LVGL.ffi_call!(self.class, :get_style, @self_pointer, style_type)
+      LVGL::LVStyle.from_pointer(style)
+    end
+
+    def set_style(style_type, style)
+      # Prevents the object from being collected
+      @_style ||= {}
+      @_style[style_type] = style
+      LVGL.ffi_call!(self.class, :set_style, @self_pointer, style_type, style.lv_style_pointer)
+    end
   end
 
   class LVSwitch < LVObject

--- a/boot/lib/lvgui/lvgl/lvgl.rb
+++ b/boot/lib/lvgui/lvgl/lvgl.rb
@@ -627,4 +627,37 @@ module LVGL
     SD_CARD        = "\xef\x9F\x82" # 63426, 0xF7C2
     NEW_LINE       = "\xef\xA2\xA2" # 63650, 0xF8A2
   end
+
+  # OPA_50 -> OPA::50 is illegal
+  # enum {                  
+  #   LV_OPA_TRANSP = 0,  
+  #   LV_OPA_0      = 0,  
+  #   LV_OPA_10     = 25, 
+  #   LV_OPA_20     = 51, 
+  #   LV_OPA_30     = 76, 
+  #   LV_OPA_40     = 102,
+  #   LV_OPA_50     = 127,
+  #   LV_OPA_60     = 153,
+  #   LV_OPA_70     = 178,
+  #   LV_OPA_80     = 204,
+  #   LV_OPA_90     = 229,
+  #   LV_OPA_100    = 255,
+  #   LV_OPA_COVER  = 255,
+  # };                      
+  module OPA
+    TRANSP = 0
+    COVER = 255
+    HALF = 127 # 50
+
+    # 0-100
+    def self.scale(num)
+      (255*num/100.0).round
+    end
+  end
+
+  module LVColor
+    def self.mix(col1, col2, mix)
+      LVGL::FFI.lv_color_mix(col1, col2, mix)
+    end
+  end
 end

--- a/boot/lib/lvgui/lvgl/lvgl.rb
+++ b/boot/lib/lvgui/lvgl/lvgl.rb
@@ -96,7 +96,7 @@ module LVGL
     }
 
     def initialize(parent = nil, pointer: nil)
-      @event_handler_proc = nil
+      @__event_handler_proc = nil
 
       unless pointer
         parent_ptr =
@@ -155,15 +155,16 @@ module LVGL
     end
 
     def event_handler=(cb_proc)
-      # Hook the handler on-the-fly.
-      unless @event_handler_proc
+      # Hook the handler on-the-fly, assuming it wasn't set if we didn't have
+      # a handler proc.
+      unless @__event_handler_proc
         LVGL.ffi_call!(self.class, :set_event_cb, @self_pointer, LVGL::FFI["handle_lv_event"])
       end
-      @event_handler_proc = cb_proc
+      @__event_handler_proc = cb_proc
     end
 
     def event_handler()
-      @event_handler_proc
+      @__event_handler_proc
     end
 
     def register_userdata()

--- a/boot/lib/lvgui/lvgl/lvgl.rb
+++ b/boot/lib/lvgui/lvgl/lvgl.rb
@@ -61,6 +61,14 @@ module LVGL
     end
   end
 
+  def self.layer_top()
+    LVObject.from_pointer(LVGL::FFI.lv_layer_top())
+  end
+
+  def self.layer_sys()
+    LVObject.from_pointer(LVGL::FFI.lv_layer_sys())
+  end
+
   class LVDisplay
     # This is not actually an object type in LVGL proper.
 

--- a/boot/lib/lvgui/lvgui/base_window.rb
+++ b/boot/lib/lvgui/lvgui/base_window.rb
@@ -24,7 +24,7 @@ module LVGUI
 
       @focus_group = []
       # Dummy object used as a "null" focus
-      LVGL::LVObject.new(@screen).tap do |obj|
+      LVGUI::Dummy.new(@screen).tap do |obj|
         add_to_focus_group(obj)
       end
       reset_focus_group

--- a/boot/lib/lvgui/lvgui/gui.rb
+++ b/boot/lib/lvgui/lvgui/gui.rb
@@ -82,6 +82,17 @@ module LVGUI
     end
   end
 
+  # Used mainly to create an intangible object that the focus ring can default
+  # on so it doesn't focus anything by default.
+  class Dummy < Widget
+    def initialize(parent)
+      super(LVGL::LVObject.new(parent))
+      set_width(0)
+      set_height(0)
+      set_style(LVGL::LVStyle::STYLE_TRANSP)
+    end
+  end
+
   class Button < Widget
     def initialize(parent)
       super(LVGL::LVButton.new(parent))

--- a/boot/lib/lvgui/lvgui/gui.rb
+++ b/boot/lib/lvgui/lvgui/gui.rb
@@ -93,6 +93,22 @@ module LVGUI
     end
   end
 
+  # Horizontal separator between elements
+  class HorizontalSeparator < Widget
+    def initialize(parent)
+      super(LVGL::LVObject.new(parent))
+      set_width(parent.get_width_fit())
+      set_height(1)
+
+      LVGL::LVStyle::STYLE_PLAIN.dup().tap do |style|
+        style.body_main_color = 0x99BBBBBB
+        style.body_grad_color = style.body_main_color
+        style.body_border_width = 0
+        set_style(style)
+      end
+    end
+  end
+
   class Button < Widget
     def initialize(parent)
       super(LVGL::LVButton.new(parent))

--- a/boot/lib/lvgui/lvgui/gui.rb
+++ b/boot/lib/lvgui/lvgui/gui.rb
@@ -67,6 +67,15 @@ module LVGUI
     LVGL::FFI.lvgui_focus_ring_disable()
   end
 
+  module Styles
+    def self.debug(color)
+      LVGL::LVStyle::STYLE_PLAIN.dup.tap do |style|
+        style.body_main_color = color
+        style.body_grad_color = color
+      end
+    end
+  end
+
   # Wraps an LVGL widget.
   class Widget
     def initialize(widget)

--- a/boot/lib/lvgui/lvgui/option_selection.rb
+++ b/boot/lib/lvgui/lvgui/option_selection.rb
@@ -1,0 +1,512 @@
+# Wraps multiple elements in a line element that allows the end-user to pick
+# one option among a selection.
+class LVGUI::OptionSelection < LVGUI::Widget
+  attr_reader :options
+  attr_reader :selected
+
+  # Cached accessor to the container styles
+  def self.container_style()
+    return @@_container_styles if class_variable_defined?(:@@_container_styles)
+
+    cont = LVGL::LVContainer.new()
+    # Dup to ensure we don't modify the existing styles
+    @@_container_styles = cont.get_style(LVGL::CONT_STYLE::MAIN).dup()
+    cont.del()
+    @@_container_styles
+  end
+
+  # The overlay_location will hold the actual "selection" interface
+  # It should be a "layer" on top of your app, which does not scroll with the
+  # app's contents.
+  def initialize(parent, overlay_location)
+    super(FlatishButtonBase.new(parent))
+
+    # The "overlay" window, which actually includes the options you select from.
+    # (Implementation at the bottom of this file.)
+    @overlay = Overlay.new(self)
+    @overlay.on_select = ->(value) { self.select(value) }
+
+    # Selected option
+    @selected = nil
+
+    # Add a container for the labels
+    @label_container = LVGL::LVContainer.new(self).tap do |container|
+      tr_style = LVGL::LVStyle::STYLE_TRANSP.dup
+      tr_style.body_padding_left = 0
+      tr_style.body_padding_right = 0
+      container.set_style(LVGL::CONT_STYLE::MAIN, tr_style)
+
+      # The layout is a column, two distinct lines, top to bottom.
+      container.set_layout(LVGL::LAYOUT::COL_L)
+
+      # Width will be computed in set_width; automatic layout from LVGL fails.
+      container.set_fit2(LVGL::FIT::NONE, LVGL::FIT::TIGHT)
+
+      container.set_click(false)
+    end
+
+    # Add the main label
+    @main_label = LVGL::LVLabel.new(@label_container).tap do |label|
+      label.set_long_mode(LVGL::LABEL_LONG::BREAK)
+      label.set_click(false)
+    end
+    set_label(nil)
+
+    # The chosen option label (second row, optional)
+    @chosen_option_label = LVGL::LVLabel.new(@label_container).tap do |label|
+      style = label.get_style(LVGL::LABEL_STYLE::MAIN).dup()
+      # It's a bit more subdued
+      style.text_color = 0xffaaaaaa
+      label.set_style(LVGL::LABEL_STYLE::MAIN, style)
+      label.set_long_mode(LVGL::LABEL_LONG::BREAK)
+      label.set_click(false)
+    end
+    set_chosen_option_label(nil)
+
+    # Drill down icon
+    @icon = LVGL::LVLabel.new(self).tap do |icon|
+      icon.set_text("\uF054")
+      icon.set_click(false)
+    end
+
+    # Call on @widget since we re-define event_handler=() for users of this class.
+    @widget.event_handler = ->(event) {
+      case event
+      when LVGL::EVENT::RELEASED
+        @overlay.open()
+      end
+    }
+
+    # Defaults to full width
+    self.set_width(parent.get_width())
+  end
+
+  # Like the parent function.
+  # Also recomputes the layout of internal elements
+  def set_width(width)
+    super(width)
+
+    # Resize the label container to fill, working around segfault.
+    container_padding = get_style(LVGL::BTN_STYLE::REL).body_padding_right
+    @label_container.set_width(self.get_width_fit - @icon.get_width - container_padding*2)
+    @main_label.set_width(@label_container.get_width)
+    @chosen_option_label.set_width(@label_container.get_width)
+  end
+
+  # Sets the main label, optionally hiding it.
+  # When hidden, it takes no vertical space in the layout.
+  def set_label(text)
+    @main_label_text = text
+    @main_label.set_text(text)
+    if text
+      @main_label.set_hidden(false)
+    else
+      @main_label.set_hidden(true)
+    end
+  end
+
+  def get_label()
+    @main_label_text
+  end
+
+  # Set all available options, ordered list of pairs.
+  def set_options(options)
+    @options = options
+    if options.map(&:first).include?(@selected)
+      # Refresh label
+      select(@selected)
+    else
+      # Unset value (and label)
+      @selected = nil
+      set_chosen_option_label("")
+    end
+  end
+
+  # Force a selection for the given value
+  def select(value)
+    label = @options.to_h[value]
+
+    # Fails silently to change on wrong option
+    return unless label
+
+    @selected = value
+    set_chosen_option_label(label)
+
+    if @event_handler
+      @event_handler.call(LVGL::EVENT::VALUE_CHANGED)
+    end
+  end
+
+  def event_handler=(prc)
+    @event_handler = prc
+  end
+
+  def event_handler()
+    @event_handler
+  end
+
+  # Open the overlay; this is how you select a new value.
+  def open()
+    @overlay.open()
+  end
+
+  private
+
+  # Sets the description label, optionally hiding it.
+  # When hidden, it takes no vertical space in the layout.
+  def set_chosen_option_label(text)
+    @chosen_option_label.set_text(text)
+  end
+end
+
+class LVGUI::OptionSelection::FlatishButtonBase < LVGUI::Widget
+  def initialize(parent)
+    super(LVGL::LVButton.new(parent))
+
+    # Styles
+    [
+      :REL,
+      :PR,
+      :TGL_REL,
+      :TGL_PR,
+      :INA,
+    ].each do |sym|
+      get_style(LVGL::BTN_STYLE.const_get(sym)).dup.tap do |style|
+        style.body_radius = 0
+
+        ## Button paddings are quite harsh by default
+        style.body_padding_left = LVGUI::OptionSelection.container_style.body_padding_inner
+        style.body_padding_right = LVGUI::OptionSelection.container_style.body_padding_inner
+        style.body_padding_top = style.body_padding_top / 2
+        style.body_padding_bottom = style.body_padding_bottom / 2
+        style.body_shadow_width = 0
+        set_style(LVGL::BTN_STYLE.const_get(sym), style)
+      end
+    end
+
+    get_style(LVGL::BTN_STYLE::REL).dup.tap do |style|
+      main_color = LVGUI::OptionSelection.container_style.body_main_color
+      style.body_grad_color = LVGL::LVColor.mix(style.body_grad_color, main_color, LVGL::OPA.scale(30))
+      style.body_main_color = LVGL::LVColor.mix(style.body_main_color, main_color, LVGL::OPA.scale(30))
+      set_style(LVGL::BTN_STYLE::REL, style)
+    end
+
+    set_ink_in_time(200)
+    set_ink_wait_time(100)
+    set_ink_out_time(500)
+
+    # Set layout for the line, labels left, "drill down icon" right, so a row.
+    set_layout(LVGL::LAYOUT::ROW_M)
+    set_fit2(LVGL::FIT::NONE, LVGL::FIT::TIGHT)
+  end
+end
+
+# Version of the button with a built-in label.
+class LVGUI::OptionSelection::OptionButton < LVGUI::OptionSelection::FlatishButtonBase
+  class Pip < LVGUI::Widget
+    def initialize(parent, background)
+      @background = background
+      super(LVGL::LVObject.new(parent))
+      set_height(25)
+      set_width(get_height())
+      get_style().dup().tap do |style|
+        style.body_radius = get_height()/2 - 1
+        style.body_border_width = 4
+        style.body_border_opa = LVGL::OPA::COVER
+        style.body_border_color = 0xFFFFFFFF
+        style.body_main_color = @background
+        style.body_grad_color = @background
+        set_style(style)
+      end
+      set_opa_scale_enable(true)
+      set_opa_scale(LVGL::OPA.scale(20))
+    end
+
+    def selected=(val)
+      style = get_style()
+      if val
+        set_opa_scale(LVGL::OPA.scale(90))
+        style.body_main_color = style.body_border_color
+        style.body_grad_color = style.body_border_color
+      else
+        set_opa_scale(LVGL::OPA.scale(50))
+        style.body_main_color = @background
+        style.body_grad_color = @background
+      end
+    end
+  end
+
+  def initialize(parent)
+    super(parent)
+
+    set_fit2(LVGL::FIT::FILL, LVGL::FIT::TIGHT)
+
+    # Add a container for the labels
+    @label_container = LVGL::LVContainer.new(self).tap do |container|
+      tr_style = LVGL::LVStyle::STYLE_TRANSP.dup
+      tr_style.body_padding_left = 0
+      tr_style.body_padding_right = 0
+      container.set_style(LVGL::CONT_STYLE::MAIN, tr_style)
+
+      # The layout is a row, [icon] [label              ]
+      container.set_layout(LVGL::LAYOUT::ROW_M)
+      container.set_fit2(LVGL::FIT::FILL, LVGL::FIT::TIGHT)
+
+      container.set_click(false)
+    end
+
+    @icon = Pip.new(@label_container, get_style(LVGL::BTN_STYLE::REL).body_main_color)
+
+    @label = LVGL::LVLabel.new(@label_container)
+    @label.set_long_mode(LVGL::LABEL_LONG::BREAK)
+    @label.set_width(get_width_fit - @label.get_x() - @icon.get_x())
+
+    # The defaults for FlatishButtonBase are too small to be comfortably
+    # touchable as a one-liner element.
+    [
+      :REL,
+      :PR,
+      :TGL_REL,
+      :TGL_PR,
+      :INA,
+    ].each do |sym|
+      get_style(LVGL::BTN_STYLE.const_get(sym)).tap do |style|
+        style.body_padding_top = style.body_padding_top * 2
+        style.body_padding_bottom = style.body_padding_bottom * 2
+      end
+    end
+  end
+
+  def set_label(label)
+    @label.set_text(label)
+  end
+
+  def selected=(val)
+    @icon.selected = val
+  end
+end
+
+# Implementation of the scrollable area, which depends on the implementation of
+# the OptionSelection overlay.
+class LVGUI::OptionSelection::ScrollableArea < LVGUI::Widget
+  def initialize(parent, overlay)
+    # Remove all styling
+    style = LVGL::LVStyle::STYLE_TRANSP.dup
+    # Padding to zero in the actual scrolling widget makes the scrollbar visible
+    style.body_padding_left = 0
+    style.body_padding_right = 0
+    style.body_padding_top = 0
+    style.body_padding_bottom = 0
+
+    @overlay = overlay
+    # A "holder" widget to work around idiosyncrasies of pages.
+    @holder = LVGL::LVContainer.new(parent)
+    @holder.set_fit2(LVGL::FIT::FILL, LVGL::FIT::TIGHT)
+    @holder.set_style(LVGL::CONT_STYLE::MAIN, style)
+
+    # The actual widget we interact with
+    super(LVGL::LVPage.new(@holder))
+
+    set_style(LVGL::PAGE_STYLE::BG, style)
+    set_style(LVGL::PAGE_STYLE::SCRL, style)
+    set_fit2(LVGL::FIT::FILL, LVGL::FIT::TIGHT)
+
+    # Make this scroll
+    set_scrl_layout(LVGL::LAYOUT::COL_M)
+
+    refresh
+  end
+
+  # Re-computes the scrollable area's metrics.
+  def refresh()
+    @holder.set_height(@overlay.get_scrollable_area)
+
+    # First reduce to a minimum
+    set_fit2(LVGL::FIT::FILL, LVGL::FIT::NONE)
+    set_height(0)
+
+    # Then re-compute height according to LVGL
+    set_fit2(LVGL::FIT::FILL, LVGL::FIT::TIGHT)
+
+    if get_height_fit > @overlay.get_scrollable_area
+      # If too big, resize manually
+      @holder.set_fit2(LVGL::FIT::FILL, LVGL::FIT::NONE)
+      set_fit2(LVGL::FIT::FILL, LVGL::FIT::NONE)
+      set_height(@overlay.get_scrollable_area)
+    else
+      # Otherwise fit tightly!
+      @holder.set_fit2(LVGL::FIT::FILL, LVGL::FIT::TIGHT)
+    end
+  end
+
+  def set_height(v)
+    # Send to the original function
+    method_missing(:set_height, v)
+    @holder.set_height(v)
+  end
+
+  def set_hidden(v)
+    @holder.set_hidden(v)
+  end
+end
+
+class LVGUI::OptionSelection::Overlay < LVGUI::Widget
+  def initialize(linked_select)
+    parent = LVGL.layer_top
+    super(LVGL::LVContainer.new(parent))
+    @linked_select = linked_select
+
+    # Dummy object used as a "null" focus
+    @dummy = LVGUI::Dummy.new(linked_select)
+
+    # Fill the parent with this background overlay
+    set_width(parent.get_width())
+    set_height(parent.get_height())
+    set_x(0)
+    set_y(0)
+
+    set_layout(LVGL::LAYOUT::CENTER)
+
+    # Make the backdrop half-transparent
+    get_style(LVGL::CONT_STYLE::MAIN).dup().tap do |style|
+      style.body_opa = LVGL::OPA::HALF
+      # Compute from the default paddings
+      style.body_padding_left   *= 2
+      style.body_padding_right  *= 2
+      style.body_padding_top    *= 4
+      style.body_padding_bottom *= 4
+      set_style(LVGL::CONT_STYLE::MAIN, style)
+    end
+
+    # Hide by default
+    set_hidden(true)
+
+    # Actual items will live in this container, which will live on top of
+    # the "page overlay".
+    @container = LVGL::LVContainer.new(self).tap do |cont|
+      cont.set_layout(LVGL::LAYOUT::COL_M)
+      cont.set_fit2(LVGL::FIT::FILL, LVGL::FIT::TIGHT)
+    end
+
+    # Add a label for the title
+    @title = LVGL::LVLabel.new(@container).tap do |label|
+      label.set_long_mode(LVGL::LABEL_LONG::BREAK)
+      label.set_align(LVGL::LABEL_ALIGN::CENTER)
+      label.set_width(@container.get_width_fit())
+      label.set_click(false)
+    end
+
+    LVGUI::HorizontalSeparator.new(@container)
+
+    # This is where the content will live, scrollable, without affecting
+    # either the title or the cancel button.
+    @options = LVGUI::OptionSelection::ScrollableArea.new(@container, self)
+
+    LVGUI::HorizontalSeparator.new(@container)
+
+    # A button to cancel out. Touching the overlay background does exit too,
+    # but that's not user-friendly, give them a "real" option.
+    @cancel = LVGUI::Button.new(@container).tap do |button|
+      button.set_label("Cancel")
+      button.event_handler = ->(event) do
+        case event
+        when LVGL::EVENT::RELEASED
+          self.close()
+        end
+      end
+    end
+
+    # Close (without changing selection) on overlay press
+    self.event_handler = ->(event) {
+      case event
+      when LVGL::EVENT::RELEASED
+        self.close()
+      end
+    }
+  end
+
+  def open()
+    # Refresh the title
+    set_title(@linked_select.get_label())
+
+    # Create a new focus group on the "stack"
+    LVGUI.focus_group.push()
+
+    # Ensure we scroll down as needed to the focused element
+    LVGUI.focus_group.focus_handler = ->() do
+      @options.focus(
+        LVGUI.focus_group.get_focused,
+        LVGL::ANIM::OFF
+      )
+    end
+
+    # Start with the dummy item (default selected)
+    LVGUI.focus_group.add_obj(@dummy)
+
+    # Remove children
+    @options.clean()
+
+    selected = @linked_select.selected
+    
+    # Then make fresh children, ensuring labels are updated, and the selected
+    # state is updated too.
+    @linked_select.options.each do |pair|
+      sym, label = pair
+      LVGUI::OptionSelection::OptionButton.new(@options).tap do |option|
+        option.selected = (selected == sym)
+        option.set_label(label)
+        option.event_handler = ->(event) do
+          case event
+          when LVGL::EVENT::RELEASED
+            if @on_select_handler
+              @on_select_handler.call(sym)
+            end
+            self.close()
+          end
+        end
+        # Don't forget to add to the focus group
+        LVGUI.focus_group.add_obj(option)
+      end
+    end
+
+    # Refresh the metrics of the scrollable area
+    @options.refresh()
+
+    # Add the cancel button too, otherwise we're in for a bad time.
+    LVGUI.focus_group.add_obj(@cancel)
+
+    set_hidden(false)
+  end
+
+  def close()
+    LVGUI.focus_group.pop()
+    set_hidden(true)
+  end
+
+  def set_title(text)
+    @title.set_text(text)
+  end
+
+  # For the scrollable area widget
+  def get_scrollable_area()
+    return 0 unless @options && @cancel
+
+    @container.set_fit2(LVGL::FIT::FILL, LVGL::FIT::FLOOD)
+    @options.set_hidden(true)
+    offset = height = @cancel.get_y() + @cancel.get_height()
+    height = get_height_fit() - offset
+    @options.set_hidden(false)
+    @container.set_fit2(LVGL::FIT::FILL, LVGL::FIT::TIGHT)
+
+    height
+  end
+
+  # Will call this proc with the new value on selection.
+  def on_select=(prc)
+    @on_select_handler = prc
+  end
+
+  def on_select()
+    @on_select_handler
+  end
+end

--- a/boot/lib/lvgui/lvgui/switch_line.rb
+++ b/boot/lib/lvgui/lvgui/switch_line.rb
@@ -1,0 +1,126 @@
+# Wraps an +lv_sw+ and other elements into a widget intended to be added as a
+# line to a window.
+# This imitates the common control found in mobile UIs.
+class LVGUI::SwitchLine < LVGUI::Widget
+  def initialize(parent)
+    super(LVGL::LVContainer.new(parent))
+
+    # Remove container "presence"
+    tr_style = LVGL::LVStyle::STYLE_TRANSP.dup
+    tr_style.body_padding_left = 0
+    tr_style.body_padding_right = 0
+    set_style(LVGL::CONT_STYLE::MAIN, tr_style)
+
+    # Set layout for the line, labels left, toggle right, so a row.
+    set_layout(LVGL::LAYOUT::ROW_M)
+    set_fit2(LVGL::FIT::FILL, LVGL::FIT::TIGHT)
+
+    # Add a container for the labels
+    @label_container = LVGL::LVContainer.new(self).tap do |container|
+      tr_style = LVGL::LVStyle::STYLE_TRANSP.dup
+      container.set_style(LVGL::CONT_STYLE::MAIN, tr_style)
+
+      # The layout is a column, two distinct lines, top to bottom.
+      container.set_layout(LVGL::LAYOUT::COL_L)
+
+      # segfault on horizontal fill here...
+      container.set_fit2(LVGL::FIT::NONE, LVGL::FIT::TIGHT)
+    end
+
+    # Add the main label
+    @main_label = LVGL::LVLabel.new(@label_container).tap do |label|
+      label.set_long_mode(LVGL::LABEL_LONG::BREAK)
+    end
+    set_label(nil)
+
+    # The description label (second row, optional)
+    @description_label = LVGL::LVLabel.new(@label_container).tap do |label|
+      style = label.get_style(LVGL::LABEL_STYLE::MAIN).dup()
+      # It's a bit more subdued
+      style.text_color = 0xffaaaaaa
+      label.set_style(LVGL::LABEL_STYLE::MAIN, style)
+      label.set_long_mode(LVGL::LABEL_LONG::BREAK)
+    end
+    set_description(nil)
+
+    # Add the actual toggle control
+    @switch = LVGL::LVSwitch.new(self)
+
+    padding = @label_container.get_style(LVGL::CONT_STYLE::MAIN).body_padding_inner
+    # Resize the label container to fill, working around segfault.
+    @label_container.set_width(self.get_width - @switch.get_width - padding)
+    @main_label.set_width(@label_container.get_width)
+    @description_label.set_width(@label_container.get_width)
+  end
+
+  # Sets the main label, optionally hiding it.
+  # When hidden, it takes no vertical space in the layout.
+  def set_label(text)
+    @main_label.set_text(text)
+    if text
+      @main_label.set_hidden(false)
+    else
+      @main_label.set_hidden(true)
+    end
+  end
+
+  # Sets the description label, optionally hiding it.
+  # When hidden, it takes no vertical space in the layout.
+  def set_description(text)
+    @description_label.set_text(text)
+    if text
+      @description_label.set_hidden(false)
+    else
+      @description_label.set_hidden(true)
+    end
+  end
+
+  # Hook the handler to the toggle *and* the whole row.
+  def event_handler=(handler)
+    # Directly hook the handler to the switch event handler
+    @switch.event_handler=(handler)
+
+    # Proc to hook the same event on multiple UI elements
+    delegate_to_switch = ->(event) {
+      case event
+      when LVGL::EVENT::RELEASED
+        @switch.toggle(true)
+        @switch.event_handler.call(LVGL::EVENT::VALUE_CHANGED)
+      end
+    }
+
+    # Hook on the row, otherwise we get a small dead zone in the padding
+    # between the toggle and the label container
+    @widget.event_handler=(delegate_to_switch)
+    # Then also hook to the label container
+    @label_container.event_handler=(delegate_to_switch)
+  end
+
+  def event_handler()
+    @switch.event_handler
+  end
+
+  # Proxies a few functions to the switch
+
+  def on(*args)
+    @switch.on(*args)
+  end
+
+  def off(*args)
+    @switch.off(*args)
+  end
+
+  def toggle(*args)
+    @switch.toggle(*args)
+  end
+
+  def get_state()
+    @switch.get_state()
+  end
+
+  # Access the actual control.
+  # This is meant to be used so this can be added to the focus group.
+  def switch_control()
+    @switch
+  end
+end

--- a/boot/lib/lvgui/lvgui/windows.rb
+++ b/boot/lib/lvgui/lvgui/windows.rb
@@ -25,6 +25,17 @@ module LVGUI
     end
   end
 
+  module BaseUIElements
+    def add_main_text(text, alignment: LVGL::LABEL_ALIGN::CENTER)
+      LVGL::LVLabel.new(@container).tap do |label|
+        label.set_long_mode(LVGL::LABEL_LONG::BREAK)
+        label.set_text(text)
+        label.set_align(alignment)
+        label.set_width(@container.get_width_fit)
+      end
+    end
+  end
+
   module Window
     # Include with +include LVGUI::Window::WithBackButton+ and
     # use e.g. +goes_back_to ->() { MainWindow.instance }+

--- a/boot/lib/lvgui/lvgui/windows.rb
+++ b/boot/lib/lvgui/lvgui/windows.rb
@@ -34,6 +34,25 @@ module LVGUI
         label.set_width(@container.get_width_fit)
       end
     end
+
+    def add_switch(label, description: nil, initial: false)
+      LVGUI::SwitchLine.new(@container).tap do |switch|
+        add_to_focus_group(switch.switch_control)
+        if initial
+          switch.on
+        else
+          switch.off
+        end
+        switch.set_label(label)
+        switch.set_description(description)
+        switch.event_handler = ->(event) do
+          case event
+          when LVGL::EVENT::VALUE_CHANGED
+            yield(switch.get_state())
+          end
+        end
+      end
+    end
   end
 
   module Window

--- a/boot/lib/lvgui/lvgui/windows.rb
+++ b/boot/lib/lvgui/lvgui/windows.rb
@@ -53,6 +53,22 @@ module LVGUI
         end
       end
     end
+
+    def add_select(label, options, initial: nil)
+      LVGUI::OptionSelection.new(@container, @screen).tap do |select|
+        select.set_label(label)
+        select.set_options(options)
+        select.select(initial)
+        add_to_focus_group(select)
+
+        select.event_handler = ->(event) do
+          case event
+          when LVGL::EVENT::VALUE_CHANGED
+            yield(select.selected())
+          end
+        end
+      end
+    end
   end
 
   module Window

--- a/boot/script-loader/mruby-lvgui-native-fragment/lvgui.nix
+++ b/boot/script-loader/mruby-lvgui-native-fragment/lvgui.nix
@@ -93,13 +93,13 @@ let
 in
   stdenv.mkDerivation {
     pname = "lvgui";
-    version = "2020-11-20";
+    version = "2021-01-23";
 
     src = fetchFromGitHub {
       repo = "lvgui";
       owner = "mobile-nixos";
-      rev = "c94c3916012f5615af027389e77e7a974cc3e634";
-      sha256 = "16dfdky5v72jqs9v22h1k73g74bnif6fg52vhxw2k8sh6mw1cmzp";
+      rev = "b971f2dc954b4177aed53c0134a77e12db415b98";
+      sha256 = "02y5m495a9ax7c6fhr5qkpy0c0a6szh7nnmkixzxmq9k425cd196";
     };
 
     # Document `LVGL_ENV_SIMULATOR` in the built headers.

--- a/boot/script-loader/mruby-lvgui-native-fragment/lvgui.nix
+++ b/boot/script-loader/mruby-lvgui-native-fragment/lvgui.nix
@@ -13,6 +13,37 @@ let
     SDL2
   ];
 
+  # Minified libinput, both for size and cross-compilation.
+  libinput = (pkgs.libinput.override({
+    # libwacom doesn't cross-compile at the moment
+    libwacom = null;
+
+    documentationSupport = false;
+    doxygen = null;
+    graphviz = null;
+
+    eventGUISupport = false;
+    cairo = null;
+    glib = null;
+    gtk3 = null;
+
+    testsSupport = false;
+    check = null;
+    valgrind = null;
+    python3 = null;
+  })).overrideAttrs(old: {
+    buildInputs = with pkgs; [
+      libevdev     
+      mtdev        
+    ];
+    nativeBuildInputs = old.nativeBuildInputs ++ [
+      pkgs.buildPackages.udev
+    ];
+    mesonFlags = old.mesonFlags ++ [
+      "-Dlibwacom=false"
+    ];
+  });
+
   # Allow libevdev to cross-compile.
   libevdev = (pkgs.libevdev.override({
     python3 = null;
@@ -83,6 +114,7 @@ in
 
     buildInputs = [
       libevdev
+      libinput
       libxkbcommon
     ]
     ++ optionals withSimulator simulatorDeps

--- a/boot/script-loader/mruby-lvgui-native-fragment/lvgui.nix
+++ b/boot/script-loader/mruby-lvgui-native-fragment/lvgui.nix
@@ -4,6 +4,7 @@
 , fetchFromGitHub
 , pkg-config
 , SDL2
+, libdrm
 , withSimulator ? false
 }:
 
@@ -114,6 +115,7 @@ in
 
     buildInputs = [
       libevdev
+      libdrm
       libinput
       libxkbcommon
     ]

--- a/examples/hello/app/main.rb
+++ b/examples/hello/app/main.rb
@@ -1,3 +1,10 @@
 GUI::MainWindow.instance.present
 
-LVGUI.main_loop
+if LVGL::Introspection.simulator?
+  LVGUI.main_loop do
+    # Torture test
+    GC.start()
+  end
+else
+  LVGUI.main_loop
+end

--- a/examples/hello/app/windows/display_validation.rb
+++ b/examples/hello/app/windows/display_validation.rb
@@ -27,6 +27,19 @@ EOF
       word("Red",   0xFF0000)
       word("Green", 0x00FF00)
       word("Blue",  0x0000FF)
+
+
+      LVGL::LVLabel.new(@container).tap do |label|
+text = <<EOF
+
+LVGUI is currently using the "#{LVGL::Introspection.display_driver}" display driver.
+
+EOF
+        label.set_long_mode(LVGL::LABEL_LONG::BREAK)
+        label.set_text(text)
+        label.set_align(LVGL::LABEL_ALIGN::CENTER)
+        label.set_width(@container.get_width_fit)
+      end
     end
 
     def word(text, color)

--- a/examples/hello/app/windows/lvguitesting.rb
+++ b/examples/hello/app/windows/lvguitesting.rb
@@ -1,0 +1,23 @@
+module GUI
+  class LVGUITestingWindow < LVGUI::BaseWindow
+    include LVGUI::BaseUIElements
+    include LVGUI::ButtonPalette
+    include LVGUI::Window::WithBackButton
+    goes_back_to ->() { MainWindow.instance }
+
+    def initialize()
+      super()
+
+      add_main_text(%Q{The different UI toolkit controls are shown here.\n\nThis is used to validate UI behaviour on different platforms.\n\n})
+
+      # Add a toggle switch
+      @switch = add_switch(
+        "Toggle switch",
+        description: "This label will mirror its value in the description field after the first activation.",
+        initial: true,
+      ) do |new_state|
+        @switch.set_description(new_state.inspect)
+      end
+    end
+  end
+end

--- a/examples/hello/app/windows/lvguitesting.rb
+++ b/examples/hello/app/windows/lvguitesting.rb
@@ -8,15 +8,34 @@ module GUI
     def initialize()
       super()
 
-      add_main_text(%Q{The different UI toolkit controls are shown here.\n\nThis is used to validate UI behaviour on different platforms.\n\n})
+      add_main_text(%Q{The different UI toolkit controls are shown here.\n\nThis is used to validate UI behaviour on different platforms.\n})
+
+      LVGUI::HorizontalSeparator.new(@container)
+
+      add_main_text(%Q{\nThe description label here will mirror the switch's value.\n})
 
       # Add a toggle switch
       @switch = add_switch(
         "Toggle switch",
-        description: "This label will mirror its value in the description field after the first activation.",
+        description: "true",
         initial: true,
       ) do |new_state|
         @switch.set_description(new_state.inspect)
+      end
+
+      LVGUI::HorizontalSeparator.new(@container)
+
+      add_main_text(%Q{\nThese items allow choosing among many options\n})
+
+      @select = add_select("Options selection", [
+        [:A, "Option A"],
+        [:B, "Option B"],
+        [:C, "Option C"],
+        [:D, "Option D"],
+        #[:_Z, "An option with a label that is large enough to cause a line wrap"],
+        #[:_X, "Commas wrap snuggly,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,"],
+      ]) do |new_state|
+        p new_state
       end
     end
   end

--- a/examples/hello/app/windows/main.rb
+++ b/examples/hello/app/windows/main.rb
@@ -1,15 +1,11 @@
 module GUI
   class MainWindow < LVGUI::BaseWindow
+    include LVGUI::BaseUIElements
     include LVGUI::ButtonPalette
     def initialize()
       super()
 
-      LVGL::LVLabel.new(@container).tap do |label|
-        label.set_long_mode(LVGL::LABEL_LONG::BREAK)
-        label.set_text(%Q{Your device booted to\nstage-2 of a NixOS system successfully!\n\nSelect from the following options})
-        label.set_align(LVGL::LABEL_ALIGN::CENTER)
-        label.set_width(@container.get_width_fit)
-      end
+      add_main_text(%Q{Your device booted to\nstage-2 of a NixOS system successfully!\n\nSelect from the following options})
 
       add_buttons([
         ["Display validation", ->() { DisplayValidationWindow.instance.present }],

--- a/examples/hello/app/windows/main.rb
+++ b/examples/hello/app/windows/main.rb
@@ -12,6 +12,7 @@ module GUI
         ["Input devices information", ->() { InputsWindow.instance.present }],
         ["Disks information", ->() { DisksWindow.instance.present }],
         ["Logs", ->() { LogsWindow.instance.present }],
+        ["GUI testing", ->() { LVGUITestingWindow.instance.present }],
         ["About", ->() { AboutWindow.instance.present }],
         ["Quit",  ->() { QuitWindow.instance.present }],
       ])

--- a/examples/hello/configuration.nix
+++ b/examples/hello/configuration.nix
@@ -57,6 +57,10 @@ in
     log.level = "DEBUG";
   };
 
+  # Ensure hello-gui isn't trampled over by the TTY
+  systemd.services."getty@tty1" = {
+    enable = false;
+  };
   systemd.services.hello-gui = {
     description = "GUI for the hello example of Mobile NixOS";
     wantedBy = [ "multi-user.target" ];

--- a/examples/hello/configuration.nix
+++ b/examples/hello/configuration.nix
@@ -114,4 +114,9 @@ in
   system.build = {
     app-simulator = pkgs.callPackage ./app/simulator.nix {};
   };
+
+  # Override stage-0 support for this example app.
+  # It's only noise, and the current stage-0 is not able to boot anything else
+  # than a system it was built for anyway.
+  mobile.quirks.supportsStage-0 = lib.mkForce false;
 }

--- a/examples/target-disk-mode/app/simulator.nix
+++ b/examples/target-disk-mode/app/simulator.nix
@@ -9,11 +9,7 @@
 
 let
   script-loader = mobile-nixos.stage-1.script-loader.override({
-    mrbgems = mrbgems // {
-      mruby-lvgui = callPackage ../../../overlay/mruby-builder/mrbgems/mruby-lvgui {
-        withSimulator = true;
-      };
-    };
+    withSimulator = true;
   });
   applet = callPackage ./. {};
 in

--- a/examples/target-disk-mode/app/windows/main.rb
+++ b/examples/target-disk-mode/app/windows/main.rb
@@ -1,5 +1,6 @@
 module GUI
   class MainWindow < LVGUI::BaseWindow
+    include LVGUI::BaseUIElements
     include LVGUI::ButtonPalette
 
     def run(*cmd)
@@ -9,23 +10,26 @@ module GUI
 
     def initialize()
       super()
+      add_main_text("Your device should act as a USB mass storage.\n\nEject it from your system before rebooting.")
 
-      LVGL::LVLabel.new(@container).tap do |label|
-        label.set_long_mode(LVGL::LABEL_LONG::BREAK)
-        label.set_text("Your device should act as a USB mass storage.\n\nEject it from your system before rebooting.")
-        label.set_align(LVGL::LABEL_ALIGN::CENTER)
-        label.set_width(@container.get_width_fit)
+      # A reminder for simulator users
+      if LVGL::Introspection.simulator?
+        add_main_text("\n(Since this is running in the simulator, this actually does nothing...)\n")
       end
 
-      # TODO: At some point, allow selecting the storage device to present.
-      # Though, this will need better coordination with a "gadget mode tool" system
-      # that will be able to re-do the USB gadget work.
-      add_buttons([
-        ["Reboot", ->() { run("reboot") }],
-        ["Reboot to recovery", ->() { run("reboot recovery") }],
-        ["Reboot to bootloader", ->() { run("reboot bootloader") }],
-        ["Power off", ->() { run("poweroff") }],
-      ])
+      # The exit options
+      if LVGL::Introspection.simulator?
+        add_buttons([
+          ["Exit", ->() { exit 0 }],
+        ])
+      else
+        add_buttons([
+          ["Reboot", ->() { run("reboot") }],
+          ["Reboot to recovery", ->() { run("reboot recovery") }],
+          ["Reboot to bootloader", ->() { run("reboot bootloader") }],
+          ["Power off", ->() { run("poweroff") }],
+        ])
+      end
     end
   end
 end


### PR DESCRIPTION
First, to the lvgui project itself:

 - Support `libinput` as an input source
 - Try `DRM` before falling back to `fbdev`

Then, in LVGUI

 - Added a *toggle switch* control
 - Added an *select* control

# `libinput` support

Compared to `evdev`, really there shouldn't be any differences. Except in practice there is. One difference is that there is no need for a hack to detect the input type (touchscreen vs. mouse).

Another is that `libinput` supports calibration matrices. It's not been needed for any in-tree devices, but an x86 tablet I own requires it (per-device though). While the support isn't in Mobile NixOS yet, it should be possible to add handle this.

Additionally, working with libinput feels much better, as it does things like translate touchpad events to relative movements for you (me).

# `DRM` support

This is a big one! `SDM845` devices, like the Pixel 3 family and `razer-cheryl2` don't have a working `fbdev` backend. Luckily, it seems Android works with DRM, and we also can. Furthermore `asus-dumo` actually has bad behaviours with `fbdev` available, where the display cannot suspend/resume and gets into a *bad place*.

It might not actually work as implemented right now. I still need to test on SDM845, but for `asus-dumo` it does work as expected.

For SDM845 it might still require page flipping or something similar to be added. Though known working DRM sample programs exist, and were used as a basis for the reworked DRM driver.

# *toggle switch*

![image](https://user-images.githubusercontent.com/132835/105568541-2bbf2200-5d08-11eb-9abf-4f9fc67c88c2.png)

The description is configured by the user. It does not automatically mirror the value, but it is trivial enough for the user to handle it by themselves.

It's meant to describe a boolean state (duh).

It will soon be used to optionally disable `kexec`ing into a generation's kernel from stage-0.

# *select*

![image](https://user-images.githubusercontent.com/132835/105568562-6de86380-5d08-11eb-9ee6-150fb96eef31.png)

![image](https://user-images.githubusercontent.com/132835/105568571-7ccf1600-5d08-11eb-886b-7ffc907517f5.png)

It is meant to allow choosing *one* option among a list. It shows up as an overlay.

A few uses are thought of, but nothing concrete planned. It just felt right to implement it at this moment while working on this. It might be used in target disk mode to select a partition or disk to export.

# TODO

 - [x] test DRM on `razer-cheryl2`