### PR TITLE
pine64-pinephone: kernel 6.0.10 -> 6.0.12

### DIFF
--- a/devices/pine64-pinephone/kernel/config.aarch64
+++ b/devices/pine64-pinephone/kernel/config.aarch64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm64 6.0.10 Kernel Configuration
+# Linux/arm64 6.0.12 Kernel Configuration
 #
 CONFIG_CC_VERSION_TEXT="aarch64-unknown-linux-gnu-gcc (GCC) 9.5.0"
 CONFIG_CC_IS_GCC=y
@@ -1050,6 +1050,7 @@ CONFIG_NET_UDP_TUNNEL=y
 # CONFIG_INET_AH is not set
 # CONFIG_INET_ESP is not set
 # CONFIG_INET_IPCOMP is not set
+CONFIG_INET_TABLE_PERTURB_ORDER=16
 CONFIG_INET_TUNNEL=y
 CONFIG_INET_DIAG=y
 CONFIG_INET_TCP_DIAG=y

--- a/devices/pine64-pinephone/kernel/default.nix
+++ b/devices/pine64-pinephone/kernel/default.nix
@@ -6,15 +6,15 @@
 }:
 
 mobile-nixos.kernel-builder {
-  version = "6.0.10";
+  version = "6.0.12";
   configfile = ./config.aarch64;
   src = fetchFromGitHub {
     # https://github.com/megous/linux
     owner = "megous";
     repo = "linux";
     # orange-pi-6.0
-    rev = "e191fb41a4fa9d8e8e3b2f4b0452c536222c087e";
-    sha256 = "sha256-vYs/cI291W+IGsnOxQIF9v6s3qSwh6UjwqzM98M8olE=";
+    rev = "bb505b76761d1f196fc3e3948e756fc1583ff2e5";
+    sha256 = "sha256-XOy011gGTxxof2syG5fk1xlpmUVvzTBMT98YfkNlD+s=";
   };
   patches = [
     ./0001-dts-pinephone-Setup-default-on-and-panic-LEDs.patch


### PR DESCRIPTION
I have used this kernel on my PinePhone for more than a day and haven't noticed any regressions. I tested the camera, 4G data connectivity, WiFi, waking from sleep, nheko, notifications and Firefox.