### PR TITLE
Fix boot problem with google-marlin/sailfish

### DIFF
--- a/devices/google-marlin/default.nix
+++ b/devices/google-marlin/default.nix
@@ -39,6 +39,8 @@
   mobile.system.vendor.partition = "/dev/disk/by-partlabel/vendor_a";
 
   boot.kernelParams = [
+    # For use with the "Nexus-style" UART cable, add the following kernel parameter.
+    # "console=ttyHSL0,115200,n8"
   ];
 
   mobile.usb.mode = "android_usb";

--- a/devices/google-marlin/default.nix
+++ b/devices/google-marlin/default.nix
@@ -39,15 +39,6 @@
   mobile.system.vendor.partition = "/dev/disk/by-partlabel/vendor_a";
 
   boot.kernelParams = [
-    "console=ttyHSL0,115200,n8"
-    "androidboot.console=ttyHSL0"
-    "androidboot.hardware=marlin"
-    "user_debug=31"
-    "ehci-hcd.park=3"
-    "lpm_levels.sleep_disabled=1"
-    "cma=32M@0-0xffffffff"
-    "loop.max_part=7"
-    "buildvariant=eng"
   ];
 
   mobile.usb.mode = "android_usb";


### PR DESCRIPTION
When the ttyHSL0 console isn't actually available, things will hopelessly break.

I also took the time to cleanup the (now known to be) unneeded kernel params.

Actually tested on `google-sailfish`, but turns out the build works.

cc @danielfullmer 
cc @nh2