### PR TITLE
Use mobile.outputs rather than system.build

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -26,7 +26,7 @@ in
 import ./lib/eval-with-configuration.nix (args // {
   configuration = defaultConfiguration;
   additionalHelpInstructions = ''
-    You can build the `-A build.default` attribute to build an empty and
+    You can build the `-A outputs.default` attribute to build an empty and
     un-configured image. That image can be configured using `local.nix`.
 
      ** Note that an unconfigured image may appear to hang at boot. **
@@ -36,6 +36,6 @@ import ./lib/eval-with-configuration.nix (args // {
     cross-compilation is the `examples/hello` system. Read its README for more
     information.
 
-     $ nix-build examples/hello --argstr device ${device} -A build.default
+     $ nix-build examples/hello --argstr device ${device} -A outputs.default
   '';
 })

--- a/doc/_support/devices/default.nix
+++ b/doc/_support/devices/default.nix
@@ -15,7 +15,7 @@ let
   devicesDir = ../../../devices;
   devicesInfo = symlinkJoin {
     name = "devices-metadata";
-    paths = (map (device: (evalFor device).config.system.build.device-metadata) all-devices);
+    paths = (map (device: (evalFor device).config.mobile.outputs.device-metadata) all-devices);
   };
 in
 

--- a/doc/boot_process.adoc
+++ b/doc/boot_process.adoc
@@ -41,7 +41,7 @@ When the device is not a _"Boot as recovery"_, or still uses a recovery
 partition, you will need to flash a recovery image to the recovery partition.
 
 ....
- $ nix-build --argstr device $DEVICE -A build.android-recovery
+ $ nix-build --argstr device $DEVICE -A outputs.android-recovery
  $ fastboot flash recovery result
 ....
 

--- a/doc/getting-started.adoc
+++ b/doc/getting-started.adoc
@@ -67,38 +67,6 @@ $ export NIX_PATH="nixpkgs=$HOME/Projects/nixpkgs"
 $ nix-build [...]
 ```
 
-=== Using a pre-built `system.img`
-
-When bootstrapping yourself up, without an aarch64-linux system, it may be
-easier to deal with some systems if you use a pre-built `rootfs` rather than
-rely on the dummy basic `rootfs`. For those systems, you can download a
-link:https://hydra.nixos.org/job/mobile-nixos/unstable/examples-demo.aarch64-linux.rootfs[pre-built rootfs],
-and configure the system build to use it. Assuming it is next to the
-`local.nix` file in your Mobile NixOS checkout.
-
-```nix
-# local.nix
-{ pkgs, ... }:
-
-let
-  fromPath = input: pkgs.runCommandNoCC "system.img" {
-    filename = "system.img";
-    filesystemType = "ext4";
-  } ''
-    mkdir -p "$out"
-    cp ${input} "$out/$filename"
-  '';
-in
-{
-  system.build.rootfs = fromPath ./system.img;
-}
-```
-
-Note that for Android-based devices, you can simply use the `system.img`. There
-is no need to configure it as such. This is most useful for _depthcharge_ and
-_u-boot_ systems.
-
-
 == Customizing
 
 You probably will want to toggle options and such things when fiddling with

--- a/examples/demo/default.nix
+++ b/examples/demo/default.nix
@@ -3,9 +3,9 @@
 import ../../lib/eval-with-configuration.nix (args // {
   configuration = [ (import ./configuration.nix) ];
   additionalHelpInstructions = ''
-    You can build the `-A build.default` attribute to build the default output
+    You can build the `-A outputs.default` attribute to build the default output
     for your device.
 
-     $ nix-build examples/demo --argstr device ${device} -A build.default
+     $ nix-build examples/demo --argstr device ${device} -A outputs.default
   '';
 })

--- a/examples/hello/README.md
+++ b/examples/hello/README.md
@@ -5,7 +5,7 @@
 
 ```
  $ cd .../mobile-nixos
- $ nix-build examples/hello --argstr device DEVICE-NAME -A build.default
+ $ nix-build examples/hello --argstr device DEVICE-NAME -A outputs.default
 ```
 
 ## Installing

--- a/examples/hello/default.nix
+++ b/examples/hello/default.nix
@@ -3,9 +3,9 @@
 import ../../lib/eval-with-configuration.nix (args // {
   configuration = [ (import ./configuration.nix) ];
   additionalHelpInstructions = ''
-    You can build the `-A build.default` attribute to build the default output
+    You can build the `-A outputs.default` attribute to build the default output
     for your device.
 
-     $ nix-build examples/hello --argstr device ${device} -A build.default
+     $ nix-build examples/hello --argstr device ${device} -A outputs.default
   '';
 })

--- a/examples/target-disk-mode/README.md
+++ b/examples/target-disk-mode/README.md
@@ -24,7 +24,7 @@ This will have different implications depending on the device.
 (E.g. `pine64-pinephone`)
 
 ```
- $ nix-build examples/target-disk-mode/ --argstr device pine64-pinephone -A build.default
+ $ nix-build examples/target-disk-mode/ --argstr device pine64-pinephone -A outputs.default
  $ file -L result
 result: DOS/MBR boot sector; partition 1 : ID=0xee, start-CHS (0x0,0,2), end-CHS (0x3ff,255,63), startsector 1, 319555 sectors, extended partition table (last)
 ```
@@ -41,7 +41,7 @@ The disk image produced can be flashed to a bootable medium (e.g. an SD card).
 > actually bricked** devices.
 
 ```
- $ nix-build examples/target-disk-mode/ --argstr device ____ -A build.android-bootimg
+ $ nix-build examples/target-disk-mode/ --argstr device ____ -A outputs.android-bootimg
  $ file -L result
 result: Android bootimg, kernel (0x10008000), ramdisk (0x11000000), page size: 2048, cmdline (...)
 ```

--- a/examples/target-disk-mode/default.nix
+++ b/examples/target-disk-mode/default.nix
@@ -7,14 +7,14 @@ import ../../lib/eval-with-configuration.nix (args // {
 
     Pinephone, other u-boot, and depthcharge devices: 
 
-      $ nix-build examples/target-disk-mode --argstr device ${device} -A build.default
+      $ nix-build examples/target-disk-mode --argstr device ${device} -A outputs.default
 
     Android-based devices:
 
-      $ nix-build examples/target-disk-mode --argstr device ${device} -A build.android-bootimg
+      $ nix-build examples/target-disk-mode --argstr device ${device} -A outputs.android-bootimg
 
     App "simulator":
 
-      $ nix-build examples/target-disk-mode --argstr device uefi-x86_64 -A build.app-simulator
+      $ nix-build examples/target-disk-mode --argstr device uefi-x86_64 -A outputs.app-simulator
   '';
 })

--- a/lib/eval-with-configuration.nix
+++ b/lib/eval-with-configuration.nix
@@ -43,6 +43,9 @@ let
     in
     builtins.trace (concatStringsSep "\ntrace: " [line str' line])
   ;
+
+  # Merge the system-type outputs at the root of the outputs.
+  outputs = eval.config.mobile.outputs // eval.config.mobile.outputs.${eval.config.mobile.system.type};
 in
   (
     # Don't break if `device` is not set.
@@ -55,7 +58,8 @@ in
   )
 {
   # The build artifacts from the modules system.
-  inherit (eval.config.system) build;
+  inherit outputs;
+  build = builtins.trace "The `build` argument has been renamed `outputs`. This alias will be removed after 2022-05." outputs;
 
   # The evaluated config
   inherit (eval) config;

--- a/modules/devices-metadata.nix
+++ b/modules/devices-metadata.nix
@@ -12,6 +12,7 @@ in
   options = {
     mobile.outputs.device-metadata = mkOption {
       type = types.package;
+      internal = true;
       description = ''
         The device-metadata output is used internally by the documentation
         generation to generate the per-device pages.

--- a/modules/devices-metadata.nix
+++ b/modules/devices-metadata.nix
@@ -1,14 +1,27 @@
-{ config, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 
 let
   inherit (config) mobile;
+  inherit (lib)
+    mkOption
+    types
+  ;
   inherit (mobile.device) identity;
 in
 {
-  # The device-metadata output is used internally by the documentation
-  # generation to generate the per-device pages.
-  # Assume this format is fluid and will change.
-  system.build.device-metadata = pkgs.writeTextFile {
+  options = {
+    mobile.outputs.device-metadata = mkOption {
+      type = types.package;
+      description = ''
+        The device-metadata output is used internally by the documentation
+        generation to generate the per-device pages.
+
+        Assume this format is fluid and will change.
+      '';
+    };
+  };
+
+  config.mobile.outputs.device-metadata = pkgs.writeTextFile {
     name = "${mobile.device.name}-metadata";
     destination = "/${mobile.device.name}.json";
     text = (builtins.toJSON {

--- a/modules/generated-filesystems.nix
+++ b/modules/generated-filesystems.nix
@@ -94,6 +94,7 @@ in
     };
     mobile.outputs.rootfs = lib.mkOption {
       type = types.package;
+      visible = false;
       description = ''
         The rootfs image for the build.
       '';

--- a/modules/generated-filesystems.nix
+++ b/modules/generated-filesystems.nix
@@ -85,10 +85,23 @@ in
         Filesystem definitions that will be created at build.
       '';
     };
+    mobile.outputs.generatedFilesystems = lib.mkOption {
+      type = with types; attrsOf package;
+      internal = true;
+      description = ''
+        All generated filesystems from the build.
+      '';
+    };
+    mobile.outputs.rootfs = lib.mkOption {
+      type = types.package;
+      description = ''
+        The rootfs image for the build.
+      '';
+    };
   };
 
   config = {
-    system.build.generatedFilesystems = lib.attrsets.mapAttrs (name: {raw, type, id, label, ...} @ attrs:
+    mobile.outputs.generatedFilesystems = lib.attrsets.mapAttrs (name: {raw, type, id, label, ...} @ attrs:
     if raw != null then raw else
       filesystemFunctions."${type}" (attrs // {
         name = label;
@@ -96,7 +109,12 @@ in
       })
     ) config.mobile.generatedFilesystems;
 
+    mobile.outputs.rootfs = config.mobile.outputs.generatedFilesystems.rootfs;
+
     # Compatibility alias with the previous path.
-    system.build.rootfs = config.system.build.generatedFilesystems.rootfs;
+    system.build.rootfs =
+      builtins.trace "`system.build.rootfs` is being deprecated. Use `mobile.outputs.rootfs` instead. It will be removed after 2022-05"
+      config.mobile.outputs.generatedFilesystems.rootfs
+    ;
   };
 }

--- a/modules/initrd-logs.nix
+++ b/modules/initrd-logs.nix
@@ -2,7 +2,7 @@
 
 let
   inherit (lib) mkIf mkMerge mkOption optionalString types;
-  inherit (config.system.build) extraUtils;
+  inherit (config.mobile.outputs) extraUtils;
   cfg = config.mobile.boot.stage-1.bootlog;
 in
 {

--- a/modules/initrd.nix
+++ b/modules/initrd.nix
@@ -320,16 +320,32 @@ in
             See `mobile.boot.stage-1.extraUtils`.
           '';
         };
+        initrd = mkOption {
+          type = types.str;
+          internal = true;
+          description = ''
+            Path to the initrd, likely compressed, for the system.
+          '';
+        };
+        initrd-meta = mkOption {
+          type = types.package;
+          internal = true;
+          description = ''
+            Additional metadata about the initrd; used for debugging.
+          '';
+        };
       };
     };
 
     config = {
       mobile.outputs = {
-        inherit extraUtils;
+        inherit
+          extraUtils
+          initrd-meta
+        ;
+        initrd = "${initrd}/initrd";
       };
 
-      system.build.initrd = "${initrd}/initrd";
-      system.build.initrd-meta = initrd-meta;
 
       system.build.initialRamdisk =
         if config.mobile.rootfs.shared.enabled

--- a/modules/initrd.nix
+++ b/modules/initrd.nix
@@ -346,7 +346,8 @@ in
         initrd = "${initrd}/initrd";
       };
 
-
+      # This is not a Mobile NixOS output; this is to "dis"-integrate with the
+      # default NixOS outputs. Do not refer to this in Mobile NixOS.
       system.build.initialRamdisk =
         if config.mobile.rootfs.shared.enabled
         then pkgs.runCommandNoCC "dummy" {} "touch $out"

--- a/modules/initrd.nix
+++ b/modules/initrd.nix
@@ -309,10 +309,25 @@ in
         '';
         internal = true;
       };
+
+      mobile.outputs = {
+        extraUtils = mkOption {
+          type = types.package;
+          internal = true;
+          description = ''
+            Stripped packages for use in stage-1.
+
+            See `mobile.boot.stage-1.extraUtils`.
+          '';
+        };
+      };
     };
 
     config = {
-      system.build.extraUtils = extraUtils;
+      mobile.outputs = {
+        inherit extraUtils;
+      };
+
       system.build.initrd = "${initrd}/initrd";
       system.build.initrd-meta = initrd-meta;
 

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -36,6 +36,7 @@
   ./luks.nix
   ./mobile-device.nix
   ./nixpkgs.nix
+  ./outputs.nix
   ./quirks
   ./recovery.nix
   ./rootfs.nix

--- a/modules/outputs.nix
+++ b/modules/outputs.nix
@@ -15,6 +15,8 @@ in
 
             The default depends on the system type in use.
           '';
+          # Mark internal so that the documentation does not expose a bogus description.
+          internal = true;
         };
       };
     };

--- a/modules/outputs.nix
+++ b/modules/outputs.nix
@@ -1,0 +1,22 @@
+{ config, lib, ... }:
+
+let
+  inherit (lib)
+    mkOption
+  ;
+in
+{
+  options = {
+    mobile = {
+      outputs = {
+        default = mkOption {
+          description = ''
+            Default most likely desired output for this Mobile NixOS build.
+
+            The default depends on the system type in use.
+          '';
+        };
+      };
+    };
+  };
+}

--- a/modules/recovery.nix
+++ b/modules/recovery.nix
@@ -1,15 +1,35 @@
-{ config, pkgs, ... }:
+{ config, lib, pkgs, ... }:
 
 # This module provides the `recovery` build output.
 # It is the same configuration, with minor customizations.
 
+let
+  inherit (lib)
+    mkOption
+    types
+  ;
+in
 {
-  system.build.recovery = (config.lib.mobile-nixos.composeConfig {
-    config = {
-      mobile.system.android.bootimg.name = "recovery.img";
-      mobile.boot.stage-1.bootConfig = {
-        is_recovery = true;
+  options = {
+    mobile = {
+      outputs = {
+        recovery = mkOption {
+          description = ''
+            The configuration, re-evaluated with assumptions for recovery use.
+          '';
+        };
       };
     };
-  }).config;
+  };
+
+  config = {
+      mobile.outputs.recovery = (config.lib.mobile-nixos.composeConfig {
+      config = {
+        mobile.system.android.bootimg.name = "recovery.img";
+        mobile.boot.stage-1.bootConfig = {
+          is_recovery = true;
+        };
+      };
+    }).config;
+  };
 }

--- a/modules/recovery.nix
+++ b/modules/recovery.nix
@@ -14,6 +14,7 @@ in
     mobile = {
       outputs = {
         recovery = mkOption {
+          internal = true;
           description = ''
             The configuration, re-evaluated with assumptions for recovery use.
           '';

--- a/modules/stage-0.nix
+++ b/modules/stage-0.nix
@@ -53,10 +53,20 @@ in
         '';
       };
     };
+
+    mobile = {
+      outputs = {
+        stage-0 = mkOption {
+          description = ''
+            The configuration, re-evaluated with assumptions for stage-0 use.
+          '';
+        };
+      };
+    };
   };
 
   config = {
-    system.build.stage-0 = (config.lib.mobile-nixos.composeConfig {
+    mobile.outputs.stage-0 = (config.lib.mobile-nixos.composeConfig {
       config = { config, ... }: {
         mobile.boot.stage-1.stage = if supportsStage-0 then 0 else 1;
         mobile.boot.stage-1.extraUtils = with pkgs; [

--- a/modules/stage-0.nix
+++ b/modules/stage-0.nix
@@ -57,6 +57,7 @@ in
     mobile = {
       outputs = {
         stage-0 = mkOption {
+          internal = true;
           description = ''
             The configuration, re-evaluated with assumptions for stage-0 use.
           '';

--- a/modules/system-types.nix
+++ b/modules/system-types.nix
@@ -34,6 +34,10 @@ in
         produced for the system.
       '';
     };
+
+    # Useless attrset for the special "none" system-type.
+    outputs.none = {
+    };
   };
 
   config = {

--- a/modules/system-types/android/default.nix
+++ b/modules/system-types/android/default.nix
@@ -21,7 +21,7 @@ let
     kernel = "${kernelPackage}/${kernelPackage.file}";
   };
 
-  android-recovery = recovery.system.build.android-bootimg;
+  android-recovery = recovery.mobile.outputs.android-bootimg;
 
   inherit (config.mobile.outputs.generatedFilesystems) rootfs;
 
@@ -67,11 +67,6 @@ let
     EOF
     chmod +x $out/flash-critical.sh
   '';
-
-  # The output name `android-device` does not describe well what it is.
-  # This is kept for some backwards compatibility (6 months)
-  # Change to a throw by or after September 2021.
-  android-device = builtins.trace "The output `android-device` has been renamed to: `android-systems-image`." android-fastboot-images;
 
   mkBootimgOption = name: lib.mkOption {
     type = types.str;
@@ -162,16 +157,37 @@ in
         ] mkBootimgOption;
       };
     };
+    mobile = {
+      outputs = {
+        android-bootimg = lib.mkOption {
+          type = types.package;
+          description = ''
+            `boot.img` type image for Android-based systems.
+          '';
+        };
+        android-recovery = lib.mkOption {
+          type = types.package;
+          description = ''
+            `recovery.img` type image for Android-based systems.
+          '';
+        };
+        android-fastboot-images = lib.mkOption {
+          type = types.package;
+          description = ''
+            Flashing scripts and images for use with fastboot or odin.
+          '';
+        };
+      };
+    };
   };
 
   config = lib.mkMerge [
     { mobile.system.types = [ "android" ]; }
 
     (lib.mkIf enabled {
-      system.build = {
+      mobile.outputs = {
         default = android-fastboot-images;
         inherit
-          android-device
           android-bootimg
           android-recovery
           android-fastboot-images

--- a/modules/system-types/android/default.nix
+++ b/modules/system-types/android/default.nix
@@ -4,8 +4,7 @@ let
   enabled = config.mobile.system.type == "android";
 
   inherit (lib) concatStringsSep optionalString types;
-  inherit (config.mobile.outputs) recovery;
-  inherit (config.system.build) stage-0;
+  inherit (config.mobile.outputs) recovery stage-0;
   inherit (config.mobile) device;
   inherit (config.mobile.system.android) ab_partitions boot_as_recovery has_recovery_partition flashingMethod;
   inherit (stage-0.mobile.boot.stage-1) kernel;

--- a/modules/system-types/android/default.nix
+++ b/modules/system-types/android/default.nix
@@ -23,7 +23,7 @@ let
 
   android-recovery = recovery.system.build.android-bootimg;
 
-  inherit (config.system.build) rootfs;
+  inherit (config.mobile.outputs.generatedFilesystems) rootfs;
 
   # Note:
   # The flash scripts, by design, are not using nix-provided paths for

--- a/modules/system-types/android/default.nix
+++ b/modules/system-types/android/default.nix
@@ -4,7 +4,8 @@ let
   enabled = config.mobile.system.type == "android";
 
   inherit (lib) concatStringsSep optionalString types;
-  inherit (config.system.build) recovery stage-0;
+  inherit (config.mobile.outputs) recovery;
+  inherit (config.system.build) stage-0;
   inherit (config.mobile) device;
   inherit (config.mobile.system.android) ab_partitions boot_as_recovery has_recovery_partition flashingMethod;
   inherit (stage-0.mobile.boot.stage-1) kernel;

--- a/modules/system-types/android/default.nix
+++ b/modules/system-types/android/default.nix
@@ -21,7 +21,7 @@ let
     kernel = "${kernelPackage}/${kernelPackage.file}";
   };
 
-  android-recovery = recovery.mobile.outputs.android-bootimg;
+  android-recovery = recovery.mobile.outputs.android.android-bootimg;
 
   inherit (config.mobile.outputs.generatedFilesystems) rootfs;
 
@@ -159,23 +159,25 @@ in
     };
     mobile = {
       outputs = {
-        android-bootimg = lib.mkOption {
-          type = types.package;
-          description = ''
-            `boot.img` type image for Android-based systems.
-          '';
-        };
-        android-recovery = lib.mkOption {
-          type = types.package;
-          description = ''
-            `recovery.img` type image for Android-based systems.
-          '';
-        };
-        android-fastboot-images = lib.mkOption {
-          type = types.package;
-          description = ''
-            Flashing scripts and images for use with fastboot or odin.
-          '';
+        android = {
+          android-bootimg = lib.mkOption {
+            type = types.package;
+            description = ''
+              `boot.img` type image for Android-based systems.
+            '';
+          };
+          android-recovery = lib.mkOption {
+            type = types.package;
+            description = ''
+              `recovery.img` type image for Android-based systems.
+            '';
+          };
+          android-fastboot-images = lib.mkOption {
+            type = types.package;
+            description = ''
+              Flashing scripts and images for use with fastboot or odin.
+            '';
+          };
         };
       };
     };
@@ -187,11 +189,13 @@ in
     (lib.mkIf enabled {
       mobile.outputs = {
         default = android-fastboot-images;
-        inherit
-          android-bootimg
-          android-recovery
-          android-fastboot-images
-        ;
+        android = {
+          inherit
+            android-bootimg
+            android-recovery
+            android-fastboot-images
+          ;
+        };
       };
 
       mobile.HAL.boot.rebootModes = [

--- a/modules/system-types/android/default.nix
+++ b/modules/system-types/android/default.nix
@@ -165,18 +165,21 @@ in
             description = ''
               `boot.img` type image for Android-based systems.
             '';
+            visible = false;
           };
           android-recovery = lib.mkOption {
             type = types.package;
             description = ''
               `recovery.img` type image for Android-based systems.
             '';
+            visible = false;
           };
           android-fastboot-images = lib.mkOption {
             type = types.package;
             description = ''
               Flashing scripts and images for use with fastboot or odin.
             '';
+            visible = false;
           };
         };
       };

--- a/modules/system-types/android/default.nix
+++ b/modules/system-types/android/default.nix
@@ -16,7 +16,7 @@ let
   android-bootimg = pkgs.callPackage ./bootimg.nix rec {
     inherit (config.mobile.system.android) bootimg;
     inherit cmdline;
-    initrd = stage-0.system.build.initrd;
+    inherit (config.mobile.outputs) initrd;
     name = "mobile-nixos_${device.name}_${bootimg.name}";
     kernel = "${kernelPackage}/${kernelPackage.file}";
   };

--- a/modules/system-types/android/flashable-zip.nix
+++ b/modules/system-types/android/flashable-zip.nix
@@ -71,18 +71,21 @@ in
             description = ''
               `boot.img` in Android flashable zip format.
             '';
+            visible = false;
           };
           android-flashable-system = mkOption {
             type = types.package;
             description = ''
               `system.img` in Android flashable zip format.
             '';
+            visible = false;
           };
           android-flashable-zip = mkOption {
             type = types.package;
             description = ''
               Android flashable zip which will install `boot.img` and `system.img`.
             '';
+            visible = false;
           };
         };
       };

--- a/modules/system-types/android/flashable-zip.nix
+++ b/modules/system-types/android/flashable-zip.nix
@@ -3,9 +3,10 @@
 let
   enabled = config.mobile.system.type == "android";
 
-  inherit (lib) types;
+  inherit (lib) mkOption types;
   inherit (config.mobile) device;
-  inherit (config.system.build) android-bootimg rootfs;
+  inherit (config.mobile.outputs.generatedFilesystems) rootfs;
+  inherit (config.mobile.outputs.android) android-bootimg;
   inherit (pkgs.mobile-nixos) make-flashable-zip;
 
   # Fragments that will be re-used in the flashable zip builds
@@ -61,9 +62,36 @@ let
   };
 in
 {
+  options = {
+    mobile = {
+      outputs = {
+        android = {
+          android-flashable-bootimg = mkOption {
+            type = types.package;
+            description = ''
+              `boot.img` in Android flashable zip format.
+            '';
+          };
+          android-flashable-system = mkOption {
+            type = types.package;
+            description = ''
+              `system.img` in Android flashable zip format.
+            '';
+          };
+          android-flashable-zip = mkOption {
+            type = types.package;
+            description = ''
+              Android flashable zip which will install `boot.img` and `system.img`.
+            '';
+          };
+        };
+      };
+    };
+  };
+
   config = lib.mkMerge [
     (lib.mkIf enabled {
-      system.build = {
+      mobile.outputs.android = {
         inherit
           android-flashable-bootimg
           android-flashable-system

--- a/modules/system-types/depthcharge/default.nix
+++ b/modules/system-types/depthcharge/default.nix
@@ -4,7 +4,7 @@ let
   enabled = config.mobile.system.type == "depthcharge";
 
   inherit (lib) types;
-  inherit (config.system.build) stage-0;
+  inherit (config.mobile.outputs) stage-0;
   inherit (stage-0.mobile.boot.stage-1) kernel;
 
   build = pkgs.callPackage ./depthcharge-build.nix {

--- a/modules/system-types/depthcharge/default.nix
+++ b/modules/system-types/depthcharge/default.nix
@@ -37,12 +37,14 @@ in
             description = ''
               Full Mobile NixOS disk image for a depthcharge-based system.
             '';
+            visible = false;
           };
           kpart = lib.mkOption {
             type = types.package;
             description = ''
               Kernel partition for a depthcharge-based system.
             '';
+            visible = false;
           };
         };
       };

--- a/modules/system-types/depthcharge/default.nix
+++ b/modules/system-types/depthcharge/default.nix
@@ -10,7 +10,7 @@ let
   build = pkgs.callPackage ./depthcharge-build.nix {
     inherit (config.mobile.system.depthcharge.kpart) dtbs;
     device_name = config.mobile.device.name;
-    initrd = stage-0.system.build.initrd;
+    inherit (config.mobile.outputs) initrd;
     system = config.system.build.rootfs;
     cmdline = lib.concatStringsSep " " config.boot.kernelParams;
     kernel = kernel.package;

--- a/modules/system-types/depthcharge/default.nix
+++ b/modules/system-types/depthcharge/default.nix
@@ -11,7 +11,7 @@ let
     inherit (config.mobile.system.depthcharge.kpart) dtbs;
     device_name = config.mobile.device.name;
     inherit (config.mobile.outputs) initrd;
-    system = config.system.build.rootfs;
+    system = config.mobile.outputs.generatedFilesystems.rootfs;
     cmdline = lib.concatStringsSep " " config.boot.kernelParams;
     kernel = kernel.package;
     arch = lib.strings.removeSuffix "-linux" config.mobile.system.system;
@@ -29,15 +29,35 @@ in
         };
       };
     };
+    mobile = {
+      outputs = {
+        depthcharge = {
+          disk-image = lib.mkOption {
+            type = types.package;
+            description = ''
+              Full Mobile NixOS disk image for a depthcharge-based system.
+            '';
+          };
+          kpart = lib.mkOption {
+            type = types.package;
+            description = ''
+              Kernel partition for a depthcharge-based system.
+            '';
+          };
+        };
+      };
+    };
   };
 
   config = lib.mkMerge [
     { mobile.system.types = [ "depthcharge" ]; }
 
     (lib.mkIf enabled {
-      system.build = {
-        inherit (build) disk-image kpart;
+      mobile.outputs = {
         default = build.disk-image;
+        depthcharge = {
+          inherit (build) disk-image kpart;
+        };
       };
     })
   ];

--- a/modules/system-types/depthcharge/device-notes.adoc.erb
+++ b/modules/system-types/depthcharge/device-notes.adoc.erb
@@ -2,7 +2,7 @@
 
 This will build the default output for your _<%= info["fullName"] %>_.
 
- $ nix-build --argstr device <%= info["identifier"] %> -A build.default
+ $ nix-build --argstr device <%= info["identifier"] %> -A outputs.default
 
 The default output is a disk-image that can be written on a storage media that
 your device can boot from.
@@ -22,7 +22,7 @@ image to a storage media, either external or internal.
 The `kpart` output can be used to build only the stage-1, which is helpful for
 updating the kernel and the stage-1 boot program.
 
- $ nix-build --argstr device <%= info["identifier"] %> -A build.kpart
+ $ nix-build --argstr device <%= info["identifier"] %> -A outputs.kpart
 
 This can be `dd`'d over the first partition on an existing storage media
 containing a Mobile NixOS installation.

--- a/modules/system-types/u-boot/default.nix
+++ b/modules/system-types/u-boot/default.nix
@@ -123,13 +123,13 @@ let
         mkdir -vp mobile-nixos/{boot,recovery}
         (
         cd mobile-nixos/boot
-        cp -v ${stage-0.system.build.initrd} stage-1
+        cp -v ${stage-0.mobile.outputs.initrd} stage-1
         cp -v ${kernel_file} kernel
         cp -vr ${kernel}/dtbs dtbs
         )
         (
         cd mobile-nixos/recovery
-        cp -v ${recovery.system.build.initrd} stage-1
+        cp -v ${recovery.mobile.outputs.initrd} stage-1
         cp -v ${kernel_file} kernel
         cp -vr ${kernel}/dtbs dtbs
         )

--- a/modules/system-types/u-boot/default.nix
+++ b/modules/system-types/u-boot/default.nix
@@ -3,8 +3,7 @@
 let
   enabled = config.mobile.system.type == "u-boot";
 
-  inherit (config.mobile.outputs) recovery;
-  inherit (config.system.build) stage-0;
+  inherit (config.mobile.outputs) recovery stage-0;
   inherit (pkgs) buildPackages imageBuilder runCommandNoCC;
   inherit (lib) mkIf mkOption types;
   cfg = config.mobile.quirks.u-boot;

--- a/modules/system-types/u-boot/default.nix
+++ b/modules/system-types/u-boot/default.nix
@@ -3,7 +3,8 @@
 let
   enabled = config.mobile.system.type == "u-boot";
 
-  inherit (config.system.build) recovery stage-0;
+  inherit (config.mobile.outputs) recovery;
+  inherit (config.system.build) stage-0;
   inherit (pkgs) buildPackages imageBuilder runCommandNoCC;
   inherit (lib) mkIf mkOption types;
   cfg = config.mobile.quirks.u-boot;

--- a/modules/system-types/u-boot/default.nix
+++ b/modules/system-types/u-boot/default.nix
@@ -109,6 +109,7 @@ let
     mkimage -C none -A ${ubootPlatforms.${pkgs.targetPlatform.system}} -T script -d ${bootcmd} $out
   '';
 
+  # TODO: use generatedFilesystems
   boot-partition =
     imageBuilder.fileSystem.makeExt4 {
       name = "mobile-nixos-boot";
@@ -169,8 +170,8 @@ let
     partitions = [
       miscPartition
       persistPartition
-      config.system.build.boot-partition
-      config.system.build.rootfs
+      boot-partition
+      config.mobile.outputs.generatedFilesystems.rootfs
     ];
   };
 
@@ -235,6 +236,29 @@ in
         '';
       };
     };
+
+    outputs = {
+      u-boot = {
+        boot-partition = mkOption {
+          type = types.package;
+          description = ''
+            Boot partition for the system.
+          '';
+        };
+        disk-image = lib.mkOption {
+          type = types.package;
+          description = ''
+            Full Mobile NixOS disk image for a u-boot-based system.
+          '';
+        };
+        u-boot = mkOption {
+          type = types.package;
+          description = ''
+            U-Boot build for the system.
+          '';
+        };
+      };
+    };
   };
 
   config = lib.mkMerge [
@@ -245,11 +269,13 @@ in
           u-boot = cfg.package;
         };
       })];
-      system.build = {
-        inherit boot-partition;
-        disk-image = withBootloader;
-        u-boot = cfg.package;
-        default = config.system.build.disk-image;
+      mobile.outputs = {
+        default = config.mobile.outputs.u-boot.disk-image;
+        u-boot = {
+          inherit boot-partition;
+          disk-image = withBootloader;
+          u-boot = cfg.package;
+        };
       };
     })
   ];

--- a/modules/system-types/u-boot/default.nix
+++ b/modules/system-types/u-boot/default.nix
@@ -244,18 +244,21 @@ in
           description = ''
             Boot partition for the system.
           '';
+          visible = false;
         };
         disk-image = lib.mkOption {
           type = types.package;
           description = ''
             Full Mobile NixOS disk image for a u-boot-based system.
           '';
+          visible = false;
         };
         u-boot = mkOption {
           type = types.package;
           description = ''
             U-Boot build for the system.
           '';
+          visible = false;
         };
       };
     };

--- a/modules/system-types/uefi/default.nix
+++ b/modules/system-types/uefi/default.nix
@@ -111,18 +111,21 @@ in
           description = ''
             Boot partition for the system.
           '';
+          visible = false;
         };
         disk-image = lib.mkOption {
           type = types.package;
           description = ''
             Full Mobile NixOS disk image for a UEFI-based system.
           '';
+          visible = false;
         };
         efiKernel = mkOption {
           type = types.package;
           description = ''
             EFI executable with the kernel, cmdline and initramfs built-in.
           '';
+          visible = false;
         };
       };
     };

--- a/modules/system-types/uefi/default.nix
+++ b/modules/system-types/uefi/default.nix
@@ -28,9 +28,9 @@ let
   } ''
     (PS4=" $ "; set -x
     ${pkgs.stdenv.cc.bintools.targetPrefix}objcopy \
-      --add-section .cmdline="${kernelParamsFile}"          --change-section-vma  .cmdline=0x30000 \
-      --add-section .linux="${kernelFile}"                  --change-section-vma  .linux=0x2000000 \
-      --add-section .initrd="${config.system.build.initrd}" --change-section-vma .initrd=0x3000000 \
+      --add-section .cmdline="${kernelParamsFile}"            --change-section-vma  .cmdline=0x30000 \
+      --add-section .linux="${kernelFile}"                    --change-section-vma  .linux=0x2000000 \
+      --add-section .initrd="${config.mobile.outputs.initrd}" --change-section-vma .initrd=0x3000000 \
       "${pkgs.libudev}/lib/systemd/boot/efi/linux${uefiPlatform}.efi.stub" \
       "$out"
     )

--- a/modules/system-types/uefi/default.nix
+++ b/modules/system-types/uefi/default.nix
@@ -5,7 +5,8 @@ let
 
   inherit (lib) mkEnableOption mkIf mkOption types;
   inherit (pkgs) hostPlatform imageBuilder runCommandNoCC;
-  inherit (config.system.build) recovery stage-0;
+  inherit (config.mobile.outputs) recovery;
+  inherit (config.system.build) stage-0;
   cfg = config.mobile.quirks.uefi;
   deviceName = config.mobile.device.name;
   kernel = stage-0.mobile.boot.stage-1.kernel.package;

--- a/modules/system-types/uefi/default.nix
+++ b/modules/system-types/uefi/default.nix
@@ -5,8 +5,7 @@ let
 
   inherit (lib) mkEnableOption mkIf mkOption types;
   inherit (pkgs) hostPlatform imageBuilder runCommandNoCC;
-  inherit (config.mobile.outputs) recovery;
-  inherit (config.system.build) stage-0;
+  inherit (config.mobile.outputs) recovery stage-0;
   cfg = config.mobile.quirks.uefi;
   deviceName = config.mobile.device.name;
   kernel = stage-0.mobile.boot.stage-1.kernel.package;

--- a/modules/system-types/uefi/device-notes.adoc.erb
+++ b/modules/system-types/uefi/device-notes.adoc.erb
@@ -2,4 +2,4 @@
 
 This will build the default output for your _<%= info["fullName"] %>_.
 
- $ nix-build --argstr device <%= info["identifier"] %> -A build.default
+ $ nix-build --argstr device <%= info["identifier"] %> -A outputs.default

--- a/modules/system-types/uefi/vm.nix
+++ b/modules/system-types/uefi/vm.nix
@@ -4,16 +4,30 @@ let
   # This particular VM module is only enabled for the uefi system type.
   enabled = config.mobile.system.type == "uefi";
 
-  inherit (lib) mkAfter mkIf;
+  inherit (lib) mkAfter mkIf mkOption types;
   inherit (config.mobile) device hardware;
   inherit (config.mobile.boot) stage-1;
-  inherit (config.system.build) disk-image;
+  inherit (config.mobile.outputs.uefi) disk-image;
 
   ram  = toString hardware.ram;
   xres = toString hardware.screen.width;
   yres = toString hardware.screen.height;
 in
 {
+  options = {
+    mobile = {
+      outputs = {
+        uefi = {
+          vm = mkOption {
+            type = types.package;
+            description = ''
+              Script to start a UEFI-based virtual machine.
+            '';
+          };
+        };
+      };
+    };
+  };
   config = mkIf enabled {
     boot.kernelParams = mkAfter [
       "console=ttyS0"
@@ -29,7 +43,7 @@ in
       # Video
       "bochs_drm"
     ];
-    system.build = {
+    mobile.outputs.uefi = {
       vm = pkgs.writeShellScript "run-vm-${device.name}" ''
         ARGS=(
           -enable-kvm

--- a/modules/system-types/uefi/vm.nix
+++ b/modules/system-types/uefi/vm.nix
@@ -23,6 +23,7 @@ in
             description = ''
               Script to start a UEFI-based virtual machine.
             '';
+            visible = false;
           };
         };
       };

--- a/release.nix
+++ b/release.nix
@@ -110,7 +110,7 @@ let
     lib.genAttrs systems (system:
       (evalWithConfiguration {
         nixpkgs.localSystem = knownSystems.${system};
-      } device).config.system.build.default
+      } device).config.mobile.outputs.default
     )
   );
 
@@ -130,7 +130,7 @@ let
       };
     in
     {
-      aarch64-linux.rootfs = aarch64-eval.build.rootfs;
+      aarch64-linux.rootfs = aarch64-eval.outputs.rootfs;
     };
 in
 rec {


### PR DESCRIPTION
`system.build` is, at best, a wart in the current design of the NixOS options. It is an arbitrary attrset full of arbitrary under-defined values. This, in itself, eh, is an implementation detail.

The issue is that Mobile NixOS started with using that catch-all property to transmit internal *and* user-centric outputs. Now, *that* is a problem. First, we have to dance around any possible names used by NixOS, as it's *just* an attrset, without `mkForce` and similar merge semantics.

The solution here, and probably should be investigated by NixOS to provide better composition semantics, is to provide all outputs as discrete options in the options system. Internal-use ones are marked `internal`.

> Side-note: It has been implemented under the `mobile.outputs` namespace, but that's not the only possible design. In ██████, a WIP project, any relatively independent options namespace has its own `outputs` attrset. This is because the intent there is to allow multiple divergent implementations of modules, internal and external, to co-exist gracefully. Though here Mobile NixOS is a monolithic composable layer on top of the ultra-monolithic NixOS, so it's fine this way.

### Drawbacks

The main drawback is that I moved things around.

There is a minor drawback in that outputs are now namespaced by system-type, e.g. `outputs.android.android-flashable-bootimg` rather than `build.android-flashable-bootimg`. But this is minor since when the evaluation is done *imperatively* (e.g. `nix-build ./default.nix`) the system-type's sub-attrset is merged into the `outputs` attrset. So in the end it's `outputs.android-flashable-bootimg`.

### `outputs` rather than `build`?

I find that `outputs` better describe what it is. A `build` is really a `build artifact`, or a `build output`. While this somewhat breaks backwards compatibility by renaming the attribute, I think it's totally fine to do since this


### TODO

 - [x] Comb over documentation for `build.*` references.

Maybe for now, maybe after?

 - [x] Add `exportedOutputs` or similar attrset for documentation purposes.
 - [x] Use `exportedOutputs` in device pages, show a table of possible outputs.