### PR TITLE
Enable use of device firmware by default

### DIFF
--- a/devices/families/sdm845-mainline/default.nix
+++ b/devices/families/sdm845-mainline/default.nix
@@ -15,7 +15,6 @@
   };
 
   hardware.enableRedistributableFirmware = true;
-  hardware.firmware = lib.mkBefore [ config.mobile.device.firmware ];
 
   # Note: on devices it's highly likely no firmware is required during stage-1.
   # DRM *should* work fine without firmware.

--- a/devices/motorola-addison/default.nix
+++ b/devices/motorola-addison/default.nix
@@ -20,6 +20,8 @@
   };
 
   mobile.device.firmware = pkgs.callPackage ./firmware {};
+  # Firmware is not enabled by default since it requires manually providing unredistributable files.
+  mobile.device.enableFirmware = false;
 
   mobile.system.android.device_name = "addison";
   mobile.system.android.bootimg = {

--- a/devices/motorola-potter/default.nix
+++ b/devices/motorola-potter/default.nix
@@ -20,6 +20,8 @@
   };
 
   mobile.device.firmware = pkgs.callPackage ./firmware {};
+  # Firmware is not enabled by default since it requires manually providing unredistributable files.
+  mobile.device.enableFirmware = false;
 
   mobile.system.android.device_name = "potter";
   mobile.system.android.bootimg = {

--- a/devices/oneplus-oneplus3/default.nix
+++ b/devices/oneplus-oneplus3/default.nix
@@ -20,6 +20,8 @@
   };
 
   mobile.device.firmware = pkgs.callPackage ./firmware {};
+  # Firmware is not enabled by default since it requires manually providing unredistributable files.
+  mobile.device.enableFirmware = false;
 
   mobile.system.android.device_name = "OnePlus3";
   mobile.system.android.bootimg = {

--- a/modules/mobile-device.nix
+++ b/modules/mobile-device.nix
@@ -1,7 +1,13 @@
 { config, lib, pkgs, ... }:
 
-with lib;
-
+let
+  inherit (lib)
+    mkIf
+    mkOption
+    mkOptionDefault
+    types
+  ;
+in
 {
   options.mobile.device = {
     name = mkOption {


### PR DESCRIPTION
> I'm thinking we probably should enable adding `config.mobile.device.firmware` to `hardware.firmware` automatically by default, as it seems to be a common pain point among users.
> 
> The only reason I don't notice it myself is because the few devices I use with Mobile NixOS I use my "integrated" custom config where I do this outright.
> 
> (To be handled in a separate PR)

— https://github.com/NixOS/mobile-nixos/pull/535#issuecomment-1336268322

Now handled in a separate PR.

This will make it less surprising for end-users, as firmware that is needed will be provided by default.