### PR TITLE
Enable ADB with GadgetFS devices

### DIFF
--- a/boot/init/lib/system.rb
+++ b/boot/init/lib/system.rb
@@ -190,6 +190,11 @@ module System
     end
   end
 
+  # Unmounts a mount.
+  def self.umount(target, *args)
+    run("umount", target, *args)
+  end
+
   def self.cmdline()
     if File.exists?("/proc/cmdline") then
       File.read("/proc/cmdline").split(/\s+/)

--- a/boot/init/lib/system.rb
+++ b/boot/init/lib/system.rb
@@ -199,6 +199,8 @@ module System
   end
 
   def self.failure(code, title, message="(No details given)", color: "000000", delay: Configuration["boot"]["fail"]["delay"], status: 111)
+    $logger.debug("-- Entering System.failure handler --")
+    $logger.debug("Killing the splash applet...")
     Progress.kill()
 
     # First print the error we're handling.
@@ -230,6 +232,9 @@ module System
       status: status,
     }.to_json)
 
+    # Drop down to a shell if possible and wanted.
+    shell if respond_to?(:shell) && Configuration["boot"]["shellOnFail"]
+
     # Show the error handler applet.
     begin
       System.exec(LOADER, "/applets/boot-error.mrb", "/.error.json")
@@ -243,9 +248,6 @@ module System
 
     # If we're here, things are broken beyond belief!
     _flush_outputs()
-
-    # Drop down to a shell if possible.
-    shell if respond_to?(:shell)
 
     # As in "command not found".
     exit 127

--- a/devices/google-walleye/default.nix
+++ b/devices/google-walleye/default.nix
@@ -65,7 +65,6 @@
 
   mobile.usb.gadgetfs.functions = {
     rndis = "gsi.rndis";
-    # FIXME: This is the right function name, but doesn't work.
-    # adb = "ffs.usb0";
+    adb = "ffs.adb";
   };
 }

--- a/devices/motorola-surfna/default.nix
+++ b/devices/motorola-surfna/default.nix
@@ -50,5 +50,6 @@
 
   mobile.usb.gadgetfs.functions = {
     rndis = "rndis_bam.rndis";
+    adb = "ffs.adb";
   };
 }

--- a/devices/pine64-pinephone/default.nix
+++ b/devices/pine64-pinephone/default.nix
@@ -49,6 +49,7 @@
   mobile.usb.gadgetfs.functions = {
     rndis = "rndis.usb0";
     mass_storage = "mass_storage.0";
+    adb = "ffs.adb";
   };
 
   mobile.boot.stage-1.bootConfig = {

--- a/devices/razer-cheryl2/default.nix
+++ b/devices/razer-cheryl2/default.nix
@@ -64,6 +64,7 @@
 
   mobile.usb.gadgetfs.functions = {
     rndis = "gsi.rndis";
+    adb = "ffs.adb";
   };
 
   mobile.boot.stage-1.tasks = [

--- a/devices/sony-pioneer/default.nix
+++ b/devices/sony-pioneer/default.nix
@@ -64,6 +64,7 @@
 
   mobile.usb.gadgetfs.functions = {
     rndis = "rndis_bam.rndis";
+    adb = "ffs.adb";
   };
 
 }

--- a/devices/xiaomi-begonia/default.nix
+++ b/devices/xiaomi-begonia/default.nix
@@ -57,5 +57,6 @@
   mobile.usb.idProduct = "FF80"; # Mi/Redmi series (RNDIS)
 
   mobile.usb.gadgetfs.functions = {
+    adb = "ffs.adb";
   };
 }

--- a/devices/xiaomi-lavender/default.nix
+++ b/devices/xiaomi-lavender/default.nix
@@ -68,7 +68,6 @@
 
   mobile.usb.gadgetfs.functions = {
     rndis = "rndis_bam.rndis";
-    # FIXME: This is likely the right function name, but doesn't work.
-    # adb = "ffs.usb0";
+    adb = "ffs.adb";
   };
 }

--- a/examples/target-disk-mode/configuration.nix
+++ b/examples/target-disk-mode/configuration.nix
@@ -7,6 +7,19 @@ let
     config.mobile.boot.stage-1.bootConfig.storage ? internal &&
     config.mobile.boot.stage-1.bootConfig.storage.internal != null
   ;
+
+  # Only enable `adb` if we know how to.
+  # FIXME: relies on implementation details. Poor separation of concerns.
+  enableADB = 
+  let
+    value =
+      config.mobile.usb.mode == "android_usb" ||
+      (config.mobile.usb.mode == "gadgetfs" && config.mobile.usb.gadgetfs.functions ? adb)
+    ;
+  in
+    if value then value else
+    builtins.trace "warning: unable to enable ADB for this device." value
+  ;
 in
 {
   mobile.boot.stage-1.tasks = [
@@ -50,6 +63,7 @@ in
     app-simulator = pkgs.callPackage ./app/simulator.nix {};
   };
 
+  mobile.adbd.enable = lib.mkDefault enableADB;
   mobile.boot.stage-1.networking.enable = true;
   mobile.boot.stage-1.ssh.enable = true;
 }

--- a/modules/adb.nix
+++ b/modules/adb.nix
@@ -26,34 +26,10 @@ with lib;
     mobile.boot.stage-1 = {
       usb.features = [ "adb" ];
 
-      tasks = [
-        (pkgs.writeText "adbd-task.rb" ''
-          class Tasks::ADBD < SingletonTask
-            def initialize()
-              add_dependency(:Mount, "/dev/usb-ffs/adb")
-              Targets[:SwitchRoot].add_dependency(:Task, self)
-            end
-            
-            def run()
-              System.spawn("adbd")
-            end
-          end
-        '')
-      ];
-
       extraUtils = with pkgs; [{
         package = adbd;
         extraCommand = ''cp -fpv "${glibc.out}"/lib/libnss_files.so.* "$out"/lib/'';
       }];
-    };
-
-    boot.specialFileSystems = {
-      # This is required for gadgetfs configuration.
-      "/dev/usb-ffs/adb" = {
-        device = "adb";
-        fsType = "functionfs";
-        options = [ "nosuid" "noexec" "nodev" ];
-      };
     };
 
     boot.postBootCommands = ''

--- a/modules/adb.nix
+++ b/modules/adb.nix
@@ -15,9 +15,6 @@ with lib;
 
   config = lib.mkIf config.mobile.adbd.enable {
     assertions = [
-      { assertion = config.mobile.system.type == "android";
-        message = "adb is only available on Android";
-      }
       { assertion = config.mobile.boot.stage-1.usb.enable;
         message = "adb requires mobile.boot.stage-1.usb.enable = true";
       }

--- a/modules/initrd.nix
+++ b/modules/initrd.nix
@@ -342,6 +342,7 @@ in
 
         boot = {
           inherit (config.mobile.boot.stage-1) fail crashToBootloader;
+          inherit (config.mobile.boot.stage-1.shell) shellOnFail;
         };
 
         # Transmit all of the mobile NixOS HAL options.


### PR DESCRIPTION
It happens that, with time, I learned enough to finally be able to tackle this problem.

With these changes, `adb` in stage-1 (and I expect the system) works with GadgetFS devices:

While it doesn't seem needed, after all we have `rndis` working just fine, it is. See, sometimes `rndis` is a big unknown variable that is hard to correctly *guess* the proper solution for. With these changes you can get insight into the device using `adb`, and gather the required knowledge to setup `rndis`, if desired. 

## Tested on

 - [x] asus-z00t (verify against regression with `android_usb`)
 - [x] motorola-surfna
 - [x] razer-cheryl2
 - [x] sony-pioneer
 - [x] xiaomi-begonia
 - [x] chuwi-hi10prohq64 (out of tree; mainline linux)

Cannot test on, due to hardware issues:

 - [ ] pine64-pinephone