### PR TITLE
pine64-pinephone: upgrade firmware package to fix bluetooth firmware path

### DIFF
--- a/devices/pine64-pinephone/firmware/default.nix
+++ b/devices/pine64-pinephone/firmware/default.nix
@@ -7,8 +7,8 @@
 runCommandNoCC "pine64-pinephone-firmware" {
   src = fetchgit {
     url = "https://megous.com/git/linux-firmware";
-    rev = "4ec2645b007ba4c3f2962e38b50c06f274abbf7c";
-    sha256 = "0mx5h2r7j5bik4wdkgdyzjpj1x6fx2y4p8y1ir4ic76902xhipr6";
+    rev = "6e8e591e17e207644dfe747e51026967bb1edab5";
+    hash = "sha256-TaGwT0XvbxrfqEzUAdg18Yxr32oS+RffN+yzSXebtac=";
   };
   meta.license = lib.licenses.unfreeRedistributable;
 } ''


### PR DESCRIPTION
Per https://github.com/NixOS/mobile-nixos/issues/395#issuecomment-1007411427, the kernel is looking for firmware at rtl_bt/rtl8723cs_xx_config.bin but in the current firmware package there is no such file:

```
$ ls /run/current-system/firmware/rtl_bt | grep -i rtl8723cs
rtl8723cs_xx_config-pinebook.bin
rtl8723cs_xx_config-pinephone.bin
rtl8723cs_xx_fw.bin
```

I have not yet figured out why this path changed, but I can see Megi has a
commit renaming the firmware:
https://megous.com/git/linux-firmware/commit/?id=6e8e591e17e207644dfe747e51026967bb1edab5.

I tested this on Linux 5.15.6 (https://github.com/NixOS/mobile-nixos/pull/449) and it worked: Bluetooth is now working again.

However, if this firmware rename is dependent on Linux 5.15.6, then this PR risks breaking users with older kernels. I will look into this.