### PR TITLE
overlay: Fix eval after xorg improvements

### DIFF
--- a/overlay/overlay.nix
+++ b/overlay/overlay.nix
@@ -73,7 +73,14 @@ in
     # Totally not upstreamable stuff.
     #
 
-    xorg = super.xorg.overrideScope'(self: super: {
+    xorg = (
+      # Backward compatibility shim
+      # Fixes eval after https://github.com/NixOS/nixpkgs/pull/199912
+      # Can be removed on or after 2023-05-16
+      if super.xorg ? overrideScope'
+      then super.xorg.overrideScope'
+      else super.xorg.overrideScope
+    ) (self: super: {
       xf86videofbdev = super.xf86videofbdev.overrideAttrs({patches ? [], ...}: {
         patches = patches ++ [
           ./xserver/0001-HACK-fbdev-don-t-bail-on-mode-initialization-fail.patch


### PR DESCRIPTION
Breaking change: https://github.com/NixOS/nixpkgs/pull/199912

* * *

Tested building

```
time nix-build examples/installer --argstr device lenovo-krane -A pkgs.xorg.xf86videofbdev
```

Against both current pin and current Nixpkgs, verified that the changes were being applied still correctly.