### PR TITLE
Fixes for boot GUI and physical keyboard/keypad

### DIFF
--- a/boot/lib/hal/recovery.rb
+++ b/boot/lib/hal/recovery.rb
@@ -6,6 +6,8 @@ module Hal
       # Keys used for "mobile" use-cases
       :KEY_VOLUMEUP,
       :KEY_VOLUMEDOWN,
+      :KEY_UP,
+      :KEY_DOWN,
       # Keys used for "computer" use-cases
       :KEY_LEFTCTRL,
       :KEY_RIGHTCTRL,

--- a/boot/lib/lvgui/lvgui/text_area.rb
+++ b/boot/lib/lvgui/lvgui/text_area.rb
@@ -28,10 +28,10 @@ class LVGUI::TextArea < LVGUI::Widget
         # Assume there is only one input.
         # Also assume Enter sends; that it is a single line.
         if char == "\n"
-          LVGUI::Keyboard.instance.set_ta(nil)
-          LVGUI::Keyboard.instance.hide()
           # Ensures the field is updated, then call the callback
           LVGL::Hacks::LVTask.once ->() do
+            LVGUI::Keyboard.instance.set_ta(nil)
+            LVGUI::Keyboard.instance.hide()
             @on_submit.call(get_text()) if @on_submit
           end
         else

--- a/boot/script-loader/mruby-lvgui-native/lvgui.nix
+++ b/boot/script-loader/mruby-lvgui-native/lvgui.nix
@@ -97,13 +97,13 @@ let
 in
   stdenv.mkDerivation {
     pname = "lvgui";
-    version = "2022-10-26";
+    version = "2023-02-11";
 
     src = fetchFromGitHub {
       repo = "lvgui";
       owner = "mobile-nixos";
-      rev = "364397e6294efb53341cc1c54d4885cb21f40567";
-      sha256 = "sha256-0lcXgfTwvvZPC8DYrbhfxL0cfFE1+RELubuoSq+9oOY=";
+      rev = "9280e18c838bcb83bd959bf39ee707d5bb84a954";
+      sha256 = "sha256-6rZTePZZEMZlBrKSOBr3/3vl6OLwOmqqGMIQ8zzbT3E=";
     };
 
     # Document `LVGL_ENV_SIMULATOR` in the built headers.

--- a/boot/splash/ui.rb
+++ b/boot/splash/ui.rb
@@ -178,7 +178,11 @@ class UI
     # The keyboard is not added to the page; the page holds the elements that
     # may move to ensure they're not covered by the keyboard.
     @keyboard.set_parent(@screen)
-    @keyboard.set_height(@screen.get_width * 0.55)
+    # Keyboard can't be more than half of the screen height...
+    # ... otherwise the UI is pushed too far up.
+    @keyboard.set_height(
+      (@screen.get_width() * 0.55).clamp(0, @screen.get_height()*0.5)
+    )
   end
 
   def set_progress(amount)


### PR DESCRIPTION
This is a combination of fixes that are relatively related.

First, when working on mainline for #496, it was found that the keypad is exposed as both a pointer and a keyboard, since mainline uses the mouse button bindings for the top two action buttons. This was a problem in lvgui, as it would assume only the pointer events were to be used, as its input system couldn't deal with an input device doing more than one thing at once. Furthermore, some more keyboard bindings were added for menu navigation.

 - See https://github.com/mobile-nixos/lvgui/pull/10

The previous changes in lvgui ended-up confirming my assumption as to why some keyboard input wouldn't work. Some keyboards expose mouse functions! For example logitech unifying devices often expose both. So while fixing input with keyboards, I took time to *properly* fix them, which ended up making me look at why the textarea events would break after using the Enter key.

 - See https://github.com/mobile-nixos/lvgui/pull/11

So, we're left with the changes in this PR.

The keyboard wouldn't hide when a keyboard event submitted the input.

Finally, on a standard 16:9 device, the keyboard would end-up hiding everything. This is now fixed by limiting its height to at most 50% of the height.


* * *

### What was done

Verified different input methods work as expected:

 - Tested on `asus-z00t`
 - Tested on `nokia-argon` (mainline)
 - Tested on ASUS TP300LA (a standard laptop with touchscreen)

NOTE: USB devices may or may not work, YMMV depending on how racy boot will be for your system. This is because there's no hot-plugging handling [yet] in the lvgui libinput driver. Not a goal for this PR.