### PR TITLE
pinephone: Update boot partition name in README

### DIFF
--- a/devices/pine64-pinephone/README.adoc
+++ b/devices/pine64-pinephone/README.adoc
@@ -27,7 +27,7 @@ NixOS boot partition.
 
 ```
  $ nix-build --argstr device pine64-pinephone -A build.boot-partition
- $ dd if=result/mobile-nixos-boot.img of=/dev/mmcblkXp1 bs=8M oflag=sync,direct status=progress
+ $ dd if=result/mobile-nixos-boot.img of=/dev/mmcblkXp3 bs=8M oflag=sync,direct status=progress
 ```
 
 === Building U-Boot


### PR DESCRIPTION
Hi @samueldr,

as discussed on IRC, this updates the pinephone README to refer to the boo partition as mmcblkXp3.

Thanks!