### PR TITLE
pine64-pinephone: Increase CMA to 128MiB

### DIFF
--- a/devices/pine64-pinephone/kernel/default.nix
+++ b/devices/pine64-pinephone/kernel/default.nix
@@ -1,6 +1,7 @@
 {
   mobile-nixos
 , fetchFromGitHub
+, fetchpatch
 , ...
 }:
 
@@ -17,6 +18,10 @@ mobile-nixos.kernel-builder {
   };
   patches = [
     ./0001-dts-pinephone-Setup-default-on-and-panic-LEDs.patch
+    (fetchpatch {
+      url = "https://github.com/mobile-nixos/linux/commit/372597b5449b7e21ad59dba0842091f4f1ed34b2.patch";
+      sha256 = "1lca3fdmx2wglplp47z2d1030bgcidaf1fhbnfvkfwk3fj3grixc";
+    })
   ];
 
   # Install *only* the desired FDTs


### PR DESCRIPTION
With a patch that we should get mainlined.

* * *

Verified to allocate CMA correctly:

```
Jul 26 20:23:24 itchy kernel: Reserved memory: created CMA memory pool at 0x00000000b8000000, size 128 MiB
```

For some reason megapixels only shows a black screen for me. BUT, before this change it would Abort, while with this it continues running. I wonder if running on X11 or non-phosh is supposed to work.

```
Failed to get display configuration: GDBus.Error:org.freedesktop.DBus.Error.NameHasNoOwner: Name "org.gnome.Mutter.DisplayConfig" does not exist
```

To *correctly* test, `cma=` **should not** be part of the kernel command-line arguments.

cc @Thra11 @zhaofengli @tomfitzhenry

Closes #201