### PR TITLE
initrd: Use ncdu_1 for now

### DIFF
--- a/modules/initrd.nix
+++ b/modules/initrd.nix
@@ -209,7 +209,7 @@ let
   # ncdu -f result/initrd.ncdu
   initrd-meta = pkgs.runCommand "initrd-${device_name}-meta" {
     nativeBuildInputs = with pkgs.buildPackages; [
-      ncdu
+      ncdu_1
       cpio
       tree
     ];


### PR DESCRIPTION
The updated `ncdu` is built in a way that makes it fail on older CPUs.