### PR TITLE
Add gadgetfs support for adb in stage-2

### DIFF
--- a/modules/adb.nix
+++ b/modules/adb.nix
@@ -29,10 +29,41 @@ with lib;
       }];
     };
 
+    # TODO: `teardown` on the stage-1 adb task, and execute it before switch_root
     boot.postBootCommands = ''
-      # Restart adbd early during stage-2
+      # Kill adbd early during stage-2
       ${pkgs.procps}/bin/pkill -x adbd
-      ${pkgs.adbd}/bin/adbd &
     '';
+
+    # This service assumes there was a single gadget configured during stage-1
+    # for ffs and adb use, and that this gadget is to be re-used.
+    # TODO: self-contained configuration of the gadget with gadget-tool here.
+    systemd.services.adbd = {
+      description = "ADB Daemon for stage-2";
+      wantedBy = [ "multi-user.target" ];
+      enable = true;
+      script = ''
+        ${pkgs.adbd}/bin/adbd &
+
+        # Wait a bit to ensure the ffs (functionfs) component is started.
+        sleep 1
+
+        # NOTE: the ffs (functionfs) userspace component needs to already
+        #       be running when we "enable" the gadget.
+        #       Else we will get errno -19, ENODEV.
+        if [ -e /sys/kernel/config/usb_gadget ]; then
+          cd /sys/kernel/config/usb_gadget
+          for gadget in * ; do
+            if test -n $gadget/UDC ; then
+              # honestly this does nothing more than "echo",
+              # am only using gt to show that it exists
+              ${pkgs.gadget-tool}/bin/gt enable $gadget
+            fi
+          done
+        fi
+
+        wait
+      '';
+    };
   };
 }

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -49,5 +49,6 @@
   ./system-build.nix
   ./system-target.nix
   ./system-types.nix
+  ./usb-gadget.nix
   ./zram.nix
 ]

--- a/modules/usb-gadget.nix
+++ b/modules/usb-gadget.nix
@@ -1,0 +1,9 @@
+{ config, lib, pkgs, ... }:
+
+{
+  # Ensure configfs is mounted if needed.
+  fileSystems."/sys/kernel/config" = lib.mkIf (config.mobile.usb.mode == "gadgetfs") {
+    device = "none";
+    fsType = "configfs";
+  };
+}

--- a/overlay/gt/default.nix
+++ b/overlay/gt/default.nix
@@ -1,0 +1,27 @@
+{ stdenv
+, fetchFromGitHub
+, libconfig
+, libusbgx
+, cmake
+, pkg-config
+}:
+
+stdenv.mkDerivation rec {
+  pname = "gt";
+  version = "git";
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+  buildInputs = [
+    libconfig
+    libusbgx
+  ];
+  sourceRoot = "${src.name}/source";
+  src = fetchFromGitHub {
+    owner = "linux-usb-gadgets";
+    repo = "gt";
+    rev = "7f9c45d98425a27444e49606ce3cf375e6164e8e";
+    hash = "sha256-km4U+t4Id2AZx6GpH24p2WNmvV5RVjJ14sy8tWLCQsk=";
+  };
+}

--- a/overlay/libusbgx/default.nix
+++ b/overlay/libusbgx/default.nix
@@ -1,0 +1,24 @@
+{ stdenv
+, fetchFromGitHub
+, libconfig
+, pkg-config
+, autoreconfHook
+}:
+
+stdenv.mkDerivation {
+  pname = "libusbgx";
+  version = "unstable-2021-10-31";
+  nativeBuildInputs = [
+    pkg-config
+    autoreconfHook
+  ];
+  buildInputs = [
+    libconfig
+  ];
+  src = fetchFromGitHub {
+    owner = "linux-usb-gadgets";
+    repo = "libusbgx";
+    rev = "060784424609d5a4e3bce8355f788c93f09802a5";
+    hash = "sha256-Z6Jmtk3sFNyvMhwMcOvHS3BgUvzJwUZRyPIEtR+CWJw=";
+  };
+}

--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -56,6 +56,7 @@ in
     make_ext4fs = callPackage ./make_ext4fs {};
     hardshutdown = callPackage ./hardshutdown {};
     bootlogd = callPackage ./bootlogd {};
+    libusbgx = callPackage ./libusbgx {};
 
     #
     # Hacks

--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -57,6 +57,7 @@ in
     hardshutdown = callPackage ./hardshutdown {};
     bootlogd = callPackage ./bootlogd {};
     libusbgx = callPackage ./libusbgx {};
+    gadget-tool = callPackage ./gt {}; # upstream this is called "gt", which is very Unix.
 
     #
     # Hacks


### PR DESCRIPTION
From https://github.com/NixOS/mobile-nixos/pull/506, by @telent.

Let's reduce the scope of that other PR. This change requires a tiny bit more testing, and slight cleaning.

I have kept authorship as-it-was, but split the change into logical units. This will need further cleanup.

The TODO items in the `adb` module could be handled in this PR, but not doing so wouldn't be a regression.

### TODO

 - [x] Test with `android_usb` (`google-marlin/sailfish`)
 - [x] Test with vendor `gadgetfs` (`google-walleye`)
 - [x] Test with mainline (`google-blueline`)

* * *

### Original commit message

the problem we are trying to solve is that when adbd is started in stage-1, it does not survive to stage-2. This is due to two things

- the config in configfs becomes disabled ("UDC" file becomes empty)
- adbd process is killed

This is more a workaround than a resolution: perhaps the better approach would be for stage-1 to clean up its configfs properly, and then write a NixOS module for adbd, which would be responsible for setting up its own config entries. Then it wouldn't be coupled to the stage-1 settings.
