### PR TITLE
bin/hydra-eval: Add hydra-like eval helper

### DIFF
--- a/bin/hydra-eval
+++ b/bin/hydra-eval
@@ -1,0 +1,112 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -p ruby -i ruby
+#!nix-shell -p hydra-unstable
+
+# This script uses hydra's `hydra-eval-jobs` to evaluate a given expression,
+# defaulting to `release.nix`.
+
+require "open3"
+require "json"
+require "shellwords"
+
+module MD
+  extend self
+
+  def _title(s, level)
+    "\n#{"#" * level} #{s}\n\n"
+  end
+
+  def title(s)
+    "\n#{s}\n#{s.gsub(/./, "=")}\n\n"
+  end
+
+  def section(s)
+    "\n#{s}\n#{s.gsub(/./, "-")}\n\n"
+  end
+
+  def list_item(s)
+    "  * #{s}"
+  end
+
+  def code(s)
+    "`#{s}`"
+  end
+
+  def pre(s)
+    "```\n#{s}\n```"
+  end
+
+  def paragraph(s)
+    "#{s.strip}\n\n"
+  end
+
+  def subtitle(s)
+    _title(s, 3)
+  end
+end
+
+def usage(io=$stdout)
+  io.puts "Usage: bin/hydra-eval [args...]"
+  io.puts ""
+  io.puts "Arguments are passed-through to `hydra-eval-jobs`."
+  io.puts ""
+  io.puts "You are likely to want to use:"
+  io.puts ""
+  io.puts %q{    $ bin/hydra-eval release.nix --arg systems '[ "x86_64-linux" "aarch64-linux" ]' > out.md}
+  io.puts ""
+end
+
+# No arguments, or `--help`?
+if ARGV.length == 0 || ARGV.grep(/^--help/).length > 0
+  usage()
+  exit 0
+end
+
+# We're only keeping `NIX_PATH` from the env.
+env = ENV.filter do |k, v|
+  [
+    "NIX_PATH",
+  ].include?(k)
+end
+
+args = []
+
+# Allow access to files in CWD
+args << "-I"
+args << "./"
+
+# Run the eval
+out, ret = Open3.capture2(env, "hydra-eval-jobs", *args, *ARGV)
+
+# Read the output JSON
+hydra_eval = JSON.parse(out)
+
+errors, valid_jobs = hydra_eval.partition do |k, v|
+  v.has_key?("error")
+end.map(&:to_h)
+
+out = $stdout
+
+out.puts MD.title "Hydra-like evaluation"
+
+out.puts MD.paragraph "Command used to generate this report:"
+out.puts MD.pre " $ " + (["bin/hydra-eval"] + ARGV).shelljoin()
+
+out.puts MD.section "#{valid_jobs.length} valid jobs"
+
+valid_jobs.each do |attrname, job|
+  out.puts MD.list_item(
+    MD.code(attrname) +
+    " → " +
+    MD.code(job["drvPath"])
+  )
+end
+
+out.puts MD.section "#{errors.length} errors"
+
+errors.each do |attrname, obj|
+  out.puts MD.subtitle(MD.code(attrname))
+  out.puts MD.pre(obj["error"])
+end
+
+# vim: ft=ruby

--- a/release.nix
+++ b/release.nix
@@ -58,11 +58,10 @@ let
     let
       # Trick the overlay in giving us its attributes.
       # Using the values is likely to fail. Thank lazyness!
-      overlay = import ./overlay/overlay.nix {} {};
+      overlayAttrNames = builtins.attrNames (import ./overlay/overlay.nix {} {});
     in
-    eval: 
-    (lib.genAttrs (builtins.attrNames overlay) (name: eval.pkgs.${name})) //
-    {
+    eval: let overlay = (lib.genAttrs overlayAttrNames (name: eval.pkgs.${name})); in
+    overlay // {
       # We only "monkey patch" over top of the main nixos one.
       xorg = {
         xf86videofbdev = eval.pkgs.xorg.xf86videofbdev;
@@ -71,9 +70,12 @@ let
       # lib-like attributes...
       # How should we handle these?
       imageBuilder = null;
-      kernel-builder = null;
-      kernel-builder-gcc49 = null;
-      kernel-builder-gcc6 = null;
+      mobile-nixos = overlay.mobile-nixos // {
+        kernel-builder = null;
+        kernel-builder-clang_9 = null;
+        kernel-builder-gcc49 = null;
+        kernel-builder-gcc6 = null;
+      };
 
       # Also lib-like, but a "global" like attribute :/
       defaultKernelPatches = null;


### PR DESCRIPTION
This helper is intended to be used by contributors that are changing
parts of this project that are either touching `lib/` and the evaluation
helpers, or changing `release.nix`.

There are no facilities to *compare* evals, yet. But this can be done by
the contributor, they can go to any commit they want to compare to, run
the eval and save the output markdown report. Then they can compare
against their new markdown report.

Finally, splitting the eval errors like we do in the reports should make
it really obvious what errors happened during the eval.

Here's what it looks like:

 * [With the current tip of master](https://gist.github.com/d2e9a47de833f166af2f9a58d1bc513e)
 * ~~[With this PR](https://gist.github.com/5cb881527738a8651387ec8258fd8a86)~~

And oh, look, the fix is not actually right! It's blowing away the whole `mobile-nixos` attrset!

 * [With this PR](https://gist.github.com/02053748459b16c83f66f22acbeb8474)

* * *

Additionally, fix the eval errors, as they annoyed me to no end!