### PR TITLE
lvgui: Fix add_switch description regression

### DIFF
--- a/boot/lib/lvgui/lvgui/windows.rb
+++ b/boot/lib/lvgui/lvgui/windows.rb
@@ -38,7 +38,7 @@ module LVGUI
       end
     end
 
-    def add_switch(label, description: nil, initial: false)
+    def add_switch(label, description: "", initial: false)
       LVGUI::SwitchLine.new(@container).tap do |switch|
         add_to_focus_group(switch.switch_control)
         if initial


### PR DESCRIPTION
generation-switch in recovery-menu kept crashing.

this fixes it ;)

cc @samueldr 