### PR TITLE
phosh: prepare for installer

### DIFF
--- a/examples/phosh/configuration.nix
+++ b/examples/phosh/configuration.nix
@@ -7,6 +7,10 @@ let
   defaultUserName = "alice";
 in
 {
+  imports = [
+    ./phosh.nix
+  ];
+
   config = {
     users.users."${defaultUserName}" = {
       isNormalUser = true;
@@ -21,19 +25,7 @@ in
     };
     
     services.xserver.desktopManager.phosh = {
-      enable = true;
       user = defaultUserName;
-      group = "users";
     };
-
-    programs.calls.enable = true;
-    hardware.sensor.iio.enable = true;
-
-    environment.systemPackages = [
-      pkgs.chatty
-      pkgs.kgx
-      pkgs.megapixels
-    ];
-
   };
 }

--- a/examples/phosh/phosh.nix
+++ b/examples/phosh/phosh.nix
@@ -1,0 +1,24 @@
+#
+# This file represents safe opinionated defaults for a basic Phosh system.
+#
+# NOTE: this file and any it imports **have** to be safe to import from
+#       an end-user's config.
+#
+{ pkgs, ... }:
+
+{
+  services.xserver.desktopManager.phosh = {
+    enable = true;
+    group = "users";
+  };
+
+  programs.calls.enable = true;
+
+  environment.systemPackages = with pkgs; [
+    chatty              # IM and SMS
+    kgx                 # Terminal
+    megapixels          # Camera
+  ];
+
+  hardware.sensor.iio.enable = true;
+}

--- a/examples/phosh/phosh.nix
+++ b/examples/phosh/phosh.nix
@@ -4,7 +4,7 @@
 # NOTE: this file and any it imports **have** to be safe to import from
 #       an end-user's config.
 #
-{ pkgs, ... }:
+{ config, pkgs, options, ... }:
 
 {
   services.xserver.desktopManager.phosh = {
@@ -22,4 +22,13 @@
   ];
 
   hardware.sensor.iio.enable = true;
+
+  assertions = [
+    { assertion = options.services.xserver.desktopManager.phosh.user.isDefined;
+    message = ''
+      `services.xserver.desktopManager.phosh.user` not set.
+        When importing the phosh configuration in your system, you need to set `services.xserver.desktopManager.phosh.user` to the username of the session user.
+    '';
+    }
+  ];
 }

--- a/examples/phosh/phosh.nix
+++ b/examples/phosh/phosh.nix
@@ -16,6 +16,7 @@
 
   environment.systemPackages = with pkgs; [
     chatty              # IM and SMS
+    epiphany            # Web browser
     kgx                 # Terminal
     megapixels          # Camera
   ];


### PR DESCRIPTION
Racing changes in preparation for #522.

As described in its commit, the `examples/phosh/phosh.nix` file is public API and can be imported in a user's configuration to have some good defaults for Phosh.