### PR TITLE
kernel-builder: Fix detecting dtb support (after nixpkgs#110544)

### DIFF
--- a/overlay/mobile-nixos/kernel/builder.nix
+++ b/overlay/mobile-nixos/kernel/builder.nix
@@ -148,7 +148,7 @@ let
     exec ${buildPackages.pkgconfig}/bin/${buildPackages.pkgconfig.targetPrefix}pkg-config "$@"
   '';
 
-  hasDTB = platform ? kernelDTB && platform.kernelDTB;
+  hasDTB = platform.linux-kernel ? DTB && platform.linux-kernel.DTB;
   kernelFileExtension = if isCompressed != false then ".${isCompressed}" else "";
   kernelTarget = if platform.linux-kernel.target == "Image"
     then "${platform.linux-kernel.target}${kernelFileExtension}"


### PR DESCRIPTION
This continues the fixes in commit d14b99e for the changes introduced in nixpkgs#110544.