### PR TITLE
boot/init: Work around gadget teardown errors

### DIFF
--- a/boot/init/tasks/switch_root.rb
+++ b/boot/init/tasks/switch_root.rb
@@ -191,7 +191,12 @@ class Tasks::SwitchRoot < SingletonTask
     if will_kexec?
       if Tasks.constants.include?(:SetupGadgetMode)
         Progress.exec_with_message("Tearing down USB Gadget mode") do
-          Tasks::SetupGadgetMode.instance.teardown()
+          begin
+            Tasks::SetupGadgetMode.instance.teardown()
+          rescue => e
+            $logger.fatal("Caught an error during teardown for kexec...")
+            $logger.fatal(e.inspect)
+          end
         end
       end
 


### PR DESCRIPTION
Those errors are non-issues.

Tear-down should, anyway, be implemented in a library to be used in
other tools like target disk mode and a stage-2 gadget utility.