### PR TITLE
examples/demo: Misc fixes

### DIFF
--- a/examples/demo/configuration.nix
+++ b/examples/demo/configuration.nix
@@ -100,6 +100,13 @@ in
         ln -sfT ${minesDesktopFile} ${desktopDir + "mines.desktop"}
       '';
 
+      users.users.nixos = {
+        isNormalUser = true;
+        extraGroups = [ "wheel" "networkmanager" "video" ];
+      };
+    }
+
+    {
       # Forcibly set a password on users...
       # FIXME: highly insecure!
       # FIXME: Figure out why this breaks...

--- a/examples/demo/configuration.nix
+++ b/examples/demo/configuration.nix
@@ -18,6 +18,10 @@ let
   '';
 in
 {
+  imports = [
+    ./workaround-v4l_id-hang.nix
+  ];
+
   config = lib.mkMerge [
     {
 
@@ -102,11 +106,6 @@ in
       #services.openssh.extraConfig = "PermitEmptyPasswords yes";
       users.users.nixos.password = "nixos";
       users.users.root.password = "nixos";
-
-      # Okay, systemd-udev-settle times out... no idea why yet...
-      # Though, it seems fine to simply disable it.
-      # FIXME : figure out why systemd-udev-settle doesn't work.
-      systemd.services.systemd-udev-settle.enable = false;
     }
 
     # Networking, modem and misc.

--- a/examples/demo/workaround-v4l_id-hang.nix
+++ b/examples/demo/workaround-v4l_id-hang.nix
@@ -1,0 +1,17 @@
+# This works around an issue on at least one device (motorola-addison) where
+# the v4l_id tool from udev hangs for more than a minute on boot.
+#
+# This replaces the file from udev with an empty one.
+{ pkgs, lib, ... }:
+
+let
+  emptyV4lRules = pkgs.runCommandNoCC "empty-v4l-rules" {} ''
+    mkdir -p $out/lib/udev/rules.d
+    touch $out/lib/udev/rules.d/60-persistent-v4l.rules
+  '';
+in
+{
+  services.udev.packages = lib.mkOrder 10000 [
+    emptyV4lRules
+  ];
+}


### PR DESCRIPTION
This fixes:

 - The currently broken build
 - Uses the now-known workaround for the hang on boot

The main goal here is to get the demo rootfs to be built again on Hydra.