### PR TITLE
modules/beautification: Start adding fluff with silent/splash boot

### DIFF
--- a/devices/pine64-pinephone/default.nix
+++ b/devices/pine64-pinephone/default.nix
@@ -28,13 +28,11 @@
     kernel.package = pkgs.callPackage ./kernel { };
   };
 
-  boot.kernelParams = [
+  boot.kernelParams = lib.mkAfter [
+    # TODO: useSerial option
     # Serial console on ttyS0, using the serial headphone adapter.
     "console=ttyS0,115200"
-    "vt.global_cursor_default=0"
     "earlycon=uart,mmio32,0x01c28000"
-    "panic=10"
-    "consoleblank=0"
   ];
 
   mobile.system.type = "u-boot";

--- a/devices/uefi-x86_64/default.nix
+++ b/devices/uefi-x86_64/default.nix
@@ -16,11 +16,6 @@
     ram = 1024 * 2;
   };
 
-  boot.kernelParams = [
-    "fbcon=vc:2-6"
-    "console=tty0"
-  ];
-
   mobile.system.type = "uefi";
 
   mobile.boot.stage-1 = {

--- a/examples/phosh/phosh.nix
+++ b/examples/phosh/phosh.nix
@@ -4,9 +4,14 @@
 # NOTE: this file and any it imports **have** to be safe to import from
 #       an end-user's config.
 #
-{ config, pkgs, options, ... }:
+{ config, lib, pkgs, options, ... }:
 
 {
+  mobile.beautification = {
+    silentBoot = lib.mkDefault true;
+    splash = lib.mkDefault true;
+  };
+
   services.xserver.desktopManager.phosh = {
     enable = true;
     group = "users";

--- a/modules/beautification.nix
+++ b/modules/beautification.nix
@@ -1,0 +1,35 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib)
+    mkDefault
+    mkIf
+    mkMerge
+    mkOption
+    types
+  ;
+in
+{
+  options = {
+    mobile = {
+      beautification = {
+        silentBoot = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            When enabled, fbcon consoles are disabled.
+          '';
+        };
+      };
+    };
+  };
+
+  config = mkMerge [
+    (mkIf config.mobile.beautification.silentBoot {
+      boot.kernelParams = lib.mkBefore [
+        "fbcon=vc:2-6"
+        "console=tty0"
+      ];
+    })
+  ];
+}

--- a/modules/beautification.nix
+++ b/modules/beautification.nix
@@ -20,6 +20,16 @@ in
             When enabled, fbcon consoles are disabled.
           '';
         };
+        splash = mkOption {
+          type = types.bool;
+          default = true;
+          description = ''
+            When enabled, plymouth is configured with nice defaults.
+
+            Note that this requires an update to the kernel command-line
+            parameters, thus the boot image may need to be reflashed.
+          '';
+        };
       };
     };
   };
@@ -30,6 +40,10 @@ in
         "fbcon=vc:2-6"
         "console=tty0"
       ];
+    })
+    (mkIf config.mobile.beautification.splash {
+      boot.plymouth.enable = mkDefault true;
+      boot.plymouth.theme = mkDefault "spinner";
     })
   ];
 }

--- a/modules/beautification.nix
+++ b/modules/beautification.nix
@@ -22,7 +22,7 @@ in
         };
         splash = mkOption {
           type = types.bool;
-          default = true;
+          default = false;
           description = ''
             When enabled, plymouth is configured with nice defaults.
 

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -40,6 +40,7 @@
   ./mobile-device.nix
   ./nixpkgs.nix
   ./outputs.nix
+  ./plymouth.nix
   ./quirks
   ./recovery.nix
   ./rootfs.nix

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -2,6 +2,7 @@
 # Keep this list `:sort`ed.
 [
   ./adb.nix
+  ./beautification.nix
   ./boot-initrd.nix
   ./bootloader.nix
   ./cross-workarounds.nix

--- a/modules/plymouth.nix
+++ b/modules/plymouth.nix
@@ -1,0 +1,14 @@
+{ config, lib, ... }:
+
+let
+  inherit (lib)
+    mkIf
+  ;
+in
+{
+  config = mkIf (config.mobile.boot.stage-1.enable && config.boot.plymouth.enable) {
+    systemd.services.plymouth-start.wantedBy = [
+      "sysinit.target"
+    ];
+  };
+}


### PR DESCRIPTION
This build on top of #523, since it enables it for phosh.

## TODO

 - [x] test against known working system (steam deck)

~~I tested against qemu and against `google-blueline`, but in both cases while the service started fine, it didn't seen to work as expected :/.~~ [It needs the boot image to be reflashed since it relies on a kernel command-line parameter](https://github.com/NixOS/nixpkgs/blob/f634d427b0224a5f531ea5aa10c3960ba6ec5f0f/nixos/modules/system/boot/plymouth.nix#L125).