### PR TITLE
boot: Add backtraces in

### DIFF
--- a/boot/init/default.nix
+++ b/boot/init/default.nix
@@ -51,7 +51,7 @@ stdenv.mkDerivation {
 
     # This is the "script" that will be loaded.
     mrbc \
-      ${lib.optionalString mruby.debug "-g"} \
+      -g \
       -o init.mrb \
       ${libs} \
       $(find lib -type f | sort) \

--- a/boot/init/init.rb
+++ b/boot/init/init.rb
@@ -47,6 +47,10 @@ System.failure(
 )
 
 rescue => e
+  msg = [
+    e.inspect,
+    e.backtrace.map{|line| "  #{line}"}.join("\n"),
+  ].join("\n----------\n")
   # Then fail
-  System.failure("INIT_EXCEPTION", "Uncaught Exception", e.inspect, color: "765300", status: 99)
+  System.failure("INIT_EXCEPTION", "Uncaught Exception", msg, color: "765300", status: 99)
 end


### PR DESCRIPTION
Otherwise it's a real pain to debug.

![image](https://user-images.githubusercontent.com/132835/197287113-edf8c0ca-5312-46c2-99f6-3d41de891be8.png)

The backtrace is shown even on the display!

Note that the backtrace entries for mruby-native bits won't be available unless mruby itself is built with `debug` turned on. It shouldn't really cause any trouble though.