### PR TITLE
boot/init: Honor some cryptsetup arguments

### DIFF
--- a/boot/init/lib/mounting.rb
+++ b/boot/init/lib/mounting.rb
@@ -77,7 +77,7 @@ module Mounting
     auto_depend_mount_points(mount_points)
 
     (Configuration["luksDevices"] or []).each do |mapper, info|
-      Tasks::Luks.new(info["device"], mapper)
+      Tasks::Luks.new(info["device"], mapper, info)
     end
   end
 

--- a/boot/init/tasks/luks.rb
+++ b/boot/init/tasks/luks.rb
@@ -49,6 +49,11 @@ class Tasks::Luks < Task
     #    "yubikey",
     @info = info
     @cryptsetup_args = []
+    if @info["allowDiscards"]
+      @cryptsetup_args.concat [
+        "--allow-discards",
+      ]
+    end
     add_dependency(:Task, Tasks::UDev.instance)
     add_dependency(:Devices, source)
     add_dependency(:Mount, "/run")

--- a/boot/init/tasks/luks.rb
+++ b/boot/init/tasks/luks.rb
@@ -54,6 +54,13 @@ class Tasks::Luks < Task
         "--allow-discards",
       ]
     end
+    if @info["bypassWorkqueues"] then
+      @cryptsetup_args.concat [
+        "--perf-no_read_workqueue",
+        "--perf-no_write_workqueue",
+      ]
+    end
+
     add_dependency(:Task, Tasks::UDev.instance)
     add_dependency(:Devices, source)
     add_dependency(:Mount, "/run")

--- a/boot/init/tasks/luks.rb
+++ b/boot/init/tasks/luks.rb
@@ -48,6 +48,7 @@ class Tasks::Luks < Task
     #    "preOpenCommands",
     #    "yubikey",
     @info = info
+    @cryptsetup_args = []
     add_dependency(:Task, Tasks::UDev.instance)
     add_dependency(:Devices, source)
     add_dependency(:Mount, "/run")
@@ -69,8 +70,14 @@ class Tasks::Luks < Task
 
       begin
         Progress.exec_with_message("Checking...") do
+          args = [
+            "luksOpen",
+            source,
+            mapper,
+            *@cryptsetup_args,
+          ]
           # TODO: implement with process redirection rather than shelling out
-          System.run("echo #{passphrase.shellescape} | exec cryptsetup luksOpen #{source.shellescape} #{mapper.shellescape}")
+          System.run("echo #{passphrase.shellescape} | exec cryptsetup #{args.shelljoin}")
         end
         Progress.update({label: nil})
 

--- a/boot/init/tasks/luks.rb
+++ b/boot/init/tasks/luks.rb
@@ -23,10 +23,31 @@ class Tasks::Luks < Task
     @registry
   end
 
-  def initialize(source, mapper)
+  def initialize(source, mapper, info)
     @source = source
     @mapper = mapper
 
+    # Current known and used keys
+    #    "device", # First param, source
+    #    "allowDiscards",
+    #    "bypassWorkqueues",
+    #
+    # Current known and unused (by design) keys
+    #    "fallbackToPassword", # Nothing else than password
+    #
+    # Currently known unsupported keys (contributions welcome)
+    #    "crypttabExtraOpts",
+    #    "fido2",
+    #    "header",
+    #    "gpgCard",
+    #    "keyFile",
+    #    "keyFileOffset",
+    #    "keyFileSize",
+    #    "postOpenCommands",
+    #    "preLVM",
+    #    "preOpenCommands",
+    #    "yubikey",
+    @info = info
     add_dependency(:Task, Tasks::UDev.instance)
     add_dependency(:Devices, source)
     add_dependency(:Mount, "/run")


### PR DESCRIPTION
Why only some? Because they're the ones I am confident in implementing.

Of those, many require hardware or a setup different enough that I'm not setup to test with:

 - https://github.com/NixOS/mobile-nixos/blob/bf43312242f94eaf6356b58edfd837f15bef4bc8/boot/init/tasks/luks.rb#L39-L49

The only few I *could* implement, I don't really want to support at this time because they imply running *shell commands*, which may or may not work as expected compared to the upstream stage-1 sh script.

* * *

#### What was done

 - Tested on `lenovo-wormdingler`, still boots... unsure how to correctly test TRIM.
 - Actually boot with `bypassWorkqueues` just in case.

Quick visual check:

```
~ $ sudo cryptsetup status LUKS-FRANKGRIMES-ROOTFS 
[sudo] password for samuel: 
/dev/mapper/LUKS-FRANKGRIMES-ROOTFS is active and is in use.
...
  flags:   discards no_read_workqueue no_write_workqueue
```

I guess it's all working?

#### What is yet to be done


* * *

cc @wentam for advice about correct testing.