### PR TITLE
audio quirks: fix ucm2 symlink

### DIFF
--- a/modules/quirks/audio.nix
+++ b/modules/quirks/audio.nix
@@ -17,7 +17,7 @@ in
   };
 
   config = lib.mkIf cfg.alsa-ucm-meld {
-    environment.pathsToLink = [ "share/alsa/ucm2" ];
+    environment.pathsToLink = [ "/share/alsa/ucm2" ];
     environment.systemPackages = [ pkgs.alsa-ucm-conf ];
 
     environment.variables.ALSA_CONFIG_UCM2 =


### PR DESCRIPTION
This fixes the issue of ucm2 being not-linked due to missing starting slash. This wasn't noticed in default environments with phosh and KDE mobile, since they link the entire `/share`.