### PR TITLE
doc: Fix issue with build dir references

### DIFF
--- a/doc/_support/converter/lib/processor/page.rb
+++ b/doc/_support/converter/lib/processor/page.rb
@@ -128,7 +128,7 @@ module Processor
         {
           article: Article.new(filename),
           # Assumes links will be relative to the root of the site.
-          url: filename.sub(/\.adoc$/, ".html").sub(%r{^/build/doc/}, "")
+          url: filename.sub(/\.adoc$/, ".html").sub(%r{^#{Dir.pwd}}, "")
         }
       end
       @output.sub!(

--- a/doc/default.nix
+++ b/doc/default.nix
@@ -71,14 +71,23 @@ stdenv.mkDerivation {
     process-doc "**/*.adoc" "**/*.md" \
       --styles-dir="${styles}" \
       --output-dir="$out"
+  '';
 
+  installPhase = ''
     rsync --prune-empty-dirs --verbose --archive \
       --exclude="*.src.svg" \
       --include="*.svg" \
       --include="*.jpeg" \
       --include="*.png" \
       --include="*/" --exclude="*" . $out/
-  '';
 
-  dontInstall = true;
+    (
+      cd $out
+      if grep -RIi "$NIX_BUILD_TOP"; then
+        echo "error: References to $NIX_BUILD_TOP found in output:"
+        grep -RIi "$NIX_BUILD_TOP"
+        exit 1
+      fi
+    )
+  '';
 }


### PR DESCRIPTION
The online site wasn't built with the same environment as used for development.

I assume `/build/doc` vs`/tmp/nix-build-mobile-nixos-docs.drv-0/doc/` comes from the possible lack of sandboxing.

Anyway, the fix is to actually strip the right thing, and not an arbitrary hardcoded value.

Additionaly, scan the output for presence of NIX_BUILD_TOP, to make sure it won't happen again!