### PR TITLE
Fix uboottools, update nixpkgs pin

### DIFF
--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -96,11 +96,6 @@ in
       ];
       patches = patches ++ [
         ./u-boot/0001-mobile-nixos-work-around-ubootTools-cross-compilatio.patch
-        (fetchpatch {
-          # https://patchwork.ozlabs.org/project/uboot/patch/20210210194309.07d1dec7@DUFFMAN/
-          url = "https://patchwork.ozlabs.org/series/229060/mbox/";
-          sha256 = "1d3h1wh5227lqvqlxvnljbkmy89b9wmf52qfsx5jhpfa9g260xql";
-        })
       ];
     });
 

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -1,6 +1,6 @@
 let
-  sha256 = "sha256-M5sHgjA1OZn/c21pk64qd5kjbkBpbZuYwgaDEl9kiP8=";
-  rev = "5bc8b980b9178ef9a4bb622320cf34e59ea2ea10";
+  sha256 = "sha256:1q7n9rk4i8ky2xxiymm72cfq1xra3ss3vkhbwf60rhiblslldgqg";
+  rev = "b165ce0c4efbb74246714b5c66b6bcdce8cde175";
 in
 builtins.trace "(Using pinned Nixpkgs at ${rev})"
 import (fetchTarball {


### PR DESCRIPTION
Fix ubootTools by not applying the already upstreamed patch anymore.
Update nixpkgs pin to a more recent version that seems ok-ish.

Fixes https://github.com/NixOS/mobile-nixos/issues/421.
