### PR TITLE
Fix issues with passphrase input in stage-1

### DIFF
--- a/boot/script-loader/mruby-lvgui-native/lvgui.nix
+++ b/boot/script-loader/mruby-lvgui-native/lvgui.nix
@@ -97,13 +97,13 @@ let
 in
   stdenv.mkDerivation {
     pname = "lvgui";
-    version = "2022-10-13";
+    version = "2022-10-26";
 
     src = fetchFromGitHub {
       repo = "lvgui";
       owner = "mobile-nixos";
-      rev = "debb25509f3e8e496fb07eef0cd73ed933012913";
-      sha256 = "sha256-WhkRYEHiLP9pD9NWjN3Qa64GLb9pvO3kgihnUrne6jk=";
+      rev = "364397e6294efb53341cc1c54d4885cb21f40567";
+      sha256 = "sha256-0lcXgfTwvvZPC8DYrbhfxL0cfFE1+RELubuoSq+9oOY=";
     };
 
     # Document `LVGL_ENV_SIMULATOR` in the built headers.

--- a/boot/splash/default.nix
+++ b/boot/splash/default.nix
@@ -9,6 +9,7 @@ in
 mobile-nixos.mkLVGUIApp {
   name = "boot-splash.mrb";
   executablePath = "libexec/boot-splash.mrb";
+  enableDebugInformation = true;
   src = lib.cleanSource ./.;
   rubyFiles = [
     "ui.rb"

--- a/boot/splash/ui.rb
+++ b/boot/splash/ui.rb
@@ -195,6 +195,7 @@ class UI
 
     @ask_identifier = identifier
     @ta.set_placeholder_text(placeholder)
+    @ta.set_text("")
     @ta.show()
     @keyboard.set_ta(@ta)
     @keyboard.show()
@@ -204,7 +205,7 @@ class UI
     offset_page(delta) if delta < 0
 
     @ta.on_submit = ->(value) do
-      @ta.set_text("")
+      @ta.hide()
       offset_page(0)
       cb.call(value)
     end


### PR DESCRIPTION
Under unclear conditions (understandably due to the source of the bug), the passphrase input could sometimes crash.

I reproduced relatively-reliably the issue under different conditions, and verified that the overflow fix from upstream fixes this problem.

@Mindavi if you can test, please do. ~~I will on my devices before merging.~~ Not that I was able to reliably make it crash, it doesn't seem to want to now.

* * *

This also fixes a visual issue with the stage-1 passphrase input, and how it wouldn't hide properly anymore.