### PR TITLE
pine64-pinephone: Use the more generic device path for modem

### DIFF
--- a/devices/pine64-pinephone/modem.nix
+++ b/devices/pine64-pinephone/modem.nix
@@ -29,11 +29,11 @@
   #
   # If you want it to be disabled by default on boot, use:
   #
-  #     systemd.services.modem-control.wantedBy = lib.mkForce [ "sys-devices-platform-soc-1c1b000.usb-usb3-3\\x2d1-3\\x2d1:1.4-net-wwan0.device" ];
+  #     systemd.services.modem-control.wantedBy = lib.mkForce [ "sys-subsystem-net-devices-wwan0.device" ];
   #
   systemd.services =
     let
-      dotDeviceName = "sys-devices-platform-soc-1c1b000.usb-usb3-3\\x2d1-3\\x2d1:1.4-net-wwan0.device";
+      dotDeviceName = "sys-subsystem-net-devices-wwan0.device";
     in {
     "modem-control" = {
       bindsTo = [ dotDeviceName ];


### PR DESCRIPTION
Finally have a spare SIM to plug into my pmOS edition PinePhone so it can be an actual phone. However, the device path for the modem [in modem.nix](https://github.com/NixOS/mobile-nixos/blob/bf42da0c3f7c302527620a2f77632739bf56b621/devices/pine64-pinephone/modem.nix#L36) is wrong. For me (pmOS CE), the correct path is `sys-devices-platform-soc-1c1b000.usb-usb2-2\\x2d1-2\\x2d1:1.4-net-wwan0.device`. It may be better to make it `sys-subsystem-net-devices-wwan0.device` instead.