### PR TITLE
imageBuilder: speed up gen on binfmt by batching `du` calls: 44min -> 1min45s

### DIFF
--- a/lib/image-builder/makeFilesystem.nix
+++ b/lib/image-builder/makeFilesystem.nix
@@ -62,7 +62,7 @@ stdenvNoCC.mkDerivation (args // rec {
       # multiple of blockSize.
       # Use of `--apparent-size` is to ensure we don't get the block size of the underlying FS.
       # Use of `--block-size` is to get *our* block size.
-      size=$(find . ! -type d -exec 'du' '--apparent-size' '--block-size' "$blockSize" '{}' ';' | cut -f1 | sum-lines)
+      size=$(find . ! -type d -print0 | xargs -0 'du' '--apparent-size' '--block-size' "$blockSize" | cut -f1 | sum-lines)
       echo "Reserving $size sectors for files..." 1>&2
 
       # Adds one blockSize per directory, they do take some place, in the end.

--- a/lib/image-builder/makeFilesystem.nix
+++ b/lib/image-builder/makeFilesystem.nix
@@ -62,7 +62,7 @@ stdenvNoCC.mkDerivation (args // rec {
       # multiple of blockSize.
       # Use of `--apparent-size` is to ensure we don't get the block size of the underlying FS.
       # Use of `--block-size` is to get *our* block size.
-      size=$(find . ! -type d -print0 | xargs -0 'du' '--apparent-size' '--block-size' "$blockSize" | cut -f1 | sum-lines)
+      size=$(find . ! -type d -print0 | du --files0-from=- --apparent-size --block-size "$blockSize" | cut -f1 | sum-lines)
       echo "Reserving $size sectors for files..." 1>&2
 
       # Adds one blockSize per directory, they do take some place, in the end.


### PR DESCRIPTION
fixes https://github.com/NixOS/mobile-nixos/issues/372

Per https://github.com/NixOS/mobile-nixos/issues/372, I observed
building an image takes ~40 minutes, and it spends the vast majority
of that performing `du` on the files that will be included in the image.

Most of that time is on process invocation overhead, and thus we can
save a lot by batching calls to `du`.

Per https://danielmiessler.com/blog/linux-xargs-vs-exec/, replacing
`find -exec du` with `find -print0 | xargs -0 du` is an optimisation to do
this. xargs will invoke du as "du fn1 fn2 fn3 fn4 ...", etc.

Before: 44mins (full output: https://paste.debian.net/1203075/ )
After: 1m45s (full output: https://paste.debian.net/1203076/ )

To reproduce this issue on a smaller dataset, try the before and after
on a directory with many files (e.g. nixpkgs checkout, which has ~27k files):

```
$ cd nixpkgs
$ time find . ! -type d -exec du {} \; | cut -f1 | sum
53288    55

real	0m20.802s
user	0m9.660s
sys	0m11.626s

$ time find . ! -type d -print0 | xargs -0 du | cut -f1 | sum
53288    55

real	0m0.097s
user	0m0.042s
sys	0m0.171s
```

That's a 200x speedup.

To discount the possibility of this issue being `find` or file I/O related:

```
$ time bash -c 'seq 27000 | xargs /run/current-system/sw/bin/echo | wc'
      2   27000  150894

real	0m0.008s
user	0m0.006s
sys	0m0.006s

$ time bash -c 'for i in $(seq 27000); do /run/current-system/sw/bin/echo $i; done | wc'
  27000   27000  150894

real	0m19.815s
user	0m9.876s
sys	0m10.755s
```

The ~27k process invocation still takes ~20s.

This shows the problem is process invocation.

Is this safe?

* Both before and after produce the same sector result: "926478
sectors for files" and "21491 sectors for directories"
* `-print0` and `-0` are needed to ensure this works with filenames
that contain spaces.