### PR TITLE
Finish stage-0 boot features

### DIFF
--- a/boot/init/tasks/switch_root.rb
+++ b/boot/init/tasks/switch_root.rb
@@ -113,10 +113,14 @@ class Tasks::SwitchRoot < SingletonTask
   # Pauses the boot to allow the user to select a generation.
   def choose_generation()
     generate_selection()
-    # FIXME: In the future, boot GUIs will be launched async, before this
-    # task is ran.
+
+    # Synchronuously (pause the init code) show the selection applet.
     System.run(LOADER, "/applets/boot-selection.mrb")
-    generation = File.read("/run/boot/choice")
+
+    # Read data from the user
+    data = JSON.parse(File.read("/run/boot/choice"))
+    generation = data["generation"]
+
     # Why "$default" rather than passing a path?
     # Because there may be no generations folder. It's easier to cheat and
     # use "$default" and rely on the existing default "maybe rehydrate"

--- a/boot/init/tasks/switch_root.rb
+++ b/boot/init/tasks/switch_root.rb
@@ -120,6 +120,7 @@ class Tasks::SwitchRoot < SingletonTask
     # Read data from the user
     data = JSON.parse(File.read("/run/boot/choice"))
     generation = data["generation"]
+    @use_generation_kernel = data["use_generation_kernel"]
 
     # Why "$default" rather than passing a path?
     # Because there may be no generations folder. It's easier to cheat and
@@ -152,6 +153,9 @@ class Tasks::SwitchRoot < SingletonTask
   def will_kexec?()
     # Only stage-0 bootloader-flavourd init will kexec.
     return false unless STAGE == 0
+
+    # The user wants to use the generation's kernel
+    return false unless @use_generation_kernel
 
     # AND if we find the required files.
     [

--- a/boot/recovery-menu/main.rb
+++ b/boot/recovery-menu/main.rb
@@ -69,7 +69,9 @@ module BootGUI
         JSON.parse(File.read(::SELECTIONS)).each do |selection|
           add_button(selection["name"]) do
             File.open("/run/boot/choice", "w") do |file|
-              file.write(selection["id"])
+              file.write({
+                generation: selection["id"],
+              }.to_json())
             end
 
             # Put back the console on the framebuffer

--- a/boot/recovery-menu/main.rb
+++ b/boot/recovery-menu/main.rb
@@ -1,4 +1,5 @@
 # File with boot selection
+STAGE = Configuration["stage"]
 SELECTIONS = "/run/boot/selection.json"
 
 # Runs and prints a command. Probably.
@@ -58,12 +59,38 @@ module BootGUI
 
   # Shows the list of generations to boot into.
   class GenerationsWindow < LVGUI::BaseWindow
+    include LVGUI::BaseUIElements
     include LVGUI::ButtonPalette
     include LVGUI::Window::WithBackButton
     goes_back_to ->() { MainWindow.instance }
 
+    def update_switch_label()
+      if use_generation_kernel?
+        @use_generation_kernel.set_description("Use kexec with the generation kernel")
+      else
+        @use_generation_kernel.set_description("Continue directly to stage-2")
+      end
+    end
+
+    def use_generation_kernel?()
+      return false unless STAGE == 0
+      @use_generation_kernel.get_state()
+    end
+
     def initialize()
       super()
+
+      if STAGE == 0
+        # Add a toggle switch
+        @use_generation_kernel = add_switch(
+          "Boot using generation kernel",
+          initial: true,
+        ) do |new_state|
+          update_switch_label()
+        end
+
+        update_switch_label()
+      end
 
       if File.exist?(::SELECTIONS)
         JSON.parse(File.read(::SELECTIONS)).each do |selection|
@@ -71,6 +98,7 @@ module BootGUI
             File.open("/run/boot/choice", "w") do |file|
               file.write({
                 generation: selection["id"],
+                use_generation_kernel: use_generation_kernel?,
               }.to_json())
             end
 

--- a/devices/pine64-pinephone/default.nix
+++ b/devices/pine64-pinephone/default.nix
@@ -69,4 +69,10 @@
 
   # Supports rebooting into generation kernel through kexec.
   mobile.quirks.supportsStage-0 = true;
+
+  mobile.quirks.fdt-forward = {
+    props = [
+      ["/soc/mmc@1c10000/wifi@1" "local-mac-address"]
+    ];
+  };
 }

--- a/modules/initrd.nix
+++ b/modules/initrd.nix
@@ -3,7 +3,6 @@
 let
   inherit (pkgs)
     busybox
-    kexectools
     makeInitrd
     mkExtraUtils
     runCommandNoCC
@@ -165,7 +164,6 @@ let
       busybox
     ]
     ++ optionals (stage-1 ? extraUtils) stage-1.extraUtils
-    ++ optionals (config.mobile.quirks.supportsStage-0) [ kexectools ]
     ++ [{
       package = runCommandNoCC "empty" {} "mkdir -p $out";
       extraCommand =

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -41,6 +41,7 @@
   ./rootfs.nix
   ./shared-rootfs.nix
   ./stage-0.nix
+  ./system-build.nix
   ./system-target.nix
   ./system-types.nix
 ]

--- a/modules/stage-0.nix
+++ b/modules/stage-0.nix
@@ -25,6 +25,9 @@ in
     system.build.stage-0 = (config.lib.mobile-nixos.composeConfig {
       config = {
         mobile.boot.stage-1.stage = if supportsStage-0 then 0 else 1;
+        mobile.boot.stage-1.extraUtils = with pkgs; [
+          { package = pkgs.kexectools; }
+        ];
       };
     }).config;
   };

--- a/modules/system-build.nix
+++ b/modules/system-build.nix
@@ -1,0 +1,20 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) mkIf;
+
+  deviceName = config.mobile.device.name;
+in
+{
+  config = mkIf (!config.mobile.rootfs.shared.enabled) {
+    system.extraSystemBuilderCmds = ''
+      echo ":: Adding Mobile NixOS information to the build..."
+      (
+        PS4=" $ "; set -x
+        mkdir -p $out/mobile-nixos
+        cd $out/mobile-nixos
+        echo "${deviceName}" > device-name
+      )
+    '';
+  };
+}

--- a/modules/system-build.nix
+++ b/modules/system-build.nix
@@ -1,9 +1,16 @@
 { config, lib, pkgs, ... }:
 
 let
-  inherit (lib) mkIf;
+  inherit (lib) mkIf optionalString;
 
   deviceName = config.mobile.device.name;
+
+  dtbMapping = pkgs.runCommandNoCC "dtb-mapping.json" {} ''
+    (
+      PS4=" $ "; set -x
+      ${pkgs.buildPackages.mobile-nixos.map-dtbs}/bin/map-dtbs $(find ${config.hardware.deviceTree.package} -name '*.dtb' | sort) > $out
+    )
+  '';
 in
 {
   config = mkIf (!config.mobile.rootfs.shared.enabled) {
@@ -14,6 +21,9 @@ in
         mkdir -p $out/mobile-nixos
         cd $out/mobile-nixos
         echo "${deviceName}" > device-name
+        ${optionalString (config.hardware.deviceTree.package != null) ''
+          ln -s ${dtbMapping} dtb-mapping.json
+        ''}
       )
     '';
   };

--- a/overlay/mobile-nixos/fdt-forward/default.nix
+++ b/overlay/mobile-nixos/fdt-forward/default.nix
@@ -1,0 +1,10 @@
+{ runCommandNoCC, runtimeShell, lib, dtc, ubootTools }:
+
+runCommandNoCC "fdt-forward" {} ''
+  mkdir -p $out/bin
+  echo "#!${runtimeShell}" > $out/bin/fdt-forward
+  cat "${./fdt-forward.sh}" >> $out/bin/fdt-forward
+  chmod +x $out/bin/fdt-forward
+  substituteInPlace $out/bin/fdt-forward \
+    --replace @PATH@ "${lib.makeBinPath [ dtc ubootTools ]}"
+''

--- a/overlay/mobile-nixos/fdt-forward/fdt-forward.sh
+++ b/overlay/mobile-nixos/fdt-forward/fdt-forward.sh
@@ -1,0 +1,104 @@
+#!/bin/sh
+
+# By default, it will use `/sys/firmware/fdt` as a source to forward from.
+# The source can be overriden using the FDT variable, or `--fdt`.
+#
+# Example usage:
+#
+# fdt-forward \
+#	--print-header \
+#	--copy-dtb "./desired-dtb.dtb" \
+#	--forward-node "/memory" \
+#	--forward-prop "/" "serial-number" \
+#	--forward-prop "/soc/mmc@1c10000/wifi@1" "local-mac-address" \
+#	  | fdt-forward --to-dtb > out.dtb
+
+set -e
+set -u
+
+PATH="@PATH@:$PATH"
+
+
+# shellcheck disable=2120
+to_dts() {
+	dtc --sort -I dtb -O dts "$@"
+}
+
+# shellcheck disable=2120
+to_dtb() {
+	dtc --sort -I dts -O dtb "$@"
+}
+
+# Functions with `__` prefixed names are expected to
+# be called from `run`, replacing `-` with `_`.
+
+# `--to-dts` will not continue execution further.
+# It is a convenience function for calling `dtc`.
+__to_dts() {
+	to_dts "$@"
+}
+
+# `--to-dtb` will not continue execution further.
+# It is a convenience function for calling `dtc`.
+__to_dtb() {
+	to_dtb "$@"
+}
+
+# Print a device tree header.
+__print_header() {
+	printf '/dts-v1/;\n'
+	run "$@"
+}
+
+# Forwards the *whole* node
+__forward_node() {
+	node="$1"; shift
+
+	printf '\n// forwarded node: "%s"\n' "$node"
+	fdtgrep --show-subnodes --include-node "$node" "$FDT"
+	run "$@"
+}
+
+# Forwards the prop matching the name from the given node.
+__forward_prop() {
+	node="$1"; shift
+	prop="$1"; shift
+
+	printf '\n// forwarded prop: "%s" from node: "%s"\n' "$prop" "$node"
+	# In order, we get the node (without descendents!) as dts
+	# Synthesize it back into dtb
+	# Then we can get the desired prop.
+	fdtgrep --show-version --include-node "$node" "$FDT" \
+		| to_dtb \
+		| fdtgrep "$prop" -
+
+	# Doing otherwise would give us *all* matching prop names,
+	# and not exclusively the one for the desired node.
+	run "$@"
+}
+
+# Copy the whole dtb as dts source.
+# Its header will be stripped.
+__copy_dtb() {
+	dtb="$1"; shift
+	printf '\n// Initial dtb copy...\n'
+	to_dts "$dtb" | tail -n+2
+	run "$@"
+}
+
+__fdt() {
+	FDT="$1"; shift
+	run "$@"
+}
+
+
+FDT="${FDT:-/sys/firmware/fdt}"
+
+run() {
+	if [ $# -gt 0 ]; then
+		cmd="${1//-/_}"; shift
+		"$cmd" "$@"
+	fi
+}
+
+run "$@"

--- a/overlay/mobile-nixos/map-dtbs/default.nix
+++ b/overlay/mobile-nixos/map-dtbs/default.nix
@@ -1,0 +1,10 @@
+{ runCommandNoCC, runtimeShell, lib, dtc }:
+
+runCommandNoCC "map-dtbs" {} ''
+  mkdir -p $out/bin
+  echo "#!${runtimeShell}" > $out/bin/map-dtbs
+  cat "${./map-dtbs.sh}" >> $out/bin/map-dtbs
+  chmod +x $out/bin/map-dtbs
+  substituteInPlace $out/bin/map-dtbs \
+    --replace @PATH@ "${lib.makeBinPath [ dtc ]}"
+''

--- a/overlay/mobile-nixos/map-dtbs/map-dtbs.sh
+++ b/overlay/mobile-nixos/map-dtbs/map-dtbs.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# shellcheck disable=SC2123
+PATH="@PATH@:${PATH}"
+
+set -u
+set -e
+
+# Ugh... xargs complains when the child processes are killed by the pipe being closed.
+# This is why there is the indirection into a variable.
+_get_compatible() {
+	filename="$1"
+	for char_text in $(fdtget -tbx "${filename}" / compatible); do
+		# shellcheck disable=SC2059
+		printf "\\x${char_text}"
+	done | xargs --null -n1 echo
+}
+
+get_compatible() {
+	data=$(_get_compatible "$1")
+	local IFS=$'\n'
+	for l in ${data}; do
+		echo "$l"
+		return 0
+	done
+}
+
+first=1
+
+printf '{\n'
+for f in "${@}"; do
+	# First line does not handle \n
+	# Every other one after add the previous line's comma, and \n
+	if ((!first)); then
+		printf ",\n"
+	fi
+	# Not the first line anymore.
+	first=0
+
+	printf '  "%s": "%s"' "$(get_compatible "$f")" "$f"
+done
+printf '\n}'

--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -111,6 +111,8 @@ in
 
       boot-recovery-menu-simulator = callPackage ../boot/recovery-menu/simulator.nix {};
       boot-splash-simulator = callPackage ../boot/splash/simulator.nix {};
+
+      map-dtbs = callPackage ./mobile-nixos/map-dtbs {};
     };
 
     imageBuilder = callPackage ../lib/image-builder {};

--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -86,6 +86,22 @@ in
       '';
     });
 
+    #
+    # Fixes sent upstream
+    # -------------------
+    #
+
+    ubootTools = super.ubootTools.overrideAttrs({ patches ? [], ... }: {
+      patches = patches ++ [
+        (fetchpatch {
+          # https://patchwork.ozlabs.org/project/uboot/patch/20210210194309.07d1dec7@DUFFMAN/
+          url = "https://patchwork.ozlabs.org/series/229060/mbox/";
+          sha256 = "1d3h1wh5227lqvqlxvnljbkmy89b9wmf52qfsx5jhpfa9g260xql";
+        })
+      ];
+    });
+
+
     # Things specific to mobile-nixos.
     # Not necessarily internals, but they probably won't go into <nixpkgs>.
     mobile-nixos = {

--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -86,13 +86,13 @@ in
       '';
     });
 
-    #
-    # Fixes sent upstream
-    # -------------------
-    #
-
-    ubootTools = super.ubootTools.overrideAttrs({ patches ? [], ... }: {
+    ubootTools = super.ubootTools.overrideAttrs({ buildInputs ? [], patches ? [], ... }: {
+      # Needed for cross-compiling ubootTools
+      buildInputs = buildInputs ++ [
+        self.openssl
+      ];
       patches = patches ++ [
+        ./u-boot/0001-mobile-nixos-work-around-ubootTools-cross-compilatio.patch
         (fetchpatch {
           # https://patchwork.ozlabs.org/project/uboot/patch/20210210194309.07d1dec7@DUFFMAN/
           url = "https://patchwork.ozlabs.org/series/229060/mbox/";

--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -112,6 +112,8 @@ in
       boot-recovery-menu-simulator = callPackage ../boot/recovery-menu/simulator.nix {};
       boot-splash-simulator = callPackage ../boot/splash/simulator.nix {};
 
+      fdt-forward = callPackage ./mobile-nixos/fdt-forward {};
+
       map-dtbs = callPackage ./mobile-nixos/map-dtbs {};
     };
 

--- a/overlay/u-boot/0001-mobile-nixos-work-around-ubootTools-cross-compilatio.patch
+++ b/overlay/u-boot/0001-mobile-nixos-work-around-ubootTools-cross-compilatio.patch
@@ -1,0 +1,30 @@
+From ab87ea4ce5d34b82a7fd539a57f99459ca2ea99e Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Thu, 11 Feb 2021 17:18:05 -0500
+Subject: [PATCH] [mobile-nixos]: work around ubootTools cross-compilation
+ issue
+
+The BMP tool gets compiled for the target system, as others tools do. In
+turn, this tool cannot be ran on the system doing the build.
+
+Forcing CONFIG_*_LOGO to values fails because it has been hardcoded to
+=y here.
+---
+ tools/Makefile | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/tools/Makefile b/tools/Makefile
+index 2d550432ba..135fbd3863 100644
+--- a/tools/Makefile
++++ b/tools/Makefile
+@@ -6,7 +6,6 @@
+ # Enable all the config-independent tools
+ ifneq ($(HOST_TOOLS_ALL),)
+ CONFIG_ARCH_KIRKWOOD = y
+-CONFIG_LCD_LOGO = y
+ CONFIG_CMD_LOADS = y
+ CONFIG_CMD_NET = y
+ CONFIG_XWAY_SWAP_BYTES = y
+-- 
+2.29.2
+

--- a/shell.nix
+++ b/shell.nix
@@ -8,10 +8,12 @@ mkShell rec {
     mobile-nixos.autoport     # Helps users kickstart their ports
 
     # Third party tools
+    dtc                       # For playing around with device tree files
     dtbTool                   # Combines multiple device tree blobs into one image
     file                      # Shows the type of files
     lz4                       # Decompress image files
     mkbootimg                 # Pack and unpack boot images
     python3Packages.binwalk   # Search a binary image for embedded files
+    ubootTools                # A couple useful utilities
   ];
 }


### PR DESCRIPTION
We were left with the following issues to deal with:

 - Fixes #264 
 - Fixes #266

This PR implements both features.

* * *

# Skip generation kernel

It is possible to continue booting with the kernel used to boot the stage-0 bootloader. It will be useful for the three following scenarios:

 - Validating kexec did not cause an issue with the booted system
 - Recovering a system where none of the generation kernels boot properly
 - Testing a kernel build without making a generation

* * *

# Use generation DTB

Self-explanatory... Or is it?

Each generation could have their own DTB, sometimes with fixes. Re-installing the bootloader to use the fresher DTB is not really a nice thing to have to do.

This change makes it so the call to `kexec` uses the `--dtb` flag.

But wait, there's more!

The kernel assumes some entries will be added to the FDT (in-memory device tree), like the `/memory` node. `kexec` does nothing to help you forward required entries.

This is where `fdt-forward` comes into play. It is used to get the nodes and properties from the running system.

For the pinephone, you can observe it forwards a property for the Wi-Fi adapter mac address. The bootloader is expected to add a few properties like this depending on the device.

Finally, since we can, let's add some nodes about the current stage-0 boot. This is not strictly needed, but it the basic boolean node can be used as a method to confirm kexec was used. We can also add other properties if it ends up being useful.

## fdt-forward?

Are you concerned about what seems like a weird script? I understand. In the end it is much easier to deal with than having to work with libfdt in C or with other language bindings.

I am open to contributions that allows doing the same kind of manipulations. The basic requirements are:

 - graft a full node from a DT to another DT (source and binary)
 - graft a property with a qualified path from a DT to another DT (source and binary)

The header and to_dtb features are only for convenience.

For the time being, this is not perfect, but totally does what is needed.