### PR TITLE
release.nix: Add kernels to the jobset

### DIFF
--- a/.ci/instantiate-all.nix
+++ b/.ci/instantiate-all.nix
@@ -42,6 +42,21 @@ let
     in
       builtins.listToAttrs (flatten devicesList)
     ;
+  kernels =
+    let
+      # Listifies devices in a list of lists of nameValuePairs.
+      # This will be flattened and re-hydrated in a shallow attrset.
+      devicesList =
+        mapAttrsToList
+        (deviceName: list: mapAttrsToList (platformName: value: {
+            name = "kernel.${deviceName}.${platformName}";
+            value = value;
+          }) list)
+        release.kernel
+      ;
+    in
+      builtins.listToAttrs (flatten devicesList)
+    ;
 
   flattened =
     # If this fails, evaluations probably don't receive additional configuration
@@ -49,6 +64,7 @@ let
     assert devices."device.asus-z00t.aarch64-linux" != devices."device.asus-z00t.x86_64-linux";
     release //
     devices //
+    kernels //
     # We could try and do something smart to unwrap two levels of attrsets
     # automatically, but by stating we want those paths we are ensuring that
     # they are still present in the attrsets.

--- a/release.nix
+++ b/release.nix
@@ -124,6 +124,16 @@ let
     )
   );
 
+  # `kernel` here is indexed by the system it's being built on first.
+  # FIXME: can we better filter this?
+  kernel = lib.genAttrs devices (device:
+    lib.genAttrs systems (system:
+      (evalWithConfiguration {
+        nixpkgs.localSystem = knownSystems.${system};
+      } device).config.mobile.boot.stage-1.kernel.package
+    )
+  );
+
   examples-demo =
     let
       aarch64-eval = import ./examples/demo {
@@ -149,6 +159,7 @@ let
 in
 rec {
   inherit device;
+  inherit kernel;
   inherit examples-demo;
   inherit doc;
 


### PR DESCRIPTION
This does **not** add more work. This only adds more tracking. The kernels as used here *are already part of the builds*.

By making them discrete components of the eval, we are now able to better track kernel build issues.

Fixes #434
