### PR TITLE
xlibs -> xorg

### DIFF
--- a/examples/demo/configuration.nix
+++ b/examples/demo/configuration.nix
@@ -226,7 +226,7 @@ in
           # A bit rude, but this ensures the keyboard always starts at a quarter
           # of the resolution.
           # onboard will not accept -s to set size with a docked keyboard.
-          height=$(( $( ${pkgs.xlibs.xwininfo}/bin/xwininfo -root | grep '^\s\+Height:' | cut -d':' -f2 ) / 4 ))
+          height=$(( $( ${pkgs.xorg.xwininfo}/bin/xwininfo -root | grep '^\s\+Height:' | cut -d':' -f2 ) / 4 ))
 
           ${pkgs.gnome3.dconf}/bin/dconf write /org/onboard/window/landscape/dock-height "$height" || :
           ${pkgs.gnome3.dconf}/bin/dconf write /org/onboard/window/portrait/dock-height "$height"  || :

--- a/modules/initrd-boot-gui.nix
+++ b/modules/initrd-boot-gui.nix
@@ -6,14 +6,14 @@ let
   } ''
     (PS4=" $ "; set -x
     mkdir -p $out
-    cp -r ${pkgs.xlibs.xkeyboardconfig}/share/X11/xkb $out/xkb
-    cp -r ${pkgs.xlibs.libX11.out}/share/X11/locale $out/locale
+    cp -r ${pkgs.xorg.xkeyboardconfig}/share/X11/xkb $out/xkb
+    cp -r ${pkgs.xorg.libX11.out}/share/X11/locale $out/locale
     )
 
-    for f in $(grep -lIiR '${pkgs.xlibs.libX11.out}' $out); do
+    for f in $(grep -lIiR '${pkgs.xorg.libX11.out}' $out); do
       printf ':: substituting original path for $out in "%s".\n' "$f"
       substituteInPlace $f \
-        --replace "${pkgs.xlibs.libX11.out}/share/X11/locale/en_US.UTF-8/Compose" "$out/locale/en_US.UTF-8/Compose"
+        --replace "${pkgs.xorg.libX11.out}/share/X11/locale/en_US.UTF-8/Compose" "$out/locale/en_US.UTF-8/Compose"
     done
   '';
 in


### PR DESCRIPTION
The alias 'xlibs' has been removed in NixOS/nixpkgs#161146. This PR fixes the following build error:

```shellsession
error: 'xlibs' has been renamed to/replaced by 'xorg'
```