### PR TITLE
examples/phosh: rename kgx -> gnome-console

### DIFF
--- a/examples/phosh/phosh.nix
+++ b/examples/phosh/phosh.nix
@@ -22,7 +22,7 @@
   environment.systemPackages = with pkgs; [
     chatty              # IM and SMS
     epiphany            # Web browser
-    kgx                 # Terminal
+    gnome-console       # Terminal
     megapixels          # Camera
   ];
 


### PR DESCRIPTION
kgx is an alias of gnome-console in Nixpkgs, so switch to using gnome-console directly.