### PR TITLE
Fix kernel config validation with large amount of options

### DIFF
--- a/overlay/mobile-nixos/kernel/builder.nix
+++ b/overlay/mobile-nixos/kernel/builder.nix
@@ -20,6 +20,7 @@
 , buildPackages
 
 , writeTextFile
+, writeShellScript
 , writeShellScriptBin
 
 , perl
@@ -141,7 +142,7 @@ in
 
 let
   evaluatedStructuredConfig = import ./eval-config.nix {
-    inherit lib path version;
+    inherit lib path version writeShellScript;
     structuredConfig = (systemBuild-structuredConfig version);
   };
 

--- a/overlay/mobile-nixos/kernel/eval-config.nix
+++ b/overlay/mobile-nixos/kernel/eval-config.nix
@@ -4,6 +4,7 @@
 , modules ? []
 , structuredConfig
 , version
+, writeShellScript
 }: rec {
   module = import (path + "/nixos/modules/system/boot/kernel_config.nix");
   config = (lib.evalModules {
@@ -42,7 +43,7 @@
           mkConf = cfg: lib.concatStringsSep "\n" (lib.mapAttrsToList mkConfigLine cfg);
           configfile = mkConf config.settings;
 
-          validatorSnippet = ''
+          validatorSnippet = writeShellScript "kernel-configuration-validator-snippet" ''
             (
             # This can be executed outside of a Nix build script.
             set -eu
@@ -153,9 +154,9 @@
             };
             validatorSnippet = lib.mkOption {
               readOnly = true;
-              type = lib.types.str;
+              type = lib.types.package;
               description = ''
-                String that can directly be used as a kernel config file contents.
+                Path to a script that can directly be called to validate the kernel config.
               '';
             };
           };

--- a/overlay/mobile-nixos/kernel/eval-config.nix
+++ b/overlay/mobile-nixos/kernel/eval-config.nix
@@ -44,6 +44,10 @@
 
           validatorSnippet = ''
             (
+            # This can be executed outside of a Nix build script.
+            set -eu
+            set -o pipefail
+
             echo
             echo ":: Validating kernel configuration"
             echo
@@ -58,14 +62,13 @@
 
             ${lib.concatMapStringsSep "\n" ({key, item}:
             let
-              line = mkConfigLine key item;
-              val = if item.freeform != null then item.freeform else item.tristate;
+              line = lib.escapeShellArg (mkConfigLine key item);
               lineNotSet = "# CONFIG_${key} is not set";
               linePattern = "^CONFIG_${key}=";
               presencePattern = "CONFIG_${key}[ =]";
             in
             ''
-              if [[ "${line}" == *" is not set" ]]; then
+              if [[ ${line} == *" is not set" ]]; then
                 # An absent unset value is *totally fine*.
                 if (
                   # Present
@@ -83,13 +86,13 @@
                   value=$(grep 'CONFIG_${key}[= ]' .config || :)
                   echo "CONFIG_${key} should be left «is not set»... set to: «$value»."
                 fi
-              elif [[ "${line}" == *=n ]]; then
+              elif [[ ${line} == *=n ]]; then
                 # An absent `=n` value is *totally fine*.
                 if (
                   # Present
                   (grep '${presencePattern}' .config) &&
                   # And neither unset or set to the value
-                  ! (grep '^${line}$' .config || grep '^${lineNotSet}$' .config)
+                  ! (grep '^'${line}'$' .config || grep '^${lineNotSet}$' .config)
                 ) > /dev/null; then
                   ${if item.optional then ''
                     ((++warn))
@@ -99,10 +102,10 @@
                     echo -n "ERROR: "
                   ''}
                   value=$(grep 'CONFIG_${key}[= ]' .config || :)
-                  echo "CONFIG_${key} not set to «${line}»... set to: «$value»."
+                  echo "CONFIG_${key} not set to «"${line}"»... set to: «$value»."
                 fi
               else
-                if ! grep '^${line}$' .config > /dev/null; then
+                if ! grep '^'${line}'$' .config > /dev/null; then
                   ${if item.optional then ''
                     ((++warn))
                     echo -n "Warning: "
@@ -112,9 +115,9 @@
                   ''}
                   value=$(grep 'CONFIG_${key}[= ]' .config || :)
                   if [[ -z "$value" ]]; then
-                    echo "CONFIG_${key} is expected to be set to «${line}», but is not present in config file."
+                    echo "CONFIG_${key} is expected to be set to «"${line}"», but is not present in config file."
                     else
-                    echo "CONFIG_${key} not set to «${line}»... set to: «$value»."
+                    echo "CONFIG_${key} not set to «"${line}"»... set to: «$value»."
                   fi
                 fi
               fi


### PR DESCRIPTION
This works around an issue where, with a large set of config options, it would error out like so:

```
ErroSysError{executing '/nix/store/eee-bash-5.1-p16/bin/bash': Argument list too long
error: builder for '/nix/store/eee-linux-aarch64-unknown-linux-gnu-5.17.5.drv' failed with exit code 1;
```