### PR TITLE
cross-canary: Execute cross-built binaries using qemu-user

### DIFF
--- a/modules/cross-workarounds.nix
+++ b/modules/cross-workarounds.nix
@@ -9,7 +9,10 @@ let
     config.nixpkgs.localSystem.system != null &&
     config.nixpkgs.crossSystem.system != config.nixpkgs.localSystem.system;
 
-  AArch32Overlay = final: super: {
+  AArch32Overlay = final: super: 
+    # Ensure pkgsBuildBuild ends up unmodified, otherwise the canary test will
+    # get super expensive to build.
+    if super.stdenv.buildPlatform == super.stdenv.hostPlatform then {} else {
     # Works around libselinux failure with python on armv7l.
     # LONG_BIT definition appears wrong for platform
     libselinux = (super.libselinux

--- a/overlay/mobile-nixos/cross-canary/test.nix
+++ b/overlay/mobile-nixos/cross-canary/test.nix
@@ -49,7 +49,11 @@ if stdenv.buildPlatform == stdenv.hostPlatform then {} else (
   runtimeShell = mkTest "runtimeShell" ''
     ${emulator} ${runtimeShell} -c 'echo runtimeShell works...'
   '';
-}) // {
+
+}) //
+# Builds expected to work in both normal and static package sets.
+{
+
   busybox = mkTest "busybox" ''
     ${emulator} ${busybox}/bin/busybox uname -a
     ${emulator} ${busybox}/bin/busybox sh -c 'echo busybox works...'

--- a/overlay/mobile-nixos/cross-canary/test.nix
+++ b/overlay/mobile-nixos/cross-canary/test.nix
@@ -7,6 +7,7 @@ let
   emulators = {
     "aarch64-linux" = "qemu-aarch64";
     "armv7l-linux" = "qemu-arm";
+    "x86_64-linux" = "qemu-x86_64";
   };
   emulator =
     if stdenv.buildPlatform == stdenv.hostPlatform then ""

--- a/overlay/mobile-nixos/cross-canary/test.nix
+++ b/overlay/mobile-nixos/cross-canary/test.nix
@@ -1,4 +1,4 @@
-{ stdenv, runCommandNoCC, runtimeShell, busybox, hello-mruby, pkgsBuildBuild }:
+{ stdenv, runCommandNoCC, runtimeShell, busybox, hello-mruby, pkgsBuildBuild, pkgsStatic }:
 
 let
   inherit (stdenv) system;
@@ -41,5 +41,9 @@ if stdenv.buildPlatform == stdenv.hostPlatform then {} else
   runtimeShell = mkTest "runtimeShell" ''
     # And what about runtimeShell?
     ${emulator} ${runtimeShell} -c 'echo runtimeShell works...'
+  '';
+
+  static-mruby = mkTest "static-mruby" ''
+    ${emulator} ${pkgsStatic.hello-mruby}/bin/hello
   '';
 }

--- a/overlay/mobile-nixos/cross-canary/test.nix
+++ b/overlay/mobile-nixos/cross-canary/test.nix
@@ -59,7 +59,7 @@ if stdenv.buildPlatform == stdenv.hostPlatform then {} else (
     ${emulator} ${hello}/bin/hello
   '';
 
-  mruby = mkTest "mruby" ''
+  hello-mruby = mkTest "hello-mruby" ''
     ${emulator} ${hello-mruby}/bin/hello
   '';
 

--- a/overlay/mobile-nixos/cross-canary/test.nix
+++ b/overlay/mobile-nixos/cross-canary/test.nix
@@ -1,4 +1,4 @@
-{ stdenv, runCommandNoCC, runtimeShell, busybox, hello, hello-mruby, pkgsBuildBuild, mruby, mrbgems }:
+{ stdenv, runCommandNoCC, runtimeShell, busybox, hello, hello-mruby, pkgsBuildBuild, mruby, mrbgems, mobile-nixos }:
 
 let
   static = stdenv.hostPlatform.isStatic;
@@ -38,6 +38,14 @@ if stdenv.buildPlatform == stdenv.hostPlatform then {} else (
 # We're not creating known-failing static builds.
 (if static then {} else
 {
+  # This is more of an integrated test. It ends up exercising the systemd build.
+  # But this is still a _canary_ for us as it is at the root of our dependencies.
+  mobile-nixos-script-loader = mkTest "mobile-nixos-script-loader" ''
+    echo 'puts ARGV.inspect' > test.rb
+    ${emulator} ${mobile-nixos.stage-1.script-loader}/bin/loader
+    ${emulator} ${mobile-nixos.stage-1.script-loader}/bin/loader ./test.rb okay
+  '';
+
   runtimeShell = mkTest "runtimeShell" ''
     ${emulator} ${runtimeShell} -c 'echo runtimeShell works...'
   '';

--- a/overlay/mobile-nixos/cross-canary/test.nix
+++ b/overlay/mobile-nixos/cross-canary/test.nix
@@ -38,6 +38,11 @@ if stdenv.buildPlatform == stdenv.hostPlatform then {} else (
 # We're not creating known-failing static builds.
 (if static then {} else
 {
+  # On armv7l, known to fails with `error: C compiler cannot create executables`
+  runtimeShell = mkTest "runtimeShell" ''
+    ${emulator} ${runtimeShell} -c 'echo runtimeShell works...'
+  '';
+
   # This is more of an integrated test. It ends up exercising the systemd build.
   # But this is still a _canary_ for us as it is at the root of our dependencies.
   mobile-nixos-script-loader = mkTest "mobile-nixos-script-loader" ''
@@ -45,11 +50,6 @@ if stdenv.buildPlatform == stdenv.hostPlatform then {} else (
     ${emulator} ${mobile-nixos.stage-1.script-loader}/bin/loader
     ${emulator} ${mobile-nixos.stage-1.script-loader}/bin/loader ./test.rb okay
   '';
-
-  runtimeShell = mkTest "runtimeShell" ''
-    ${emulator} ${runtimeShell} -c 'echo runtimeShell works...'
-  '';
-
 }) //
 # Builds expected to work in both normal and static package sets.
 {

--- a/overlay/mobile-nixos/cross-canary/test.nix
+++ b/overlay/mobile-nixos/cross-canary/test.nix
@@ -1,0 +1,45 @@
+{ stdenv, runCommandNoCC, runtimeShell, busybox, hello-mruby, pkgsBuildBuild }:
+
+let
+  inherit (stdenv) system;
+  emulators = {
+    "aarch64-linux" = "qemu-aarch64";
+    "armv7l-linux" = "qemu-arm";
+  };
+  emulator =
+    if stdenv.buildPlatform == stdenv.hostPlatform then ""
+    else "${pkgsBuildBuild.qemu}/bin/${emulators.${system}}"
+  ;
+  mkTest = what: script: runCommandNoCC "cross-canary-${what}-${stdenv.system}" {} ''
+    (
+    PS4=" $ "
+    set -x
+
+    ${script}
+
+    )
+
+    # Everything went okay, mark the build as a success!
+    touch $out
+  '';
+in
+
+# We're not creating a "useless" canary when there is no cross compilation.
+if stdenv.buildPlatform == stdenv.hostPlatform then {} else
+{
+  busybox = mkTest "busybox" ''
+    # Checks that busybox works
+    ${emulator} ${busybox}/bin/busybox uname -a
+    ${emulator} ${busybox}/bin/busybox sh -c 'echo busybox works...'
+  '';
+
+  mruby = mkTest "mruby" ''
+    # Checks that mruby works at its most basic.
+    ${emulator} ${hello-mruby}/bin/hello
+  '';
+
+  runtimeShell = mkTest "runtimeShell" ''
+    # And what about runtimeShell?
+    ${emulator} ${runtimeShell} -c 'echo runtimeShell works...'
+  '';
+}

--- a/overlay/mruby-builder/mruby/default.nix
+++ b/overlay/mruby-builder/mruby/default.nix
@@ -12,9 +12,9 @@ in
 { stdenv
 , lib
 , buildPackages
+, pkgsBuildBuild
 , ruby
 , bison
-, rake
 , fetchFromGitHub
 , file
 , mruby
@@ -189,7 +189,7 @@ let
         --replace '//#define MRB_INT64' '#define MRB_INT64'
     '';
 
-    nativeBuildInputs = [ pkgconfig-helper ruby bison rake ] ++ gemNativeBuildInputs;
+    nativeBuildInputs = [ pkgconfig-helper ruby bison pkgsBuildBuild.rake ] ++ gemNativeBuildInputs;
     buildInputs = gemBuildInputs;
 
     # Necessary so it uses `gcc` instead of `ld` for linking.

--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -136,6 +136,8 @@ in
       make-flashable-zip = callPackage ./mobile-nixos/android-flashable-zip/make-flashable-zip.nix {};
 
       map-dtbs = callPackage ./mobile-nixos/map-dtbs {};
+
+      cross-canary-test = callPackage ./mobile-nixos/cross-canary/test.nix {};
     };
 
     imageBuilder = callPackage ../lib/image-builder {};

--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -138,6 +138,7 @@ in
       map-dtbs = callPackage ./mobile-nixos/map-dtbs {};
 
       cross-canary-test = callPackage ./mobile-nixos/cross-canary/test.nix {};
+      cross-canary-test-static = self.pkgsStatic.callPackage ./mobile-nixos/cross-canary/test.nix {};
     };
 
     imageBuilder = callPackage ../lib/image-builder {};

--- a/release.nix
+++ b/release.nix
@@ -75,6 +75,12 @@ let
         kernel-builder-clang_9 = null;
         kernel-builder-gcc49 = null;
         kernel-builder-gcc6 = null;
+
+        # Ugly, but this allows the cross-canary-test to be distinct tests.
+        cross-canary-test = overlay.mobile-nixos.cross-canary-test // {
+          override = null;
+          overrideDerivation = null;
+        };
       };
 
       # Also lib-like, but a "global" like attribute :/
@@ -143,7 +149,8 @@ rec {
     hasSystem = name: lib.lists.any (el: el == name) systems;
 
     constituents =
-      lib.optionals (hasSystem "x86_64-linux") [
+      (builtins.attrValues overlay.x86_64-linux.aarch64-linux-cross.mobile-nixos.cross-canary-test)
+      ++ lib.optionals (hasSystem "x86_64-linux") [
         device.uefi-x86_64.x86_64-linux              # UEFI system
         # Cross builds
         device.asus-z00t.x86_64-linux                # Android
@@ -174,6 +181,7 @@ rec {
     hasSystem = name: lib.lists.any (el: el == name) systems;
 
     constituents = tested.constituents
+      ++ (builtins.attrValues overlay.x86_64-linux.armv7l-linux-cross.mobile-nixos.cross-canary-test)
       ++ lib.optionals (hasSystem "x86_64-linux") [
         device.asus-flo.x86_64-linux
         overlay.x86_64-linux.armv7l-linux-cross.mobile-nixos.android-flashable-zip-binaries
@@ -187,7 +195,7 @@ rec {
       ;
   in
   releaseTools.aggregate {
-    name = "mobile-nixos-tested";
+    name = "mobile-nixos-tested-plus";
     inherit constituents;
     meta = {
       description = ''


### PR DESCRIPTION
This is intended for CI (Hydra).

It should, hopefully, make it obvious if binaries produced do not work.

Right now it's testing a really shallow subset of things, but I'm not even sure it is ever going to catch anything anyway.

Let's see what will happen

## TODO

 - [x] Also build `pkgsStatic` variant in release.nix.
 - [x] ~~Review canaries, try to reproduce issue with amazon-austin and reproduce in a canary.~~

Issues on `amazon-austin` could not be reproduced on the latest Nixpkgs revisions. I assume it was specific to something that was fixed in-between the last known good, and the current-soon-good.

It was tested good using:

https://github.com/samueldr/nixpkgs/tree/wip/armv7lfixes

~~(Depends on #316)~~