### PR TITLE
default: refer to local.nix directly

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -25,7 +25,7 @@ let
         ********************************************
         * WARNING: evaluation includes ./local.nix *
         ********************************************
-      '' [ (import ./local.nix) ]
+      '' [ ./local.nix ]
     else
       []
   ;


### PR DESCRIPTION
This preserves location information, e.g. in the `nixos-option` tool
or in errors about duplicate option definitions.