### PR TITLE
examples/phosh: init

### DIFF
--- a/examples/phosh/README.md
+++ b/examples/phosh/README.md
@@ -1,0 +1,6 @@
+## Building
+
+The stage-2 needs to be built natively on the target architecture (armv7 on
+armv7, aarch64 on aarch64).
+
+(Though the tooling will try to build it through cross-compilation!)

--- a/examples/phosh/configuration.nix
+++ b/examples/phosh/configuration.nix
@@ -16,6 +16,7 @@ in
         "feedbackd"
         "networkmanager"
         "video"
+        "wheel"
       ];
     };
     

--- a/examples/phosh/configuration.nix
+++ b/examples/phosh/configuration.nix
@@ -1,0 +1,38 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib) mkForce;
+  system_type = config.mobile.system.type;
+
+  defaultUserName = "alice";
+in
+{
+  config = {
+    users.users."${defaultUserName}" = {
+      isNormalUser = true;
+      password = "1234";
+      extraGroups = [
+        "dialout"
+        "feedbackd"
+        "networkmanager"
+        "video"
+      ];
+    };
+    
+    services.xserver.desktopManager.phosh = {
+      enable = true;
+      user = defaultUserName;
+      group = "users";
+    };
+
+    programs.calls.enable = true;
+    hardware.sensor.iio.enable = true;
+
+    environment.systemPackages = [
+      pkgs.chatty
+      pkgs.kgx
+      pkgs.megapixels
+    ];
+
+  };
+}

--- a/examples/phosh/default.nix
+++ b/examples/phosh/default.nix
@@ -1,0 +1,14 @@
+{ device ? null
+, pkgs ? (import ../../pkgs.nix {})
+}@args':
+let args = args' // { inherit pkgs; }; in
+
+import ../../lib/eval-with-configuration.nix (args // {
+  configuration = [ (import ./configuration.nix) ];
+  additionalHelpInstructions = ''
+    You can build the `-A outputs.default` attribute to build the default output
+    for your device.
+
+     $ nix-build examples/phosh --argstr device ${device} -A outputs.default
+  '';
+})


### PR DESCRIPTION
This provides a Phosh example, that supports GSM.

Tested by:
```
$ NIX_PATH=~/src/nixpkgs       # that contains https://github.com/NixOS/nixpkgs/pull/153940
$ NIXPKGS_ALLOW_UNFREE=1 nix-build examples/phosh --system aarch64-linux --argstr device pine64-pinephone -A outputs.default
```

This image boots on a Pinephone to Phosh, can receive calls, and can connect to 4G.

Inspired by https://github.com/NixOS/mobile-nixos/pull/352, this PR is simpler, following subsequent upstreaming:
* https://github.com/NixOS/nixpkgs/pull/153940
* https://github.com/torvalds/linux/commit/d900a1cd310de097fb94796ca575c118b2637b3b
* Removal of Android related directives.