### PR TITLE
installer: Add support for depthcharge

### DIFF
--- a/examples/installer/app/lib/configuration.rb
+++ b/examples/installer/app/lib/configuration.rb
@@ -30,6 +30,8 @@ module Configuration
           return "pine64-pinephone"
         when /^pine64,pinetab/
           return "pine64-pinetab"
+        when /^google,krane/
+          return "lenovo-krane"
         when /^google,scarlet/
           # TODO: detect the actual scarlet model...
           return "asus-dumo"
@@ -73,6 +75,9 @@ module Configuration
         when "asus-dumo", "pine64-pinephonepro"
           # RK3399 eMMC
           File.join("/dev/disk/by-path", "platform-fe330000.mmc")
+        when "lenovo-krane"
+          # MT8183 eMMC
+          File.join("/dev/disk/by-path", "platform-11230000.mmc")
         end
 
       raise "Unknown target disk" unless path

--- a/examples/installer/pkgs/scripted-installer/automated-installer.rb
+++ b/examples/installer/pkgs/scripted-installer/automated-installer.rb
@@ -70,6 +70,9 @@ case system_type
 when "u-boot"
   boot_image = Nix.build("<nixpkgs/nixos>", attr: "config.mobile.outputs.u-boot.boot-partition")
   boot_image = Dir.glob(File.join(MOUNT_POINT, boot_image, "*.img")).first
+when "depthcharge"
+  boot_image = Nix.build("<nixpkgs/nixos>", attr: "config.mobile.outputs.depthcharge.kpart")
+  boot_image = Dir.glob(File.join(MOUNT_POINT, boot_image, "kpart")).first
 when "uefi"
   boot_image = Nix.build("<nixpkgs/nixos>", attr: "config.mobile.outputs.uefi.boot-partition")
   boot_image = Dir.glob(File.join(MOUNT_POINT, boot_image, "*.img")).first

--- a/examples/installer/pkgs/scripted-installer/disk-formatter.rb
+++ b/examples/installer/pkgs/scripted-installer/disk-formatter.rb
@@ -139,9 +139,29 @@ module Helpers
 end
 # }}}
 
-if ARGV.length != 2 then
+# Split `-*` and other arguments
+# This does not handle pairs, and is by design for simplicity at this stage.
+# We only have boolean-style parametsr.
+begin
+  params, ARGV_POSITIONAL = ARGV.partition{|arg|arg.match(/^-/)}
+  ARGV_PARAMETERS = params.map{|arg| [arg, true]}.to_h
+end
+
+if ARGV_POSITIONAL.length != 2 then
 $stderr.puts <<EOF
-Usage: #{$0} <disk> <configuration.json>
+Usage: #{$0} [--skip-partitioning|--skip-formatting] <disk> <configuration.json>
+  --skip-partitioning  The target system will not be partitioned
+  --skip-formatting    The target system partitions will not be formatted
+                       NOTE: skipping formatting must request to skip partitioning.
+EOF
+  exit 1
+end
+
+# Request to skip formatting, but do partitioning are invalid.
+if ARGV_PARAMETERS["--skip-formatting"] && !ARGV_PARAMETERS["--skip-partitioning"] then
+$stderr.puts <<EOF
+ABORTING: Use --skip-partitioning with --skip-formatting
+          It is invalid to do partitioning but no formatting.
 EOF
   exit 1
 end
@@ -151,9 +171,13 @@ puts "= Mobile NixOS installer — disk formatter ="
 puts "==========================================="
 puts
 
-disk_param = ARGV.shift
+disk_param = ARGV_POSITIONAL.shift
 disk = File.realpath(disk_param)
-configuration = JSON.parse(File.read(ARGV.shift))
+configuration = JSON.parse(File.read(ARGV_POSITIONAL.shift))
+# Will partition if the argument is not given
+do_partitioning = !ARGV_PARAMETERS["--skip-partitioning"]
+# Will format if the partition is neither arguments are given
+do_formatting = !ARGV_PARAMETERS["--skip-formatting"] || do_partitioning
 
 puts "Working on '#{disk_param}' → '#{disk}'"
 
@@ -163,30 +187,36 @@ puts "Working on '#{disk_param}' → '#{disk}'"
 
 # Partition count, to track the location of the last one, the rootfs.
 partition_count = 5
+partition_count += 1 if system_type == "depthcharge"
 
-Helpers::wipefs(disk)
-Helpers::GPT.format!(disk)
+if do_partitioning then
+  puts ""
+  puts "Partitionning..."
+  puts ""
 
-# A/B support on depthcharge
-if system_type == "depthcharge" then
-  # We're adding one more partition for A/B
-  partition_count += 1
-  Helpers::GPT.add_partition(disk, size: 128 * 1024 * 1024, partlabel: "boot_a", type: "FE3A2A5D-4F32-41A7-B725-ACCC3285A309", bootable: true)
-  Helpers::GPT.add_partition(disk, size: 128 * 1024 * 1024, partlabel: "boot_b", type: "FE3A2A5D-4F32-41A7-B725-ACCC3285A309", bootable: false)
-else
-  # This assume U-Boot, without UEFI.
-  # Boot partition, "Linux reserved", will be flashed with boot image for now
-  Helpers::GPT.add_partition(disk, size: 256 * 1024 * 1024, partlabel: "boot", type: "8DA63339-0007-60C0-C436-083AC8230908", bootable: true)
+  Helpers::wipefs(disk)
+  Helpers::GPT.format!(disk)
+
+  # A/B support on depthcharge
+  if system_type == "depthcharge" then
+    # We're adding one more partition for A/B
+    Helpers::GPT.add_partition(disk, size: 128 * 1024 * 1024, partlabel: "boot_a", type: "FE3A2A5D-4F32-41A7-B725-ACCC3285A309", bootable: true)
+    Helpers::GPT.add_partition(disk, size: 128 * 1024 * 1024, partlabel: "boot_b", type: "FE3A2A5D-4F32-41A7-B725-ACCC3285A309", bootable: false)
+  else
+    # This assume U-Boot, without UEFI.
+    # Boot partition, "Linux reserved", will be flashed with boot image for now
+    Helpers::GPT.add_partition(disk, size: 256 * 1024 * 1024, partlabel: "boot", type: "8DA63339-0007-60C0-C436-083AC8230908", bootable: true)
+  end
+
+  # Reserved for future use as a BCB, if ever implemented (e.g. ask bootloader app or recovery app to do something)
+  Helpers::GPT.add_partition(disk, size:  1 * 1024 * 1024, partlabel: "misc",    type: "EF32A33B-A409-486C-9141-9FFB711F6266")
+  # Reserved for future use to "persist" data, if ever deemed useful (e.g. timezone, "last known RTC time" and such)
+  Helpers::GPT.add_partition(disk, size: 16 * 1024 * 1024, partlabel: "persist", type: "EBC597D0-2053-4B15-8B64-E0AAC75F4DB1")
+  # Reserved for `pstore-blk`
+  Helpers::GPT.add_partition(disk, size: 15 * 1024 * 1024, partlabel: "pstore",  type: "989411FC-DFDF-40DE-9C6C-977218B794E7", uuid: "989411FC-DFDF-40DE-9C6C-977218B794E7")
+  # Rootfs partition, will be formatted and mounted as needed
+  Helpers::GPT.add_partition(disk, partlabel: "rootfs",  type: "0FC63DAF-8483-4772-8E79-3D69D8477DE4")
 end
-
-# Reserved for future use as a BCB, if ever implemented (e.g. ask bootloader app or recovery app to do something)
-Helpers::GPT.add_partition(disk, size:  1 * 1024 * 1024, partlabel: "misc",    type: "EF32A33B-A409-486C-9141-9FFB711F6266")
-# Reserved for future use to "persist" data, if ever deemed useful (e.g. timezone, "last known RTC time" and such)
-Helpers::GPT.add_partition(disk, size: 16 * 1024 * 1024, partlabel: "persist", type: "EBC597D0-2053-4B15-8B64-E0AAC75F4DB1")
-# Reserved for `pstore-blk`
-Helpers::GPT.add_partition(disk, size: 15 * 1024 * 1024, partlabel: "pstore",  type: "989411FC-DFDF-40DE-9C6C-977218B794E7", uuid: "989411FC-DFDF-40DE-9C6C-977218B794E7")
-# Rootfs partition, will be formatted and mounted as needed
-Helpers::GPT.add_partition(disk, partlabel: "rootfs",  type: "0FC63DAF-8483-4772-8E79-3D69D8477DE4")
 
 puts "Waiting for target partitions to show up..."
 
@@ -200,20 +230,30 @@ end
 # two dots such that if it's instant we get a proper length ellipsis!
 print ".. present!\n"
 
+# The rootfs is the last partition
+rootfs_partition = Helpers::Part.part(disk, partition_count)
+mapper_name = "installer-rootfs"
+
 #
 # Rootfs formatting
 #
 
-# The rootfs is the last partition
-rootfs_partition = Helpers::Part.part(disk, partition_count)
-
 if configuration["fde"]["enable"] then
-  Helpers::LUKS.format(
-    rootfs_partition,
-    uuid: configuration["filesystems"]["luks"]["uuid"],
-    passphrase: configuration["fde"]["passphrase"]
-  )
-  mapper_name = "installer-rootfs"
+  if do_formatting then
+    puts ""
+    puts "Making new LUKS volume..."
+    puts ""
+    Helpers::LUKS.format(
+      rootfs_partition,
+      uuid: configuration["filesystems"]["luks"]["uuid"],
+      passphrase: configuration["fde"]["passphrase"]
+    )
+  end
+
+  puts ""
+  puts "Opening LUKS volume..."
+  puts ""
+
   # We don't need to care about the mapper name here; we are not
   # using the NixOS config generator.
   Helpers::LUKS.open(
@@ -226,10 +266,17 @@ if configuration["fde"]["enable"] then
   rootfs_partition = mapper_name
 end
 
-Helpers::Ext4.format(
-  rootfs_partition,
-  uuid: configuration["filesystems"]["rootfs"]["uuid"],
-  label: configuration["filesystems"]["rootfs"]["label"]
-)
+if do_formatting
+  puts ""
+  puts "Formatting rootfs..."
+  puts ""
+
+  Helpers::Ext4.format(
+    rootfs_partition,
+    uuid: configuration["filesystems"]["rootfs"]["uuid"],
+    label: configuration["filesystems"]["rootfs"]["label"]
+  )
+end
+
 Dir.mkdir(MOUNT_POINT) unless Dir.exist?(MOUNT_POINT)
 Helpers::Ext4.mount(rootfs_partition, MOUNT_POINT)

--- a/examples/installer/pkgs/scripted-installer/disk-formatter.rb
+++ b/examples/installer/pkgs/scripted-installer/disk-formatter.rb
@@ -5,10 +5,6 @@ end
 
 MOUNT_POINT = "/mnt"
 
-puts "Identifying device type:"
-$system_type = Nix.instantiate("<nixpkgs/nixos>", attr: "config.mobile.system.type")
-puts ""
-
 # {{{
 
 module Helpers
@@ -179,6 +175,10 @@ do_partitioning = !ARGV_PARAMETERS["--skip-partitioning"]
 # Will format if the partition is neither arguments are given
 do_formatting = !ARGV_PARAMETERS["--skip-formatting"] || do_partitioning
 
+puts "Identifying device type:"
+$system_type = configuration["system_type"]
+puts ""
+
 puts "Working on '#{disk_param}' → '#{disk}'"
 
 #
@@ -187,7 +187,7 @@ puts "Working on '#{disk_param}' → '#{disk}'"
 
 # Partition count, to track the location of the last one, the rootfs.
 partition_count = 5
-partition_count += 1 if system_type == "depthcharge"
+partition_count += 1 if $system_type == "depthcharge"
 
 if do_partitioning then
   puts ""
@@ -198,7 +198,7 @@ if do_partitioning then
   Helpers::GPT.format!(disk)
 
   # A/B support on depthcharge
-  if system_type == "depthcharge" then
+  if $system_type == "depthcharge" then
     # We're adding one more partition for A/B
     Helpers::GPT.add_partition(disk, size: 128 * 1024 * 1024, partlabel: "boot_a", type: "FE3A2A5D-4F32-41A7-B725-ACCC3285A309", bootable: true)
     Helpers::GPT.add_partition(disk, size: 128 * 1024 * 1024, partlabel: "boot_b", type: "FE3A2A5D-4F32-41A7-B725-ACCC3285A309", bootable: false)

--- a/examples/installer/pkgs/scripted-installer/disk-formatter.rb
+++ b/examples/installer/pkgs/scripted-installer/disk-formatter.rb
@@ -4,7 +4,10 @@ require "shellwords"
 end
 
 MOUNT_POINT = "/mnt"
-$depthcharge = false
+
+puts "Identifying device type:"
+$system_type = Nix.instantiate("<nixpkgs/nixos>", attr: "config.mobile.system.type")
+puts ""
 
 # {{{
 
@@ -105,7 +108,7 @@ module Helpers
       attributes = []
       attributes << "LegacyBIOSBootable" if bootable
 
-      if bootable and $depthcharge
+      if bootable and $system_type == "depthcharge"
         # Marks depthcharge partition as prioritized, successful, with 5 tries left
         # https://chromium.googlesource.com/chromiumos/docs/+/HEAD/disk_format.md#Selecting-the-kernel
         bits = []
@@ -165,7 +168,7 @@ Helpers::wipefs(disk)
 Helpers::GPT.format!(disk)
 
 # A/B support on depthcharge
-if $depthcharge then
+if system_type == "depthcharge" then
   # We're adding one more partition for A/B
   partition_count += 1
   Helpers::GPT.add_partition(disk, size: 128 * 1024 * 1024, partlabel: "boot_a", type: "FE3A2A5D-4F32-41A7-B725-ACCC3285A309", bootable: true)

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -1,6 +1,6 @@
 let
-  sha256 = "sha256:1nb56lghla61cyyfw27rbsl9hns5898jmrddpa6q7libb4sz5hh4";
-  rev = "32096899af23d49010bd8cf6a91695888d9d9e73";
+  sha256 = "sha256:1fhv0lfj7khfr0fvwbpay3vq3v7br86qq01yyl0qxls8nsq08y0c";
+  rev = "872fceeed60ae6b7766cc0a4cd5bf5901b9098ec";
 in
 builtins.trace "(Using pinned Nixpkgs at ${rev})"
 import (fetchTarball {

--- a/release.nix
+++ b/release.nix
@@ -205,6 +205,7 @@ rec {
   };
 
   installer = {
+    lenovo-krane = (evalInstaller { device = "lenovo-krane"; localSystem = "aarch64-linux"; }).outputs.default;
     pine64-pinephone = (evalInstaller { device = "pine64-pinephone"; localSystem = "aarch64-linux"; }).outputs.default;
   };
 
@@ -231,6 +232,7 @@ rec {
 
   cross-compiled = {
     installer = {
+      lenovo-krane = (evalInstaller { device = "lenovo-krane"; localSystem = "x86_64-linux"; }).outputs.default;
       pine64-pinephone = (evalInstaller { device = "pine64-pinephone"; localSystem = "x86_64-linux"; }).outputs.default;
     };
   };


### PR DESCRIPTION
Builds on top of #552.

This adds depthcharge knowledge to the installer.

* * *

## TODO

 - [x] Rebase on `master` once #552 is merged.
 - [x] Fix the `XXX` commit that hardcoded depthcharge knowledge in the boot partition handling.
 - [x] Add krane installer to `release.nix`
 - [x] Prepare and test on my dumo (will take a hot minute to get it ready for that.) It would be inconvenient to again backup and reinstall from scratch on my krane, and *anyway* I need to re-do the setup on dumo.