### PR TITLE
system-types/u-boot: Fix build for non-allwinner

### DIFF
--- a/modules/system-types/u-boot/default.nix
+++ b/modules/system-types/u-boot/default.nix
@@ -36,21 +36,10 @@ let
     printenv kernel_addr_r
     printenv fdt_addr_r
     printenv ramdisk_addr_r
+    echo devtype = "$devtype"
+    echo devnum = "$devnum"
     echo === end of the debug information ===
     echo
-
-    if test "$mmc_bootdev" != ""; then
-      echo ":: Detected mmc booting"
-      devtype="mmc"
-    else
-      echo "!!! Could not detect devtype !!!"
-      exit
-    fi
-
-    if test "$devtype" = "mmc"; then
-      devnum="$mmc_bootdev"
-      echo ":: Booting from mmc $devnum"
-    fi
 
     bootpart=""
     echo part number $devtype $devnum boot bootpart


### PR DESCRIPTION
devnum was already provided from the distro bootcmd. Furthermore,
mmc_bootdev is an allwinnerism.

* * *

This is a *correctness* fix. This will be needed for Pinephone Pro support (and support any other U-Boot platform).