### PR TITLE
boot/init: Add a quirk to wait on USB devices to settle

### DIFF
--- a/boot/init/tasks/splash.rb
+++ b/boot/init/tasks/splash.rb
@@ -15,7 +15,10 @@ class Tasks::Splash < SingletonTask
       args << "--skip-fadein"
     end
 
+    wait_for_input_devices
+
     begin
+      $logger.info "Starting splash..."
       @pid = System.spawn(LOADER, "/applets/boot-splash.mrb", *args)
     # Don't fail the boot if the splash fails
     rescue System::CommandError
@@ -61,5 +64,63 @@ class Tasks::Splash < SingletonTask
   # Use `quit` rather than kill!
   def kill()
     System.run("kill", "-9", @pid.to_s) if @pid
+  end
+
+  # Return an appropriate enough count for devices and busses.
+  # This is used to approximate if all devices on e.g. USB have
+  # finished showing up.
+  def count_device_nodes()
+    [
+      "/dev/input/event*",
+      "/sys/bus/usb/devices/*",
+    ]
+      .map { |pattern| Dir.glob(pattern).length }
+      .reduce(&:+)
+  end
+
+  def wait_for_input_devices()
+    unless Configuration["quirks"] && Configuration["quirks"]["wait_for_devices_delay"]
+      return
+    end
+
+    # Minimum amount of time spent waiting for devices, in seconds.
+    wait_for_devices_delay = Configuration["quirks"]["wait_for_devices_delay"]
+
+    # Number of times this is looking at the state every second.
+    # This is the "precision" at which it works, e.g. wait_for_devices_delay + (1.0/looks_per_second)
+    # is the approximative minimum amount of time this will wait for.
+    # > If we looked once per second, it would be 2+1 = 3 seconds
+    # > If we look five times per second, it will be 2+0.2 = 2.2 seconds
+    # > Not a lot saved, but about 25% faster.
+    looks_per_second = 5
+
+    # We're counting down from this amount, and will need to reset.
+    stable_counts_max = wait_for_devices_delay * looks_per_second
+
+    puts "\n"
+    $logger.info "Waiting for input devices to settle..."
+    puts "\n"
+
+    stable_counts = stable_counts_max
+    last_count = 0
+
+    # We'll be looping until the device node count is stable.
+    until stable_counts == 0
+      # Wait a bit
+      sleep(1.0/looks_per_second)
+
+      # Anything changed?
+      if last_count != count_device_nodes() then
+        # Reset the counter!
+        print "!"
+        last_count = count_device_nodes()
+        stable_counts = stable_counts_max
+      else
+        # Count down one
+        stable_counts -= 1
+        print "."
+      end
+    end
+    print "\n"
   end
 end

--- a/devices/uefi-x86_64/default.nix
+++ b/devices/uefi-x86_64/default.nix
@@ -19,6 +19,9 @@
 
   mobile.system.type = "uefi";
 
+  # It is safe enough to assume that for UEFI systems we want to wait for e.g. USB devices.
+  mobile.boot.stage-1.gui.waitForDevices.enable = lib.mkDefault true;
+
   mobile.boot.stage-1 = {
     kernel = {
       # Rely on upstream NixOS modules by default for generic UEFI systems.

--- a/modules/initrd-boot-gui.nix
+++ b/modules/initrd-boot-gui.nix
@@ -27,6 +27,28 @@ in
       default = true;
       description = "enable splash and boot selection GUI";
     };
+    waitForDevices = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to wait a bit for input devices before starting the user interface.
+
+          This is only necessary on "slow" busses where devices may arrive a tad later than expected.
+
+          Generally, only enable when a device needed to input the passphrase is connected via USB.
+        '';
+      };
+      delay = mkOption {
+        type = types.int;
+        default = 2;
+        description = ''
+          Minimum delay spent waiting for input devices to settle.
+
+          The boot GUI will wait until this many seconds elapsed without changes before starting.
+        '';
+      };
+    };
   };
 
   config = mkIf (config.mobile.boot.stage-1.enable) (mkMerge [
@@ -64,6 +86,11 @@ in
       mobile.boot.stage-1.environment = {
         XKB_CONFIG_ROOT = "/etc/X11/xkb";
         XLOCALEDIR = "/etc/X11/locale";
+      };
+      mobile.boot.stage-1.bootConfig = mkIf (cfg.waitForDevices.enable) {
+        quirks = {
+          wait_for_devices_delay = cfg.waitForDevices.delay;
+        };
       };
     })
   ]);


### PR DESCRIPTION
This is useful for devices with USB, where input devices may take a short while before showing up.

With this, external USB keyboard passphrase input is reliable in the limited testing I did.

This change shouldn't cause any regressions as it *adds* a new behaviour, which is opt-in.

Note that the 2 seconds wait alone is likely sufficient on all tested targets. Though let's make this much more robust by ensuring we wait until things are settled for at least 2 seconds.

* * *

Why is this a quirk? That's mainly because it's the wrong, but trivial, way to work around the issue.

The proper solution will be to have the splash program, and thus lvgui, handle hot-plugged devices. It *is* possible to do, but not trivial. It will require some rework of its libinput driver. I have something else in the long-term pipeline that may obsolete that problem anyway.

* * *

#### What was done

 - Tested on UEFI vm
    - With the feature enabled
    - With the feature disabled
 - Testing on Steam Deck
    - With the feature disabled: no USB keyboard
    - With the feature enabled: yes USB keyboard
 - Testing on TP300LA
    - With the feature enabled: yes USB keyboard (through hub, and directly attached)

#### What needs to be done

(On all of these, connect USB devices for testing...)

 - Testing on Starbook Mk VI