### PR TITLE
Fix android flashable zips for systems with differently named boot partitions

### DIFF
--- a/devices/samsung-a5y17lte/default.nix
+++ b/devices/samsung-a5y17lte/default.nix
@@ -32,6 +32,7 @@
       pagesize = "2048";
     };
     flashingMethod = "odin";
+    boot_partition_destination = "BOOT";
   };
 
   boot.kernelParams = [

--- a/modules/system-types/android/default.nix
+++ b/modules/system-types/android/default.nix
@@ -123,6 +123,13 @@ in
         internal = true;
       };
 
+      boot_partition_destination = lib.mkOption {
+        type = types.str;
+        description = "Partition label on which to install the boot image. Some OEM name the partition BOOT.";
+        default = "boot";
+        internal = true;
+      };
+
       system_partition_destination = lib.mkOption {
         type = types.str;
         description = "Partition label on which to install the system image. E.g. change to `userdata` when it does not fit in the system partition.";

--- a/modules/system-types/android/flashable-zip.nix
+++ b/modules/system-types/android/flashable-zip.nix
@@ -16,7 +16,7 @@ let
   ;
 
   android-flashable-fragment-burnBoot = ''
-    flash_partition("boot", zip: "boot.img")
+    flash_partition(${builtins.toJSON config.mobile.system.android.boot_partition_destination}, zip: "boot.img")
   '';
 
   android-flashable-fragment-burnSystem = ''


### PR DESCRIPTION
Samsung devices seem to use uppercase partition names.

This follows the convention used for the system partition.