### PR TITLE
system-types/u-boot: Fix usage with long cmdline

### DIFF
--- a/modules/system-types/u-boot/default.nix
+++ b/modules/system-types/u-boot/default.nix
@@ -25,7 +25,13 @@ let
     echo Built for ${deviceName}
     echo
 
-    setenv bootargs ${lib.concatStringsSep " " config.boot.kernelParams}
+    # Ensure we don't pick a stray bootargs
+    env delete bootargs
+
+    # Add every args one by one, or else it may be too big to fit in a single invocation.
+    ${lib.concatMapStringsSep "\n" (arg:
+      ''setenv bootargs "$bootargs ${arg}"''
+    ) config.boot.kernelParams}
 
     ${cfg.additionalCommands}
 
@@ -69,7 +75,7 @@ let
     else
       if load ''${devtype} ''${devnum}:''${bootpart} ''${kernel_addr_r} /mobile-nixos/recovery/kernel; then
         setenv boot_type recovery
-        setenv bootargs ''${bootargs} is_recovery
+        setenv bootargs "''${bootargs} is_recovery"
       else
         echo "!!! Failed to load either of the normal and recovery kernels !!!"
         exit


### PR DESCRIPTION
The whole attempt at settings bootargs would fail. Let's instead append until it can't fit.

This exact behaviour will depend on the exact U-Boot build. This was observed on a non-Mobile NixOS device, where I used Mobile NixOS to get an initial thing going.

* * *

What was done:

 - Tested on out-of-tree device: PineNote
