### PR TITLE
default.nix: Add emulate option

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -26,6 +26,30 @@ in
   # This allows using `default.nix` as a pass-through function.
   # See usage in examples folder.
 , device ? null
+  # Build with QEMU to emulate the device's system rather than build
+  # with cross compilation.
+  #
+  # Before you can use this option, you must configure nix to support
+  # building for the device's platform.
+  #
+  # For example, by passing it as an option to nix-build (must be a trusted user):
+  # nix-build \
+  #   --argstr device pine64-pinephone \
+  #   --arg emulate true \
+  #   --option extra-platforms aarch64-linux \
+  #   -A build.default
+  #
+  # Or by permanently configuring the option in /etc/nix/nix.conf:
+  #   extra-platforms = aarch64-linux
+  #
+  # Or by using NixOS configuration to generate /etc/nix/nix.conf:
+  #   boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
+  #
+  # NOTE: This isn't a perfect emulation, and there may be problems
+  # running some tests. Ideally you should run builds natively on your
+  # device, but this can be helpful as a workaround if your device
+  # doesn't have enough system resources to build certain packages.
+, emulate ? false
 , configuration ? default_configuration
   # Internally used to tack on configuration by release.nix
 , additionalConfiguration ? {}
@@ -47,7 +71,7 @@ let
   eval = evalWith {
     device = final_device;
     modules = configuration;
-    inherit additionalConfiguration;
+    inherit emulate additionalConfiguration;
   };
 
   # Makes a mostly useless header.

--- a/lib/release-tools.nix
+++ b/lib/release-tools.nix
@@ -19,6 +19,7 @@ in
   evalWith =
     { modules
     , device
+    , emulate ? false
     , additionalConfiguration ? {}
     , baseModules ? (
       (import ../modules/module-list.nix)
@@ -31,6 +32,14 @@ in
       then [ device.config ]
       else if builtins.isPath device then [ { imports = [ device ]; } ]
       else [ { imports = [(../. + "/devices/${device}")]; } ])
+      ++ (if emulate then [ {
+        imports = [
+          ({ config, ... }: {
+            # Use mkForce to override value set in user configuration
+            nixpkgs.localSystem = pkgs.lib.mkForce config.mobile.system;
+          })
+        ];
+      } ] else [])
       ++ modules
       ++ [ additionalConfiguration ]
     ;


### PR DESCRIPTION
Allows building with QEMU to emulate the device's system

**NOTE**: This isn't a perfect emulation, and there may be problems running some tests. I've noticed issues with both the coreutils and libuv tests.

Ideally you should run builds natively on your device, but this can be helpful as a workaround if your device doesn't have enough system resources to build certain packages.