### PR TITLE
overlay/kernel-builder: ignore changes to CONFIG_AS_VERSION

### DIFF
--- a/overlay/mobile-nixos/kernel/builder.nix
+++ b/overlay/mobile-nixos/kernel/builder.nix
@@ -346,6 +346,7 @@ stdenv.mkDerivation (inputArgs // {
               "CONFIG_ARM64_MTE"
               "CONFIG_ARM64_PTR_AUTH"
               "CONFIG_AS_HAS_CFI_NEGATE_RA_STATE"
+              "CONFIG_AS_VERSION"
               "CONFIG_CC_VERSION_TEXT"
               "CONFIG_CLANG_VERSION"
               "CONFIG_DEBUG_INFO_SPLIT"


### PR DESCRIPTION
Recent updates in nixpkgs unstable (after the current pin) will cause a change in the `as` version. This patch prevents this from affecting any kernel builds,