### PR TITLE
Enable WiFi for google-marlin

### DIFF
--- a/devices/google-marlin/default.nix
+++ b/devices/google-marlin/default.nix
@@ -19,6 +19,8 @@
     kernel.package = pkgs.callPackage ./kernel { };
   };
 
+  mobile.device.firmware = pkgs.callPackage ./firmware {};
+
   mobile.system.android = {
     # This device has an A/B partition scheme
     ab_partitions = true;

--- a/devices/google-marlin/default.nix
+++ b/devices/google-marlin/default.nix
@@ -56,4 +56,7 @@
   mobile.usb.idProduct = "4EE4";
 
   mobile.system.type = "android";
+
+  mobile.quirks.qualcomm.wcnss-wlan.enable = true;
+  mobile.quirks.wifi.disableMacAddressRandomization = true;
 }

--- a/devices/google-marlin/default.nix
+++ b/devices/google-marlin/default.nix
@@ -45,7 +45,6 @@
     "cma=32M@0-0xffffffff"
     "loop.max_part=7"
     "buildvariant=eng"
-    "firmware_class.path=/vendor/firmware"
   ];
 
   mobile.usb.mode = "android_usb";

--- a/devices/google-marlin/firmware/default.nix
+++ b/devices/google-marlin/firmware/default.nix
@@ -1,0 +1,40 @@
+{ lib
+, runCommandNoCC
+, fetchurl
+, fetchgit
+, unzip
+, e2fsprogs
+, simg2img
+}:
+
+let
+  deviceSrc = fetchgit {
+    url = "https://android.googlesource.com/device/google/marlin";
+    rev = "android-10.0.0_r41";
+    sha256 = "1184rykcc2lrgr16pcjndq99ngbqa6ak3r1r2gx24ylg9sfg7liy";
+  };
+  buildID = "qp1a.191005.007.a3";
+  upstreamImage = fetchurl {
+    url = "https://dl.google.com/dl/android/aosp/marlin-${buildID}-factory-bef66533.zip";
+    sha256 = "bef6653301371b66bd7fca968cf52013c0bf6862f0c7a70a275b0f0d45ab3888";
+  };
+in runCommandNoCC "google-marlin-firmware" {
+  nativeBuildInputs = [ unzip e2fsprogs simg2img ];
+  meta.license = [
+    # We make no claims that it can be redistributed.
+    lib.licenses.unfree
+  ];
+} ''
+  fwpath=$out/lib/firmware
+  mkdir -vp $(dirname $fwpath)
+
+  unzip ${upstreamImage} marlin-${buildID}/image-marlin-${buildID}.zip
+  cd marlin-${buildID}
+  unzip image-marlin-${buildID}.zip vendor.img
+  simg2img vendor.img vendor-raw.img
+  debugfs vendor-raw.img -R "rdump firmware ."
+  mv firmware $fwpath
+
+  mkdir -vp $fwpath $fwpath/wlan/qca_cld
+  cp -v ${deviceSrc}/WCNSS_cfg.dat ${deviceSrc}/WCNSS_qcom_cfg.ini $fwpath/wlan/qca_cld
+''

--- a/devices/google-marlin/firmware/default.nix
+++ b/devices/google-marlin/firmware/default.nix
@@ -8,11 +8,6 @@
 }:
 
 let
-  deviceSrc = fetchgit {
-    url = "https://android.googlesource.com/device/google/marlin";
-    rev = "android-10.0.0_r41";
-    sha256 = "1184rykcc2lrgr16pcjndq99ngbqa6ak3r1r2gx24ylg9sfg7liy";
-  };
   buildID = "qp1a.191005.007.a3";
   upstreamImage = fetchurl {
     url = "https://dl.google.com/dl/android/aosp/marlin-${buildID}-factory-bef66533.zip";
@@ -25,16 +20,12 @@ in runCommandNoCC "google-marlin-firmware" {
     lib.licenses.unfree
   ];
 } ''
-  fwpath=$out/lib/firmware
-  mkdir -vp $(dirname $fwpath)
-
   unzip ${upstreamImage} marlin-${buildID}/image-marlin-${buildID}.zip
   cd marlin-${buildID}
   unzip image-marlin-${buildID}.zip vendor.img
   simg2img vendor.img vendor-raw.img
   debugfs vendor-raw.img -R "rdump firmware ."
-  mv firmware $fwpath
 
-  mkdir -vp $fwpath $fwpath/wlan/qca_cld
-  cp -v ${deviceSrc}/WCNSS_cfg.dat ${deviceSrc}/WCNSS_qcom_cfg.ini $fwpath/wlan/qca_cld
+  mkdir -p $out/lib
+  mv firmware $out/lib/firmware
 ''


### PR DESCRIPTION
Tested working fine on my Pixel XL (`google-marlin`).

Fetching the firmware from the upstream factory image ended up being most convenient, and is my personal preference.