### PR TITLE
lvgui: 2021-07-19 -> 2021-07-20

### DIFF
--- a/boot/script-loader/mruby-lvgui-native-fragment/lvgui.nix
+++ b/boot/script-loader/mruby-lvgui-native-fragment/lvgui.nix
@@ -95,13 +95,13 @@ let
 in
   stdenv.mkDerivation {
     pname = "lvgui";
-    version = "2021-07-19";
+    version = "2021-07-20";
 
     src = fetchFromGitHub {
       repo = "lvgui";
       owner = "mobile-nixos";
-      rev = "26ae35bb501912224c36e35a68f3b6f02fe5c751";
-      sha256 = "04qq328nf7pcnyfw0864zcns3y3wj8zv05caixbfqxl2w5v45c2q";
+      rev = "ba381a2749848ac69e08e9e59fe8a14054bcb24e";
+      sha256 = "0989m73kcrybgadszk1ffh4cbcfrmi0f79lbg87wrn5bxwaqbawr";
     };
 
     # Document `LVGL_ENV_SIMULATOR` in the built headers.

--- a/overlay/mruby-builder/mruby/default.nix
+++ b/overlay/mruby-builder/mruby/default.nix
@@ -235,7 +235,7 @@ let
     meta = with lib; {
       description = "An embeddable implementation of the Ruby language";
       homepage = https://mruby.org;
-      maintainers = [ maintainers.nicknovitski ];
+      maintainers = [ maintainers.samueldr ];
       license = licenses.mit;
       platforms = platforms.unix;
     };


### PR DESCRIPTION
This fixes the issues with rendering SVGs when a dimension is bigger than 2048

Also a minor fix for mruby's maintainer. The previous value came from importing the NixOS derivation.