### PR TITLE
initrd: generate a more compatible noop initrd secret appender

### DIFF
--- a/modules/initrd.nix
+++ b/modules/initrd.nix
@@ -355,7 +355,7 @@ in
       boot.initrd.supportedFilesystems = lib.mkOverride 10 [];
 
       system.build.initialRamdiskSecretAppender =
-        pkgs.runCommand "noopRamdiskSecretAppender" {} "touch $out"
+        pkgs.writeScriptBin "append-initrd-secrets" "#!${pkgs.coreutils}/bin/true"
       ;
 
       mobile.outputs = {


### PR DESCRIPTION
This fixes systemd-boot menu entry generation.