### PR TITLE
Fix hydra eval issues that accumulated

### DIFF
--- a/.ci/instantiate-all.nix
+++ b/.ci/instantiate-all.nix
@@ -68,7 +68,10 @@ let
     # We could try and do something smart to unwrap two levels of attrsets
     # automatically, but by stating we want those paths we are ensuring that
     # they are still present in the attrsets.
-    (dig "examples-demo.aarch64-linux") //
+    (dig "examples.hello") //
+    (dig "examples.phosh") //
+    (dig "examples.plasma-mobile") //
+    (dig "installer") //
     (dig "overlay.aarch64-linux.aarch64-linux") //
     (dig "overlay.x86_64-linux.aarch64-linux-cross") //
     (dig "overlay.x86_64-linux.armv7l-linux-cross") //

--- a/devices/amazon-austin/kernel/default.nix
+++ b/devices/amazon-austin/kernel/default.nix
@@ -1,7 +1,5 @@
-{
-  mobile-nixos
+{ mobile-nixos
 , fetchFromGitHub
-, python2
 , buildPackages
 , ...
 }:

--- a/devices/asus-dumo/firmware/default.nix
+++ b/devices/asus-dumo/firmware/default.nix
@@ -6,6 +6,7 @@
 # The minimum set of firmware files required for the device.
 runCommand "asus-dumo-firmware" {
   src = firmwareLinuxNonfree;
+  meta.license = firmwareLinuxNonfree.meta.license;
 } ''
   for firmware in \
     ath10k/QCA6174/hw3.0 \

--- a/devices/asus-z00t/default.nix
+++ b/devices/asus-z00t/default.nix
@@ -23,6 +23,7 @@
   };
 
   mobile.device.firmware = pkgs.callPackage ./firmware {};
+  mobile.device.enableFirmware = false;
 
   mobile.system.android.device_name = "Z00T";
   mobile.system.android.bootimg = {

--- a/devices/google-marlin/default.nix
+++ b/devices/google-marlin/default.nix
@@ -20,6 +20,7 @@
   };
 
   mobile.device.firmware = pkgs.callPackage ./firmware {};
+  mobile.device.enableFirmware = false;
 
   mobile.system.android.device_name = "marlin";
   mobile.system.android = {

--- a/devices/lenovo-krane/firmware/default.nix
+++ b/devices/lenovo-krane/firmware/default.nix
@@ -6,6 +6,7 @@
 # The minimum set of firmware files required for the device.
 runCommand "lenovo-krane-firmware" {
   src = firmwareLinuxNonfree;
+  meta.license = firmwareLinuxNonfree.meta.license;
 } ''
   for firmware in \
     ath10k/QCA6174/hw3.0 \

--- a/devices/lenovo-wormdingler/firmware/default.nix
+++ b/devices/lenovo-wormdingler/firmware/default.nix
@@ -6,6 +6,7 @@
 # The minimum redistributable set of firmware files required for the device.
 runCommand "lenovo-wormdingler-firmware" {
   src = firmwareLinuxNonfree;
+  meta.license = firmwareLinuxNonfree.meta.license;
 } ''
   for firmware in \
     ath10k/WCN3990/hw1.0 \

--- a/devices/oneplus-enchilada/firmware/default.nix
+++ b/devices/oneplus-enchilada/firmware/default.nix
@@ -10,7 +10,11 @@ let
     rev = "3ec855b2247291c79652b319dfe93f7747363c86";
     sha256 = "sha256-7CaXWOpao+vuFA7xknzbLml2hxTlmuzFCEM99aLD2uk=";
   };
-in runCommand "oneplus-sdm845-firmware" { inherit baseFw; } ''
+in runCommand "oneplus-sdm845-firmware" {
+  inherit baseFw;
+  # We make no claims that it can be redistributed.
+  meta.license = lib.licenses.unfree;
+} ''
   mkdir -p $out/lib/firmware
   cp -r $baseFw/lib/firmware/* $out/lib/firmware/
   chmod +w -R $out

--- a/devices/pine64-pinephone/firmware/default.nix
+++ b/devices/pine64-pinephone/firmware/default.nix
@@ -10,7 +10,7 @@ runCommand "pine64-pinephone-firmware" {
     rev = "6e8e591e17e207644dfe747e51026967bb1edab5";
     hash = "sha256-TaGwT0XvbxrfqEzUAdg18Yxr32oS+RffN+yzSXebtac=";
   };
-  meta.license = lib.licenses.unfreeRedistributable;
+  meta.license = lib.licenses.unfreeRedistributableFirmware;
 } ''
   mkdir -p "$out/lib/firmware"
   cp -vrf "$src/rtl_bt" $out/lib/firmware/

--- a/devices/pine64-pinetab/firmware/default.nix
+++ b/devices/pine64-pinetab/firmware/default.nix
@@ -11,7 +11,7 @@ runCommand "pine64-pinetab-firmware" {
     rev = "28ad3584927c0fe1f321176f73a7fd42cccec56f";
     sha256 = "0ccdifninnqpvrqg4f4b5vgy3d5g7n6xx6qny7by9aramsd94l17";
   };
-  meta.license = lib.licenses.unfreeRedistributable;
+  meta.license = lib.licenses.unfreeRedistributableFirmware;
 } ''
   mkdir -p "$out/lib/firmware"
   cp -vrf "$src/rtl_bt" $out/lib/firmware/

--- a/devices/samsung-a5y17lte/default.nix
+++ b/devices/samsung-a5y17lte/default.nix
@@ -20,6 +20,7 @@
   };
 
   mobile.device.firmware = pkgs.callPackage ./firmware {};
+  mobile.device.enableFirmware = false;
 
   mobile.system.android.device_name = "a5y17lte";
   mobile.system.android = {

--- a/modules/mobile-device.nix
+++ b/modules/mobile-device.nix
@@ -1,6 +1,7 @@
 { config, lib, pkgs, ... }:
 
 let
+  cfg = config.mobile.device;
   inherit (lib)
     mkBefore
     mkIf
@@ -29,18 +30,15 @@ in
     };
 
     firmware = mkOption {
-      type = types.package;
+      type = types.nullOr types.package;
+      default = null;
       description = ''
-        Informal option that the end-user can use to get their device's firmware package
+        Informal option that the end-user can use to get their device's firmware package.
 
-        The device configuration may provide this option so the user can simply
-        use `hardware.firmware = [ config.mobile.device.firmware ];`.
+        The firmware will be added to `hardware.firmware` automatically for most devices.
 
-        Note that not all devices provide a firmware bundle, in this case the
-        user should not add the previous example to their configuration.
-
-        This is not added automatically to the system firmwares as most device
-        firmware bundles will be unredistributable.
+        This is not added automatically to the system firmwares for some devices
+        as some bundles will be unredistributable.
       '';
     };
 
@@ -72,8 +70,8 @@ in
       mobile.device.identity.manufacturer = mkOptionDefault "generic";
     })
     (mkIf (config.mobile.enable) {
-      hardware.firmware = mkIf config.mobile.device.enableFirmware (mkBefore [
-        config.mobile.device.firmware
+      hardware.firmware = mkIf (cfg.firmware != null && cfg.enableFirmware) (mkBefore [
+        cfg.firmware
       ]);
     })
   ];

--- a/overlay/dtbtool/default.nix
+++ b/overlay/dtbtool/default.nix
@@ -1,9 +1,8 @@
-{
-  stdenv
-  , fetchurl
-  , python2
-  , python2Packages
-  , buildPackages
+{ stdenv
+, fetchurl
+, python3
+, python3Packages
+, buildPackages
 }:
 
 let
@@ -23,11 +22,11 @@ stdenv.mkDerivation {
   ];
 
   buildInputs = [
-    python2
+    python3
   ];
 
   nativeBuildInputs = [
-    python2Packages.wrapPython
+    python3Packages.wrapPython
     dtc
   ];
 


### PR DESCRIPTION
```
in job ‘examples.phosh.x86_64-linux.toplevel’:
error: The option `mobile.device.firmware' is used but not defined.
```

Also fixed other relevant breakage.

Tested using

```
 $ nix-instantiate ./release.nix
```