### PR TITLE
pine64-pinephone: Use the more generic device path for modem

### DIFF
--- a/devices/pine64-pinephone/modem.nix
+++ b/devices/pine64-pinephone/modem.nix
@@ -29,11 +29,11 @@
   #
   # If you want it to be disabled by default on boot, use:
   #
-  #     systemd.services.modem-control.wantedBy = lib.mkForce [ "sys-devices-platform-soc-1c1b000.usb-usb3-3\\x2d1-3\\x2d1:1.4-net-wwan0.device" ];
+  #     systemd.services.modem-control.wantedBy = lib.mkForce [ "sys-subsystem-net-devices-wwan0.device" ];
   #
   systemd.services =
     let
-      dotDeviceName = "sys-devices-platform-soc-1c1b000.usb-usb3-3\\x2d1-3\\x2d1:1.4-net-wwan0.device";
+      dotDeviceName = "sys-subsystem-net-devices-wwan0.device";
     in {
     "modem-control" = {
       bindsTo = [ dotDeviceName ];


### PR DESCRIPTION
Taken from https://github.com/NixOS/mobile-nixos/pull/347/

Motivation: Fix modem on postmarketOS edition PinePhone.

eg25-manager is being considered in https://github.com/NixOS/mobile-nixos/issues/348. Even if we want that, we would need a kernel patch.

Until then, let's fix modems on the other PinePhones.

For the postmarketOS edition PinePhone, the device path is:

```
sys-devices-platform-soc-1c1b000.usb-usb2-2\\x2d1-2\\x2d1:1.4-net-wwan0.device
```