### PR TITLE
examples/phosh-demo: init

### DIFF
--- a/examples/phosh-demo/README.md
+++ b/examples/phosh-demo/README.md
@@ -1,0 +1,9 @@
+> **WARNING**: This configuration is insecure.
+
+## Building
+
+The stage-2 needs to be built natively on the target architecture (armv7 on
+armv7, aarch64 on aarch64).
+
+(Though the tooling will try and likely fail to build it through
+cross-compilation!)

--- a/examples/phosh-demo/configuration.nix
+++ b/examples/phosh-demo/configuration.nix
@@ -1,0 +1,131 @@
+{ config, lib, pkgs, ... }:
+
+let
+  terminal = pkgs.kgx.override { genericBranding = true; };
+
+  # One-stop shop to customize the default username before building.
+  defaultUserName = "alice";
+in
+{
+  config = lib.mkMerge [
+    # INSECURE STUFF FIRST
+    # Users and hardcoded passwords.
+    {
+      # Forcibly set a password on users...
+      # Note that a numeric password is currently required to unlock a session
+      # with the plasma mobile shell :/
+      users.users.${defaultUserName} = {
+        isNormalUser = true;
+        # Numeric pin makes it **possible** to input on the lockscreen.
+        password = "1234";
+        home = "/home/${defaultUserName}";
+        extraGroups = [ "wheel" "networkmanager" "video" "feedbackd" ];
+        uid = 1000;
+      };
+
+      users.users.root.password  = "nixos";
+
+      # FIXME: highly insecure!
+      # FIXME: Figure out why this breaks...
+      #services.openssh.extraConfig = "PermitEmptyPasswords yes";
+    }
+
+    # "Desktop" environment configuration
+    {
+      powerManagement.enable = true;
+      hardware.opengl.enable = true;
+
+      systemd.defaultUnit = "graphical.target";
+      systemd.services.phosh = {
+        wantedBy = [ "graphical.target" ];
+        serviceConfig = {
+          ExecStart = "${pkgs.phosh}/bin/phosh";
+          User = 1000;
+          PAMName = "login";
+          WorkingDirectory = "~";
+
+          TTYPath = "/dev/tty7";
+          TTYReset = "yes";
+          TTYVHangup = "yes";
+          TTYVTDisallocate = "yes";
+
+          StandardInput = "tty-fail";
+          StandardOutput = "journal";
+          StandardError = "journal";
+
+          UtmpIdentifier = "tty7";
+          UtmpMode = "user";
+
+          Restart = "always";
+        };
+      };
+
+      services.xserver.desktopManager.gnome.enable = true;
+
+      # Unpatched gnome-initial-setup is partially broken in small screens
+      services.gnome.gnome-initial-setup.enable = false;
+
+      programs.phosh.enable = true;
+      environment.systemPackages = [ terminal pkgs.chatty ];
+      environment.gnome.excludePackages = with pkgs.gnome3; [
+        gnome-terminal
+      ];
+
+      programs.calls.enable = true;
+
+      environment.etc."machine-info".text = lib.mkDefault ''
+        CHASSIS="handset"
+      '';
+    }
+
+    # Networking, modem and misc.
+    {
+      networking.wireless.enable = false;
+      networking.networkmanager.enable = true;
+
+      # FIXME : configure usb rndis through networkmanager in the future.
+      # Currently this relies on stage-1 having configured it.
+      networking.networkmanager.unmanaged = [ "rndis0" "usb0" ];
+
+      # Setup USB gadget networking in initrd...
+      mobile.boot.stage-1.networking.enable = lib.mkDefault true;
+
+      # Required for modem access
+      users.users.${defaultUserName}.extraGroups = [ "dialout" ];
+    }
+
+    # Bluetooth
+    {
+      hardware.bluetooth.enable = true;
+    }
+
+    # SSH
+    {
+      # Start SSH by default...
+      # Not a good idea given the fact it's insecure.
+      services.openssh = {
+        enable = true;
+        permitRootLogin = "yes";
+      };
+
+      # Don't start it in stage-1 though.
+      # (Currently doesn't quit on switch root)
+      # mobile.boot.stage-1.ssh.enable = true;
+    }
+
+    # Default quirks
+    {
+      # Ensures this demo rootfs is useable for platforms requiring FBIOPAN_DISPLAY.
+      mobile.quirks.fb-refresher.enable = true;
+
+      # Okay, systemd-udev-settle times out... no idea why yet...
+      # Though, it seems fine to simply disable it.
+      # FIXME : figure out why systemd-udev-settle doesn't work.
+      systemd.services.systemd-udev-settle.enable = false;
+
+      # Force userdata for the target partition. It is assumed it will not
+      # fit in the `system` partition.
+      mobile.system.android.system_partition_destination = "userdata";
+    }
+  ];
+}

--- a/examples/phosh-demo/default.nix
+++ b/examples/phosh-demo/default.nix
@@ -1,0 +1,14 @@
+{ device ? null
+, pkgs ? (import ../../pkgs.nix {})
+}@args':
+let args = args' // { inherit pkgs; }; in
+
+import ../../lib/eval-with-configuration.nix (args // {
+  configuration = [ (import ./configuration.nix) ];
+  additionalHelpInstructions = ''
+    You can build the `-A build.default` attribute to build the default output
+    for your device.
+
+     $ nix-build examples/phosh-demo --argstr device ${device} -A outputs.default
+  '';
+})


### PR DESCRIPTION
A very simple Phosh demo image with the full default GNOME app set, with gnome-terminal replaced by kgx. Not very exciting as many apps are broken on mobile :confused:

Librem has [a GTK patchset](https://source.puri.sm/Librem5/debs/gtk/-/tree/pureos/byzantium/debian/patches) which you can apply with [my overlay](https://github.com/zhaofengli/librem-nixos) (not included).

<details>
<summary>Screenshot</summary>
<img src="https://user-images.githubusercontent.com/2189609/116799410-f9168980-aaad-11eb-9b6b-4ece93bda2e5.jpg" alt="PinePhone running Mobile NixOS with Phosh" style="max-width:30%;">
</details>