### PR TITLE
overlay/kernel-builder: Implement kernelOlder/kernelAtLeast

### DIFF
--- a/overlay/mobile-nixos/kernel/builder.nix
+++ b/overlay/mobile-nixos/kernel/builder.nix
@@ -495,10 +495,16 @@ stdenv.mkDerivation (inputArgs // {
   requiredSystemFeatures = [ "big-parallel" ];
   dontStrip = true;
 
-  passthru = {
+  passthru = let
+    baseVersion = lib.head (lib.splitString "-rc" version);
+  in {
     # Used by consumers of the kernel derivation to configure the build
     # appropriately for different quirks.
     inherit isQcdt isExynosDT;
+
+    inherit baseVersion;
+    kernelOlder = lib.versionOlder baseVersion;
+    kernelAtLeast = lib.versionAtLeast baseVersion;
 
     # Used by consumers to refer to the kernel build product.
     file = kernelTarget + optionalString isImageGzDtb "-dtb";


### PR DESCRIPTION
These are used in nixpkgs to check for firmware compression support since https://github.com/NixOS/nixpkgs/commit/8aa8e0ce7f137fe329608efcbb3494a5e6a63f42 and is expected in other out-of-tree kernel modules too.

Fixes https://github.com/NixOS/nixpkgs/issues/173832.