### PR TITLE
kernel-builder: Fix older kernel build with -fno-common

### DIFF
--- a/overlay/mobile-nixos/kernel/builder.nix
+++ b/overlay/mobile-nixos/kernel/builder.nix
@@ -121,6 +121,10 @@ in
 # The usual mkDerivation option
 , enableParallelBuilding ? true
 
+# Tries to patch `multiple definition of `yylloc';` errors from older vendor kernels.
+# Only disable if the patch does not apply.
+, enableDefaultYYLOCPatch ? true
+
 # Usual stdenv arguments we are also setting.
 # Use the ones given by the user for composition.
 , nativeBuildInputs ? []
@@ -214,6 +218,7 @@ stdenv.mkDerivation (inputArgs // {
     map (p: p.patch) kernelPatches
     # Required for deterministic builds along with some postPatch magic.
     ++ optional (lib.versionAtLeast version "4.13") (nixosKernelPath + "/randstruct-provide-seed.patch")
+    ++ optional (enableDefaultYYLOCPatch && lib.versionOlder version "4.0") ./gcc10-extern_YYLOC_global_declaration.patch
     ++ patches
   ;
 

--- a/overlay/mobile-nixos/kernel/gcc10-extern_YYLOC_global_declaration.patch
+++ b/overlay/mobile-nixos/kernel/gcc10-extern_YYLOC_global_declaration.patch
@@ -1,0 +1,39 @@
+Based on https://lkml.org/lkml/2020/4/1/1206. In original patch, YYLOC declaration was removed.
+However, using original patch, which removes yylloc declaration on 3.18.14 kernel version results in 'yylloc not declared' error.
+See part of the original description below:
+
+gcc 10 will default to -fno-common, which causes this error at link
+time:
+
+  (.text+0x0): multiple definition of `yylloc'; dtc-lexer.lex.o (symbol from plugin):(.text+0x0): first defined here
+
+This is because both dtc-lexer as well as dtc-parser define the same
+global symbol yyloc. Before with -fcommon those were merged into one
+defintion. The proper solution would be to to mark this as "extern",
+
+diff --git a/scripts/dtc/dtc-lexer.l b/scripts/dtc/dtc-lexer.l
+index 3b41bfca636..9b9c29e6f31 100644
+--- a/scripts/dtc/dtc-lexer.l
++++ b/scripts/dtc/dtc-lexer.l
+@@ -39,7 +39,7 @@ LINECOMMENT	"//".*\n
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
++extern YYLTYPE yylloc;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
+ #define	YY_USER_ACTION \
+diff --git a/scripts/dtc/dtc-lexer.lex.c_shipped b/scripts/dtc/dtc-lexer.lex.c_shipped
+index 2d30f41778b..d0eb405cb81 100644
+--- a/scripts/dtc/dtc-lexer.lex.c_shipped
++++ b/scripts/dtc/dtc-lexer.lex.c_shipped
+@@ -637,7 +637,7 @@ char *yytext;
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
++extern YYLTYPE yylloc;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
+ #define	YY_USER_ACTION \


### PR DESCRIPTION
This is causing a chunk of the failures in the Mobile NixOS hydra evals. And it's also causing the failure on `tested`.

Let's get those green!