### PR TITLE
autoport: 0.0.1 -> 0.0.2

### DIFF
--- a/overlay/mobile-nixos/autoport/default.nix
+++ b/overlay/mobile-nixos/autoport/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation {
   pname = "mobile-nixos-autoport";
-  version = "0.0.1";
+  version = "0.0.2";
 
   src = fetchFromGitHub {
     owner = "mobile-nixos";
     repo = "autoport";
-    rev = "e439066d09154e9123890c2e4fc6d6323c530640";
-    sha256 = "0x548k91q17m1zf5r8kjwiyxlsvf55n60bw0ljhw71pcn0xdlic4";
+    rev = "8958b938ab6eba5e5018580b20705bbc6d5545d4";
+    sha256 = "1ksvdk81paax3pzki5ikf6p5q7hpx2bg0abc1pgrv2avzqq9nnfh";
   };
 
   buildInputs = [


### PR DESCRIPTION
Mainly fixes issue with the original host being taken down. (For
unrelated reasons.)