### PR TITLE
Update Nixpkgs pin (and fixes for recent updates)

### DIFF
--- a/examples/hello/configuration.nix
+++ b/examples/hello/configuration.nix
@@ -112,7 +112,7 @@ in
     wheelNeedsPassword = lib.mkForce false;
   };
 
-  services.mingetty.autologinUser = "nixos";
+  services.getty.autologinUser = "nixos";
 
   # The LVGUI interface can be used with volume keys for selecting
   # and power to activate an option.

--- a/modules/cross-workarounds.nix
+++ b/modules/cross-workarounds.nix
@@ -16,16 +16,7 @@ lib.mkIf isCross (lib.mkMerge [
 
 # All cross-compilation
 {
-  # building '/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-fc-cache.drv'...
-  # [...]-fontconfig-2.10.2-aarch64-unknown-linux-gnu-bin/bin/fc-cache: cannot execute binary file: Exec format error
-  fonts.fontconfig.enable = false;
-
-  # building '/nix/store/eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee-mesa-19.3.3-aarch64-unknown-linux-gnu.drv'...
-  # meson.build:1537:2: ERROR: Dependency "wayland-scanner" not found, tried pkgconfig
-  security.polkit.enable = false;
-
-  # udisks fails due to gobject-introspection being not cross-compilation friendly.
-  services.udisks2.enable = false;
+  # No workarounds needed!
 }
 
 # 32 bit ARM
@@ -34,22 +25,14 @@ lib.mkIf isCross (lib.mkMerge [
     (final: super:
       # Ensure pkgsBuildBuild ends up unmodified, otherwise the canary test will
       # get super expensive to build.
-      if super.stdenv.buildPlatform == super.stdenv.hostPlatform then {} else {
-      # Works around libselinux failure with python on armv7l.
-      # LONG_BIT definition appears wrong for platform
-      libselinux = (super.libselinux
-        .override({
-          enablePython = false;
-        }))
-        .overrideAttrs (_: {
-          preInstall = ":";
-        })
-      ;
-
-      # btrfs-progs-armv7l-unknown-linux-gnueabihf-5.17.drv
-      # /nix/store/wnrc4daqbd6v5ifqlxsj75ky8556zy0p-python3-3.9.12/include/python3.9/pyport.h:741:2: error: #error "LONG_BIT definition appears wrong for platform (bad gcc/glibc config?)."
-      btrfs-progs = lib.warn "btrfs-progs neutered due to broken build with cross armv7l" nullPackage;
-    })
+      if super.stdenv.buildPlatform == super.stdenv.hostPlatform
+      then {}
+      else {
+        # btrfs-progs-armv7l-unknown-linux-gnueabihf-5.17.drv
+        # /nix/store/wnrc4daqbd6v5ifqlxsj75ky8556zy0p-python3-3.9.12/include/python3.9/pyport.h:741:2: error: #error "LONG_BIT definition appears wrong for platform (bad gcc/glibc config?)."
+        btrfs-progs = lib.warn "btrfs-progs neutered due to broken build with cross armv7l" nullPackage;
+      }
+    )
   ];
 })
 

--- a/modules/cross-workarounds.nix
+++ b/modules/cross-workarounds.nix
@@ -8,6 +8,9 @@ let
     config.nixpkgs.crossSystem != null &&
     config.nixpkgs.localSystem.system != null &&
     config.nixpkgs.crossSystem.system != config.nixpkgs.localSystem.system;
+  nullPackage = pkgs.runCommandNoCC "null" {} ''
+    mkdir -p $out
+  '';
 in
 lib.mkIf isCross (lib.mkMerge [
 
@@ -42,6 +45,10 @@ lib.mkIf isCross (lib.mkMerge [
           preInstall = ":";
         })
       ;
+
+      # btrfs-progs-armv7l-unknown-linux-gnueabihf-5.17.drv
+      # /nix/store/wnrc4daqbd6v5ifqlxsj75ky8556zy0p-python3-3.9.12/include/python3.9/pyport.h:741:2: error: #error "LONG_BIT definition appears wrong for platform (bad gcc/glibc config?)."
+      btrfs-progs = lib.warn "btrfs-progs neutered due to broken build with cross armv7l" nullPackage;
     })
   ];
 })

--- a/modules/system-types/uefi/default.nix
+++ b/modules/system-types/uefi/default.nix
@@ -39,9 +39,9 @@ let
   # TODO: use generatedFilesystems
   boot-partition =
     imageBuilder.fileSystem.makeESP {
-      name = "mobile-nixos-ESP";
+      name = "mn-ESP"; # volume name (up to 11 characters long)
       partitionLabel = "mn-ESP";
-      partitionID   = "966D4E021684";
+      partitionID   = "4E021684"; # FIXME: forwarded to filesystem volume ID, it shouldn't be
       partitionUUID = "CFB21B5C-A580-DE40-940F-B9644B4466E2";
 
       # Let's give us a *bunch* of space to play around.

--- a/modules/system-types/uefi/default.nix
+++ b/modules/system-types/uefi/default.nix
@@ -31,7 +31,7 @@ let
       --add-section .cmdline="${kernelParamsFile}"            --change-section-vma  .cmdline=0x30000 \
       --add-section .linux="${kernelFile}"                    --change-section-vma  .linux=0x2000000 \
       --add-section .initrd="${config.mobile.outputs.initrd}" --change-section-vma .initrd=0x3000000 \
-      "${pkgs.libudev}/lib/systemd/boot/efi/linux${uefiPlatform}.efi.stub" \
+      "${pkgs.udev}/lib/systemd/boot/efi/linux${uefiPlatform}.efi.stub" \
       "$out"
     )
   '';

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -1,6 +1,6 @@
 let
-  sha256 = "sha256:1wg55jlxyvbjvm8x2rcirmvqws4y8xq504dn3yjp05m1bajhpj5r";
-  rev = "6daa4a5c045d40e6eae60a3b6e427e8700f1c07f";
+  sha256 = "sha256:1ipd1k1gvxh9sbg4w4cpa3585q09gvsq8xbjvxnnmfjib6r6xx4i";
+  rev = "dfd82985c273aac6eced03625f454b334daae2e8";
 in
 builtins.trace "(Using pinned Nixpkgs at ${rev})"
 import (fetchTarball {


### PR DESCRIPTION
Look, no workarounds on 64 bit!

Tested:

  - Running the UEFI VM on x86_64
  - Running AArch64 `xiaomi-lavender` (`examples/hello`)
  - Running armv7l `amazon-austin` (`examples/hello`)
  - Building the pinephone image (assumed to run fine)