### PR TITLE
boot: fix misc issues

### DIFF
--- a/boot/init/tasks/modules.rb
+++ b/boot/init/tasks/modules.rb
@@ -1,5 +1,6 @@
 class Tasks::Modules < Task
   MODULES_PATH = "/lib/modules"
+  SYS_MODPROBE_PATH = "/proc/sys/kernel/modprobe"
   def initialize(*modules)
     add_dependency(:Files, MODULES_PATH)
     add_dependency(:Target, :Environment)
@@ -10,7 +11,12 @@ class Tasks::Modules < Task
   end
 
   def run()
-    System.write("/proc/sys/kernel/modprobe", System.which("modprobe"))
+    unless File.exists?(SYS_MODPROBE_PATH)
+      $logger.warn("Could not tell the path to modprobe to the kernel.")
+      $logger.warn("('#{SYS_MODPROBE_PATH}' is missing.)")
+      return
+    end
+    System.write(SYS_MODPROBE_PATH, System.which("modprobe"))
     @modules.each do |mod|
       begin
         System.run("modprobe", mod)

--- a/boot/init/tasks/switch_root.rb
+++ b/boot/init/tasks/switch_root.rb
@@ -99,9 +99,13 @@ class Tasks::SwitchRoot < SingletonTask
 
     # Given as a command-line option, from the bootloader (replacement for NixOS's stage-1)
     init_parameter = System.cmdline().grep(/^init=/).first
-    unless init_parameter.nil?
-      init_parameter = init_parameter.split("=", 2).last
-      return init_parameter.rpartition("/").first
+    if init_parameter == "init=/init" then
+      $logger.info("Skipping '#{init_parameter}' cmdline parameter from quirky device...")
+    else
+      unless init_parameter.nil?
+        init_parameter = init_parameter.split("=", 2).last
+        return init_parameter.rpartition("/").first
+      end
     end
 
     # The default generation

--- a/boot/init/tasks/switch_root.rb
+++ b/boot/init/tasks/switch_root.rb
@@ -103,6 +103,7 @@ class Tasks::SwitchRoot < SingletonTask
       $logger.info("Skipping '#{init_parameter}' cmdline parameter from quirky device...")
     else
       unless init_parameter.nil?
+        $logger.info("Using '#{init_parameter}' cmdline parameter to select generation...")
         init_parameter = init_parameter.split("=", 2).last
         return init_parameter.rpartition("/").first
       end
@@ -110,12 +111,14 @@ class Tasks::SwitchRoot < SingletonTask
 
     # The default generation
     if File.symlink?(File.join(@target, DEFAULT_SYSTEM_LINK))
+      $logger.info("Using '#{DEFAULT_SYSTEM_LINK}' default generation...")
       return DEFAULT_SYSTEM_LINK
     end
 
     # Otherwise, we need to re-hydrate a system!
     registration = File.join(@target, "nix-path-registration")
     if File.exist?(registration)
+      $logger.info("Getting NixOS generation from nix-path-registration...")
       path = File.read(registration)
         .split("\n")
         .grep(%r{^/nix/store/[a-z0-9]+-nixos-system-})

--- a/boot/init/tasks/switch_root.rb
+++ b/boot/init/tasks/switch_root.rb
@@ -233,6 +233,7 @@ class Tasks::SwitchRoot < SingletonTask
       %Q{/ { mobile-nixos,stage-0,uptime = #{`uptime`.to_json}; };},
     ].join("\n")
 
+    FileUtils.mkdir_p("/run/boot/")
     File.write("/run/boot/fdt.dts", dts)
     System.run("fdt-forward --to-dtb < /run/boot/fdt.dts > /run/boot/fdt.dtb")
 


### PR DESCRIPTION
Most of these from #511.

* * *

 - `Tasks::SwitchRoot` with stage-0 would fail if the selection menu wasn't used.
 - On a limited set of android devices, a bogus `init=` parameter may be provided, skip it.
 - Log how the generation was selected
 - Be more resilient against non-modular kernels