### PR TITLE
dtbTool-exynos + mkbootimg: support cross-compilation

### DIFF
--- a/overlay/dtbtool-exynos/default.nix
+++ b/overlay/dtbtool-exynos/default.nix
@@ -23,6 +23,11 @@ stdenv.mkDerivation {
     dtc
   ];
 
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace "strip" "${stdenv.cc.targetPrefix}strip"
+  '';
+
   installPhase = ''
     mkdir -p $out/bin
     mv dtbTool-exynos $out/bin/

--- a/overlay/mkbootimg/default.nix
+++ b/overlay/mkbootimg/default.nix
@@ -9,6 +9,15 @@ stdenv.mkDerivation rec {
     sha256 = "1zz06x31rak9sv5v01kj3cvqvzh5qvq34p00paw5p3jl0lxvnvwc";
   };
 
+  # Using makeFlags doesn't work due to the args being passed as well
+  # Replacing is required for cross-compilation
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace "AR = ar rcv" "AR = ${stdenv.cc.bintools.targetPrefix}ar rcv"
+    substituteInPlace libmincrypt/Makefile \
+      --replace "AR = ar rc" "AR = ${stdenv.cc.bintools.targetPrefix}ar rc"
+  '';
+
   installPhase = ''
     mkdir -p $out/bin
     cp -v mkbootimg $out/bin/


### PR DESCRIPTION
Not sure if making a patch would be better, or what the preference is. I can confirm that both tools now at least build with `nix-build --argstr device pine64-pinephone pkgs.<pkg-name>`.

I don't know if this is useful for anything, but since it's in hydra I guess it might be useful for something.

A nice step towards a more green hydra :).
