### PR TITLE
examples/installer: Add boot closure to installer

### DIFF
--- a/examples/installer/modules/all.nix
+++ b/examples/installer/modules/all.nix
@@ -1,6 +1,7 @@
 {
   imports = [
     ./adb.nix
+    ./boot-closure.nix
     ./filesystems.nix
     ./installer-gui.nix
     ./installer-script.nix

--- a/examples/installer/modules/boot-closure.nix
+++ b/examples/installer/modules/boot-closure.nix
@@ -1,0 +1,30 @@
+{ config, lib, ... }:
+
+let
+  inherit (lib)
+    mkIf
+    optionalString
+  ;
+  inherit (config.mobile)
+    system
+  ;
+in
+{
+  # Pins pre-built artifacts within the system closure that are going to be
+  # used by the installer.
+  system.extraSystemBuilderCmds = ''
+    echo ":: Adding pre-built boot files to closure..."
+    (
+      PS4=" $ "; set -x
+      mkdir -p $out/mobile-nixos-installer
+      cd $out/mobile-nixos-installer
+      ln -s ${config.mobile.boot.stage-1.kernel.package} kernel
+      ${optionalString (system.type == "depthcharge") ''
+        ln -s ${config.mobile.outputs.depthcharge.kpart} kpart
+      ''}
+      ${optionalString (system.type == "u-boot") ''
+        ln -s ${config.mobile.outputs.u-boot.boot-partition} boot-partition
+      ''}
+    )
+  '';
+}


### PR DESCRIPTION
As [mentioned here](https://github.com/NixOS/mobile-nixos/pull/565#discussion_r1083563692), move this into a discrete PR.

### What was done

 - Install on wormdingler, building the `kpart` was as fast as expected.

### TODO

 - [x] test install on Pinephone Pro (to test U-Boot systems without the cache being hot)