### PR TITLE
init: Fix kexec condition in SwitchRoot

### DIFF
--- a/boot/init/tasks/switch_root.rb
+++ b/boot/init/tasks/switch_root.rb
@@ -9,6 +9,10 @@ class Tasks::SwitchRoot < SingletonTask
     add_dependency(:Task, Tasks::Splash.instance)
     add_dependency(:Target, :SwitchRoot)
     @target = SYSTEM_MOUNT_POINT
+
+    # By default, with stage-0, we prefer using the generation kernel
+    # This may be overriden by the user recovery user interface
+    @use_generation_kernel = STAGE == 0
   end
 
   # Given a path name, without the leading SYSTEM_MOUNT_POINT, resolves


### PR DESCRIPTION
In #300 I "fixed" stage-0 by adding a switch to toggle between it being
enabled and disabled in the recovery menu. *That* works as expected.

In 2a46962d7638f0120db4678a97e8dc87ed45d0c9 one can observe that the
`#will_kexec?` method will use data that will only come from the
`choice` made from the recovery interface. The `@use_generation_kernel`
member is not set at any other point.

With ruby semantics, this means that the `if` is false, so *unless* you
choose to boot using the recovery menu, it will never trigger `kexec`.

Why has this gone through this way? Most likely because my main testing
target was configured so it *always* went to the recovery menu at the
time, meaning that I never saw the default behaviour.

* * *

## TODO

 - [x] Determine why stage-0 doesn't work with the UEFI VM right now (in other word with `nix-build ./examples/demo/ --argstr device uefi-x86_64 -A outputs.vm && ./result -smp 2`


* * *

cc @betaboon, note that this will not fix the other problem you had, but fixes the observation that `kexec` was never used while it should have been.