### PR TITLE
pine64-pinephone: include USB-C port anx7688 firmware

### DIFF
--- a/devices/pine64-pinephone/firmware/default.nix
+++ b/devices/pine64-pinephone/firmware/default.nix
@@ -14,4 +14,5 @@ runCommandNoCC "pine64-pinephone-firmware" {
 } ''
   mkdir -p "$out/lib/firmware"
   cp -vrf "$src/rtl_bt" $out/lib/firmware/
+  cp -vf "$src/anx7688-fw.bin" $out/lib/firmware/
 ''

--- a/devices/pine64-pinephone/firmware/default.nix
+++ b/devices/pine64-pinephone/firmware/default.nix
@@ -1,15 +1,14 @@
 { lib
 , runCommandNoCC
-, fetchFromGitHub
+, fetchgit
 }:
 
 # The minimum set of firmware files required for the device.
 runCommandNoCC "pine64-pinephone-firmware" {
-  src = fetchFromGitHub {
-    owner = "anarsoul";
-    repo = "rtl8723bt-firmware";
-    rev = "28ad3584927c0fe1f321176f73a7fd42cccec56f";
-    sha256 = "0ccdifninnqpvrqg4f4b5vgy3d5g7n6xx6qny7by9aramsd94l17";
+  src = fetchgit {
+    url = "https://megous.com/git/linux-firmware";
+    rev = "4ec2645b007ba4c3f2962e38b50c06f274abbf7c";
+    sha256 = "0mx5h2r7j5bik4wdkgdyzjpj1x6fx2y4p8y1ir4ic76902xhipr6";
   };
   meta.license = lib.licenses.unfreeRedistributable;
 } ''


### PR DESCRIPTION
Documented at https://xnux.eu/devices/feature/anx7688.html

Example dmesg of this working:
```
$ dmesg | grep anx7688
[    3.200922] anx7688 1-0028: power enabled
[    3.201218] anx7688 1-0028: Vendor id 0x1f29
[    3.216944] anx7688 1-0028: power disabled
[    3.217173] anx7688 1-0028: enabling USB BC 1.2 detection
[    3.217337] anx7688 1-0028: plug irq (cd=1)
[    3.237870] anx7688 1-0028: BC 1.2 result: SDP
[    3.237893] anx7688 1-0028: cable inserted
[    3.280929] anx7688 1-0028: power enabled
[    3.353049] anx7688 1-0028: eeprom0 = 0x03
[    3.353080] anx7688 1-0028: fw loaded after 40 ms
[    3.353267] anx7688 1-0028: OCM firmware loaded (version 0x2410)
[    3.354327] anx7688 1-0028: send pd packet cmd=0x00 05 00 32 90 01 26 12
[    3.394021] anx7688 1-0028: send pd packet cmd=0x01 05 01 2c 91 01 26 16
[    3.394570] anx7688 1-0028: send pd packet cmd=0x02 11 02 00 00 00 ec 00 00 00 00 00 00 00 00 39 00 00 51 77
[    3.395421] anx7688 1-0028: send pd packet cmd=0x03 05 03 00 00 01 ff f8
[    3.395966] anx7688 1-0028: OCM configuration completed
[    3.396567] anx7688 1-0028: status changed to 0x00
[    3.396583] anx7688 1-0028: cc_status changed to CC1 = SRC.Open CC2 = SRC.Open
[    3.396596] anx7688 1-0028: DP state changed to 0x00
[    3.396607] anx7688 1-0028: VCONN role change to SINK
[    3.396629] anx7688 1-0028: DATA role change requested to UFP
[    3.837656] anx7688 1-0028: cc_status changed to CC1 = SNK.Power3.0 CC2 = SRC.Open
[    3.921519] anx7688 1-0028: recv ocm message cmd=0x00 11 00 2c 91 51 2e 2c d1 12 00 2c b1 14 00 2c 41 16 00 30
[    3.922098] anx7688 1-0028: received SRC_CAP
[    3.922354] anx7688 1-0028: SRC_CAP PDO_FIXED (5000mV 3000mA)
[    3.922586] anx7688 1-0028: SRC_CAP PDO_FIXED (9000mV 3000mA)
[    3.922595] anx7688 1-0028: SRC_CAP PDO_FIXED (15000mV 3000mA)
[    3.922605] anx7688 1-0028: SRC_CAP PDO_FIXED (20000mV 3000mA)
[    3.922876] anx7688 1-0028: RDO max voltage = 5000mV, max power = 15000mW, PD current limit = 3000mA
[    4.207306] anx7688 1-0028: BC 1.2 result: SDP
[    5.249255] anx7688 1-0028: status changed to 0x24
[    5.249265] anx7688 1-0028: VCONN role change to SOURCE
[    5.249347] anx7688 1-0028: DATA role change requested to DFP
[    5.249383] anx7688 1-0028: updating power mode to PD, current limit 3000mA (0 => BC1.2)
[    5.249393] anx7688 1-0028: disabling USB BC 1.2 detection
[    5.249547] anx7688 1-0028: setting vbus_in current limit to 3000 mA
[    5.249624] anx7688 1-0028: enabling vbus_in power path
[    7.301393] anx7688 1-0028: DP state changed to 0x02
[    8.336700] anx7688 1-0028: DP state changed to 0x04
[    9.345416] anx7688 1-0028: DP state changed to 0x06
[  184.449440] anx7688 1-0028: DP state changed to 0x04
[  185.473438] anx7688 1-0028: DP state changed to 0x06
[  283.217368] anx7688 1-0028: plug irq (cd=0)
[  283.238714] anx7688 1-0028: cable removed
[  283.258040] anx7688 1-0028: power disabled
[  283.269783] anx7688 1-0028: setting vbus_in current limit to 500000 mA
[  283.276441] anx7688 1-0028: disabling vbus_in power path
[  283.283644] anx7688 1-0028: enabling USB BC 1.2 detection
[  283.309445] anx7688 1-0028: BC 1.2 result: SDP
[  294.128719] anx7688 1-0028: plug irq (cd=1)
[  294.140867] anx7688 1-0028: cable inserted
[  294.180890] anx7688 1-0028: power enabled
[  294.245020] anx7688 1-0028: eeprom0 = 0x03
[  294.245053] anx7688 1-0028: fw loaded after 40 ms
[  294.245216] anx7688 1-0028: OCM firmware loaded (version 0x2410)
[  294.246150] anx7688 1-0028: send pd packet cmd=0x00 05 00 32 90 01 26 12
[  294.295351] anx7688 1-0028: send pd packet cmd=0x01 05 01 2c 91 01 26 16
[  294.295881] anx7688 1-0028: send pd packet cmd=0x02 11 02 00 00 00 ec 00 00 00 00 00 00 00 00 39 00 00 51 77
[  294.296658] anx7688 1-0028: send pd packet cmd=0x03 05 03 00 00 01 ff f8
[  294.297212] anx7688 1-0028: OCM configuration completed
[  294.300221] anx7688 1-0028: status changed to 0x00
[  294.300254] anx7688 1-0028: cc_status changed to CC1 = SRC.Open CC2 = SRC.Open
[  294.300262] anx7688 1-0028: DP state changed to 0x00
[  294.300269] anx7688 1-0028: VCONN role change to SINK
[  294.300289] anx7688 1-0028: DATA role change requested to UFP
[  294.750080] anx7688 1-0028: cc_status changed to CC1 = SRC.Open CC2 = SNK.Power3.0
[  294.828602] anx7688 1-0028: recv ocm message cmd=0x00 11 00 2c 91 11 0a 2c d1 12 00 2c b1 14 00 45 41 16 00 7b
[  294.829898] anx7688 1-0028: received SRC_CAP
[  294.830023] anx7688 1-0028: SRC_CAP PDO_FIXED (5000mV 3000mA)
[  294.830035] anx7688 1-0028: SRC_CAP PDO_FIXED (9000mV 3000mA)
[  294.830044] anx7688 1-0028: SRC_CAP PDO_FIXED (15000mV 3000mA)
[  294.830054] anx7688 1-0028: SRC_CAP PDO_FIXED (20000mV 3250mA)
[  294.830332] anx7688 1-0028: RDO max voltage = 5000mV, max power = 15000mW, PD current limit = 3000mA
[  295.969449] anx7688 1-0028: updating power mode to PD, current limit 3000mA (0 => BC1.2)
[  295.969486] anx7688 1-0028: disabling USB BC 1.2 detection
[  295.969571] anx7688 1-0028: setting vbus_in current limit to 3000 mA
[  295.969657] anx7688 1-0028: enabling vbus_in power path
[  296.097957] anx7688 1-0028: BC 1.2 result: SDP

```