### PR TITLE
boot/init: Autoresize wait for graphics

### DIFF
--- a/boot/init/tasks/auto_resize.rb
+++ b/boot/init/tasks/auto_resize.rb
@@ -7,6 +7,9 @@ class Tasks::AutoResize < Task
     @type = type
     add_dependency(:Devices, @device)
     add_dependency(:Mount, "/sys")
+    # For better user experience.
+    # Otherwise the device may look like it's hanging.
+    add_dependency(:Target, :Graphics)
   end
 
   # Computes whether a filesystem needs to be expanded.


### PR DESCRIPTION
This way this time-consuming step is guaranteed to be properly shown to the end-user.