### PR TITLE
stage-1/usb-gadget: Fix error message error

### DIFF
--- a/modules/stage-1/tasks/usb-gadget-task.rb
+++ b/modules/stage-1/tasks/usb-gadget-task.rb
@@ -57,7 +57,7 @@ module System::ConfigFSUSB
       if DAEMONS[feature_name]
         DAEMONS[feature_name].start()
       else
-        $logger.fatal("Tried to get FunctionFS Daemon for #{feature_name} (#{feature_name.constantize()}) and failed.")
+        $logger.fatal("Tried to get FunctionFS Daemon for #{feature_name} and failed.")
       end
     end
   end 


### PR DESCRIPTION
`#constantize` does not exist on `String`.

This would only have been an issue in the improbable cause that a daemon
is not configured for an FFS gadget.