### PR TITLE
pine64-pinephone: upgrade ATF to 2.6 and Crust to 0.5

### DIFF
--- a/devices/pine64-pinephone/overlay/crust-firmware/default.nix
+++ b/devices/pine64-pinephone/overlay/crust-firmware/default.nix
@@ -3,13 +3,13 @@
 
 stdenv.mkDerivation rec {
   pname = "crust-firmware";
-  version = "0.4";
+  version = "0.5";
 
   src = fetchFromGitHub {
     owner = "crust-firmware";
     repo = "crust";
     rev = "v${version}";
-    sha256 = "19xxp43b6dhdfssahspyl7y15dbby0kfbfqnmhc42vz1hkp7b4q6";
+    hash = "sha256-f2+5y5RIFqLWLokD4P8r/2F77kxYmutH47GO5yJc63U=";
   };
 
   depsBuildBuild = [

--- a/devices/pine64-pinephone/u-boot/default.nix
+++ b/devices/pine64-pinephone/u-boot/default.nix
@@ -24,12 +24,12 @@ let
   };
 
   atf = armTrustedFirmwareAllwinner.overrideAttrs(old: rec {
-    version = "2.5";
+    version = "2.6";
     src = fetchFromGitHub {
       owner = "ARM-software";
       repo = "arm-trusted-firmware";
       rev = "v${version}";
-      sha256 = "0w3blkqgmyb5bahlp04hmh8abrflbzy0qg83kmj1x9nv4mw66f3b";
+      hash = "sha256-qT9DdTvMcUrvRzgmVf2qmKB+Rb1WOB4p1rM+fsewGcg=";
     };
     patches = [
       # "allwinner: Choose PSCI states to avoid translation"


### PR DESCRIPTION
Tested to boot with the kernel in https://github.com/NixOS/mobile-nixos/pull/449.

I tested this by building a full disk image, flashing it onto an SD card, and booting from that.

I've been using this firmware for >1 month without issue.