### PR TITLE
lvgui: 2023-02-25 -> 2023-03-02

### DIFF
--- a/boot/script-loader/mruby-lvgui-native/lvgui.nix
+++ b/boot/script-loader/mruby-lvgui-native/lvgui.nix
@@ -97,13 +97,13 @@ let
 in
   stdenv.mkDerivation {
     pname = "lvgui";
-    version = "2023-02-25";
+    version = "2023-03-02";
 
     src = fetchFromGitHub {
       repo = "lvgui";
       owner = "mobile-nixos";
-      rev = "62100c7b30a4abfd311dc2d8c503f5f253734a70";
-      sha256 = "sha256-//d0ZJJdbVqaj+ov8DzWWIIBap1NgCnmPCtKE+XLsTc=";
+      rev = "64d6c793be0cd71e9c665762934063e9c037125a";
+      sha256 = "sha256-k3Q5HF1hKC1LcSUxCxAnCbFrd4l4yYqytwIDEcCkKwk=";
     };
 
     # Document `LVGL_ENV_SIMULATOR` in the built headers.


### PR DESCRIPTION
 - https://github.com/mobile-nixos/lvgui/compare/62100c7b30a4abfd311dc2d8c503f5f253734a70..64d6c793be0cd71e9c665762934063e9c037125a

The important change is the DRM panel orientation property being read, and the panel being rotated (with bad-but-working software rotation).

 - https://github.com/mobile-nixos/lvgui/pull/14

This change will affect only two in-tree devices, the `lenovo-wormdingler` and `lenovo-krane` devices. They have a panel orientation node on their panel, as the "native" orientation is portrait, but it is more likely to be used as landscape with the keyboard attachment.

This change was made mainly to target Steam Deck usage.