### PR TITLE
module/lib: try to pass specialArgs to eval

### DIFF
--- a/modules/lib.nix
+++ b/modules/lib.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, baseModules, modules, ... }:
+args@{ config, lib, pkgs, baseModules, modules, ... }:
 
 let
   # Keep modules from this eval around
@@ -26,6 +26,9 @@ in
         # to use `builtins.currentSystem`.
         inherit system;
         inherit baseModules;
+        # Newer versions of module system pass specialArgs to modules, so try
+        # to pass that to eval if possible.
+        specialArgs = args.specialArgs or { };
         # Merge in this eval's modules with the argument's modules, and finally
         # with the given config.
         modules = modules' ++ modules ++ [ config ];


### PR DESCRIPTION
fixes #353

Allows hosts to make use of specialArgs if they are using a new enough version of nixpkgs and lib/evalModules. Specifically the change from nixos/nixpkgs#121870 is needed. I don't think there is any way to fix this problem for people using older versions.
