### PR TITLE
pine64-pinephone: comment how to enable console output during boot

### DIFF
--- a/devices/pine64-pinephone/default.nix
+++ b/devices/pine64-pinephone/default.nix
@@ -34,6 +34,8 @@
     "earlycon=uart,mmio32,0x01c28000"
     "panic=10"
     "consoleblank=0"
+    # Uncomment to show console output during boot.
+    # "console=tty1"
   ];
 
   mobile.system.type = "u-boot";


### PR DESCRIPTION
some people may want to have it visible

add "console=tty1" to kernelParams