### PR TITLE
lvgui: "pan" framebuffers

### DIFF
--- a/boot/script-loader/mruby-lvgui-native-fragment/lvgui.nix
+++ b/boot/script-loader/mruby-lvgui-native-fragment/lvgui.nix
@@ -94,13 +94,13 @@ let
 in
   stdenv.mkDerivation {
     pname = "lvgui";
-    version = "2021-01-23";
+    version = "2021-02-20";
 
     src = fetchFromGitHub {
       repo = "lvgui";
       owner = "mobile-nixos";
-      rev = "b971f2dc954b4177aed53c0134a77e12db415b98";
-      sha256 = "02y5m495a9ax7c6fhr5qkpy0c0a6szh7nnmkixzxmq9k425cd196";
+      rev = "5ff9b43732d44480f14fd6107d6d989106940be7";
+      sha256 = "1j65byqshxbngqrnj6lj5jhjp13z1j70ahj3dcp5a8bpadhlkgvb";
     };
 
     # Document `LVGL_ENV_SIMULATOR` in the built headers.

--- a/examples/demo/configuration.nix
+++ b/examples/demo/configuration.nix
@@ -48,6 +48,10 @@ in
         };
 
       };
+
+      # Ensures this demo rootfs is useable for platforms requiring FBIOPAN_DISPLAY.
+      quirks.fb-refresher.enable = true;
+
       powerManagement.enable = true;
       hardware.pulseaudio.enable = true;
 

--- a/modules/quirks/framebuffer.nix
+++ b/modules/quirks/framebuffer.nix
@@ -18,12 +18,22 @@ in
         may be useful for other vendors too.
       '';
     };
+    quirks.fb-refresher.stage-1.enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Add `msm-fb-refresher` to stage-1.
+
+        It should not be needed for the usual assortment of Mobile NixOS tools.
+        They already handle flipping the framebuffer as needed.
+      '';
+    };
   };
 
   config = mkMerge [
     {
       mobile.boot = mkMerge [
-        (mkIf cfg.fb-refresher.enable {
+        (mkIf cfg.fb-refresher.stage-1.enable {
           stage-1 = {
             extraUtils = with pkgs; [
               msm-fb-refresher


### PR DESCRIPTION
This is an implementation detail PR.

Some platforms, though it looks like all android-first platforms, requires the framebuffer driver to be "told" to update the display. This is done through the `FBIOPAN_DISPLAY` `ioctl`.

The updated `lvgui` release does it for fbdev. This is not needed for DRM.

It is, at worst, a no-op on other tested platforms.

This may break some setups. Previously `msm-fb-refresher` from stage-1 was **not** killed when switching root. This means that stage-2 X11 may be working only when it was started in stage-1.

This is why `examples/demo` is now starting it unconditionally. Previous rootfs images, if not re-configured, will have a slight breakage with fresh boot images.