### PR TITLE
boot/init: Make udev a dependency for the switch root target

### DIFF
--- a/boot/init/tasks/udev.rb
+++ b/boot/init/tasks/udev.rb
@@ -10,6 +10,7 @@ class Tasks::UDev < SingletonTask
     # Make the Devices target depend on this task.
     # It is preferred to depend on the specific device rather than this target.
     Targets[:Devices].add_dependency(:Task, self)
+    Targets[:SwitchRoot].add_dependency(:Task, self)
   end
 
   def udevadm(*args)


### PR DESCRIPTION
In some instances, e.g. really slow CPU, udev might not have run, and
libinput will not be able to work appropriately.

That is because uevent files will be missing.