### PR TITLE
module/lib: Actually pass specialArgs to eval

### DIFF
--- a/modules/lib.nix
+++ b/modules/lib.nix
@@ -1,4 +1,4 @@
-args@{ config, lib, pkgs, baseModules, modules, ... }:
+parentArgs@{ config, lib, pkgs, baseModules, modules, ... }:
 
 let
   # Keep modules from this eval around
@@ -28,7 +28,7 @@ in
         inherit baseModules;
         # Newer versions of module system pass specialArgs to modules, so try
         # to pass that to eval if possible.
-        specialArgs = args.specialArgs or { };
+        specialArgs = parentArgs.specialArgs or { };
         # Merge in this eval's modules with the argument's modules, and finally
         # with the given config.
         modules = modules' ++ modules ++ [ config ];


### PR DESCRIPTION
#354 doesn't really work because `args` is shadowed by the inner definition on line 19. Tested to work with Colmena which relies on `specialArgs` for evaluation.

cc @Pacman99