### PR TITLE
kernel-builder: Fix modules_install invocation

### DIFF
--- a/overlay/mobile-nixos/kernel/builder.nix
+++ b/overlay/mobile-nixos/kernel/builder.nix
@@ -412,7 +412,7 @@ stdenv.mkDerivation (inputArgs // {
   buildPhase = if enableCombiningBuildAndInstallQuirk then ":" else null;
 
   installTargets =
-    if isCompressed != false then [ "zinstall" ] else [ "install" ]
+    (if isCompressed != false then [ "zinstall" ] else [ "install" ])
     ++ installTargets
     ++ optional isModular "modules_install"
   ;


### PR DESCRIPTION
From #506, by @telent.

Let's fast-track this change to (slightly) reduce the scope of that other PR.

* * *

add parens to enable modules_install when isModular

in nix 2.10.3,

```
nix-repl> if true then [ 10] else [8] ++ [4]
[ 10 ]

nix-repl> (if true then [ 10] else [8]) ++ [4]
[ 10 4 ]
```