### PR TITLE
treewide: remove references to toplevel platform attrs

### DIFF
--- a/modules/system-target.nix
+++ b/modules/system-target.nix
@@ -28,8 +28,8 @@ in
   config = {
     assertions = [
       {
-        assertion = pkgs.targetPlatform.system == cfg.system;
-        message = "pkgs.targetPlatform.system expected to be `${cfg.system}`, is `${pkgs.targetPlatform.system}`";
+        assertion = pkgs.stdenv.targetPlatform.system == cfg.system;
+        message = "pkgs.stdenv.targetPlatform.system expected to be `${cfg.system}`, is `${pkgs.stdenv.targetPlatform.system}`";
       }
     ];
 

--- a/modules/system-types/u-boot/default.nix
+++ b/modules/system-types/u-boot/default.nix
@@ -106,7 +106,7 @@ let
       buildPackages.ubootTools
     ];
   } ''
-    mkimage -C none -A ${ubootPlatforms.${pkgs.targetPlatform.system}} -T script -d ${bootcmd} $out
+    mkimage -C none -A ${ubootPlatforms.${pkgs.stdenv.targetPlatform.system}} -T script -d ${bootcmd} $out
   '';
 
   # TODO: use generatedFilesystems

--- a/modules/system-types/uefi/default.nix
+++ b/modules/system-types/uefi/default.nix
@@ -4,7 +4,8 @@ let
   enabled = config.mobile.system.type == "uefi";
 
   inherit (lib) mkEnableOption mkIf mkOption types;
-  inherit (pkgs) hostPlatform imageBuilder runCommandNoCC;
+  inherit (pkgs.stdenv) hostPlatform;
+  inherit (pkgs) imageBuilder runCommandNoCC;
   inherit (config.mobile.outputs) recovery stage-0;
   cfg = config.mobile.quirks.uefi;
   deviceName = config.mobile.device.name;
@@ -17,7 +18,7 @@ let
     "x86_64-linux"  =  "x64";
     "aarch64-linux" = "aa64";
   };
-  uefiPlatform = uefiPlatforms.${pkgs.targetPlatform.system};
+  uefiPlatform = uefiPlatforms.${pkgs.stdenv.targetPlatform.system};
 
   kernelParamsFile = pkgs.writeText "${deviceName}-boot.cmd" config.boot.kernelParams;
 

--- a/modules/system-types/uefi/vm.nix
+++ b/modules/system-types/uefi/vm.nix
@@ -65,7 +65,7 @@ in
           -netdev "user,id=user.0"
         )
 
-        ${pkgs.qemu}/bin/qemu-system-${pkgs.targetPlatform.qemuArch} "''${ARGS[@]}" "''${@}"
+        ${pkgs.qemu}/bin/qemu-system-${pkgs.stdenv.targetPlatform.qemuArch} "''${ARGS[@]}" "''${@}"
       '';
     };
   };


### PR DESCRIPTION
The preferred way to refer to these is via stdenv.*Platform.
These will eventually be aliases in upstream Nixpkgs.