### PR TITLE
boot/init: Tear down udevd

### DIFF
--- a/boot/init/tasks/switch_root.rb
+++ b/boot/init/tasks/switch_root.rb
@@ -332,6 +332,8 @@ class Tasks::SwitchRoot < SingletonTask
       raise "Failed to kexec into #{selected_generation}"
     end
 
+    Tasks::UDev.instance.teardown()
+
     [
       "/proc",
       "/sys",

--- a/boot/init/tasks/udev.rb
+++ b/boot/init/tasks/udev.rb
@@ -37,6 +37,7 @@ class Tasks::UDev < SingletonTask
     false
   end
 
-  # TODO: teardown
-  #         udevadm control --exit
+  def teardown()
+    udevadm("control", "--exit")
+  end
 end


### PR DESCRIPTION
This fixes amdgpu suspend/resume on Steam Deck.

Unknown if it could fix anything else, but the same issue was not observed on any of intel, mali, panfrost, adreno.

Unclear how the stray `udevadm` was causing DRM issues on resume.