### PR TITLE
docs: Fix layout for wide displays

### DIFF
--- a/doc/_support/styles/layout.less
+++ b/doc/_support/styles/layout.less
@@ -1,7 +1,7 @@
 body {
-	background-color: @color-blue-light;
+	background-color: #333;
 	max-width: 1920px;
-	box-shadow: 0 0 0vw 100vw #333;
+	margin: auto;
 }
 
 


### PR DESCRIPTION
Also change the default background to fix a slight bug with the #333 "overspill" background only showing up on the first "viewport" height.