### PR TITLE
quirks/audio: add quirk for custom UCM profiles

### DIFF
--- a/modules/quirks/audio.nix
+++ b/modules/quirks/audio.nix
@@ -1,0 +1,38 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.mobile.quirks.audio;
+  ucm-env = config.environment.variables.ALSA_CONFIG_UCM2;
+in
+{
+  options.mobile.quirks.audio = {
+    alsa-ucm-meld = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Combines the derivation output path share/alsa/ucm2/ with
+        pkgs.alsa-ucm-conf and points ALSA to the result.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.alsa-ucm-meld {
+    environment.pathsToLink = [ "share/alsa/ucm2" ];
+    environment.systemPackages = [ pkgs.alsa-ucm-conf ];
+
+    environment.variables.ALSA_CONFIG_UCM2 =
+      "/run/current-system/sw/share/alsa/ucm2";
+
+    # pulseaudio
+    systemd.user.services.pulseaudio.environment.ALSA_CONFIG_UCM2 = ucm-env;
+    systemd.services.pulseaudio.environment.ALSA_CONFIG_UCM2      = ucm-env;
+
+    # pipewire
+    systemd.user.services.pipewire.environment.ALSA_CONFIG_UCM2       = ucm-env;
+    systemd.user.services.pipewire-pulse.environment.ALSA_CONFIG_UCM2 = ucm-env;
+    systemd.user.services.wireplumber.environment.ALSA_CONFIG_UCM2    = ucm-env;
+    systemd.services.pipewire.environment.ALSA_CONFIG_UCM2            = ucm-env;
+    systemd.services.pipewire-pulse.environment.ALSA_CONFIG_UCM2      = ucm-env;
+    systemd.services.wireplumber.environment.ALSA_CONFIG_UCM2         = ucm-env;
+  };
+}

--- a/modules/quirks/default.nix
+++ b/modules/quirks/default.nix
@@ -4,5 +4,6 @@
     ./qualcomm
     ./framebuffer.nix
     ./wifi.nix
+    ./audio.nix
   ];
 }


### PR DESCRIPTION
Provides a general way to add ALSA UCM profiles for a device.

Tested with pinephone pro on my [wip/pinephone-pro](https://github.com/wentam/mobile-nixos/tree/wip/pinephone-pro) branch, both pulseaudio and pipewire working.

This is set up to overlay files onto pkgs.alsa-ucm-conf to accomodate [profiles distributed like this](https://gitlab.com/pine64-org/pine64-alsa-ucm). These have references to the main alsa-ucm-conf repo but are distributed out of that context.

This does mean UCM derivations need to follow the structure of the alsa-ucm-conf repo (and not provide their own ucm.conf top-level file).

A device can just do something like:

```nix
{
  mobile.quirks.audio.alsa-ucm-meld = true;
  environment.systemPackages = [ pine64-alsa-ucm ];
}
```

Using the term 'meld' rather than 'overlay' to avoid confusion with nixpkgs overlays.