### PR TITLE
treewide: move NIX_CFLAGS_COMPILE to the env attrset

### DIFF
--- a/boot/script-loader/mruby-lvgui-native/lvgui.nix
+++ b/boot/script-loader/mruby-lvgui-native/lvgui.nix
@@ -127,9 +127,7 @@ in
     ++ optionals withSimulator simulatorDeps
     ;
 
-    NIX_CFLAGS_COMPILE = [
-      "-DX_DISPLAY_MISSING"
-    ];
+    env.NIX_CFLAGS_COMPILE = "-DX_DISPLAY_MISSING";
 
     makeFlags = [
       "PREFIX=${placeholder "out"}"

--- a/overlay/mkbootimg/default.nix
+++ b/overlay/mkbootimg/default.nix
@@ -25,7 +25,5 @@ stdenv.mkDerivation rec {
     chmod +x $out/bin/*
   '';
 
-  NIX_CFLAGS_COMPILE = [
-    "-Wno-error=address-of-packed-member"
-  ];
+  env.NIX_CFLAGS_COMPILE = "-Wno-error=address-of-packed-member";
 }


### PR DESCRIPTION
This is what the current Nixpkgs does.

Without this change it fails to evaluate:
```
error: The ‘env’ attribute set cannot contain any attributes passed to derivation. The following attributes are overlapping: NIX_CFLAGS_COMPILE
```

Please verify that this is the correct way to fix this.
Can anything be done to make this change backwards-compatible?