### PR TITLE
kernel-builder: Avoid string interpolation for path concatenation

### DIFF
--- a/overlay/mobile-nixos/kernel/builder.nix
+++ b/overlay/mobile-nixos/kernel/builder.nix
@@ -127,7 +127,7 @@ in
 
 let
   # Path within <nixpkgs> to refer to the kernel build system's file.
-  nixosKernelPath = "${path}/pkgs/os-specific/linux/kernel/";
+  nixosKernelPath = path + "/pkgs/os-specific/linux/kernel";
 
   # Same installer as in <nixpkgs>, though they don't expose it :/.
   installkernel = writeTextFile {
@@ -189,7 +189,7 @@ stdenv.mkDerivation (inputArgs // {
   patches =
     map (p: p.patch) kernelPatches
     # Required for deterministic builds along with some postPatch magic.
-    ++ optional (lib.versionAtLeast version "4.13") "${nixosKernelPath}/randstruct-provide-seed.patch"
+    ++ optional (lib.versionAtLeast version "4.13") (nixosKernelPath + "/randstruct-provide-seed.patch")
     ++ patches
   ;
 


### PR DESCRIPTION
Using string interpolation for concatenating paths caused the whole nixpkgs source to be included as an `inputSrc` for the kernel derivation.

**linux.drv:**
```json
"inputSrcs": [
  "...",
  "/nix/store/4crmmrpb9axxymrrh77lf35n015scnpj-mobile-nixos",
  "...",
],
```
_I have my mobile-nixos worktree of nixpkgs under `nixpkgs/mobile-nixos`, which is why the above is named `mobile-nixos`._

With concatenation, only the resulting file is included as an `inputSrc`, which avoids unnecessary kernel rebuilds when nixpkgs changes.

**linux.drv:**
```json
"inputSrcs": [
  "...",
  "/nix/store/hdr6v584ig3dpjlcs9afxxky3lvzm2nw-randstruct-provide-seed.patch",
  "...",
],
```