### PR TITLE
Fix/nix cflags compile

### DIFF
--- a/boot/script-loader/mruby-lvgui-native/lvgui.nix
+++ b/boot/script-loader/mruby-lvgui-native/lvgui.nix
@@ -9,8 +9,6 @@
 , withSimulator ? false
 }:
 
-let stdenv = pkgs.stdenvAdapters.keepDebugInfo pkgs.stdenv; in
-
 let
   inherit (lib) optional optionals optionalString;
   simulatorDeps = [
@@ -126,10 +124,6 @@ in
     ]
     ++ optionals withSimulator simulatorDeps
     ;
-
-    NIX_CFLAGS_COMPILE = [
-      "-DX_DISPLAY_MISSING"
-    ];
 
     makeFlags = [
       "PREFIX=${placeholder "out"}"

--- a/overlay/mkbootimg/default.nix
+++ b/overlay/mkbootimg/default.nix
@@ -24,8 +24,4 @@ stdenv.mkDerivation rec {
     cp -v unpackbootimg $out/bin/
     chmod +x $out/bin/*
   '';
-
-  NIX_CFLAGS_COMPILE = [
-    "-Wno-error=address-of-packed-member"
-  ];
 }


### PR DESCRIPTION
Closes #580.

It seems neither of those were needed anymore! Lucky!

Tested against current `nixos-unstable` and the currently pinned `pkgs.nix`. Running the VM and building an Android image.