### PR TITLE
treewide: Add lib.mdDoc prefix to option descriptions

### DIFF
--- a/modules/adb.nix
+++ b/modules/adb.nix
@@ -7,7 +7,7 @@ with lib;
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = ''
+      description = lib.mdDoc ''
         Enables adbd on the device.
       '';
     };

--- a/modules/beautification.nix
+++ b/modules/beautification.nix
@@ -16,14 +16,14 @@ in
         silentBoot = mkOption {
           type = types.bool;
           default = false;
-          description = ''
+          description = lib.mdDoc ''
             When enabled, fbcon consoles are disabled.
           '';
         };
         splash = mkOption {
           type = types.bool;
           default = false;
-          description = ''
+          description = lib.mdDoc ''
             When enabled, plymouth is configured with nice defaults.
 
             Note that this requires an update to the kernel command-line

--- a/modules/boot-control.nix
+++ b/modules/boot-control.nix
@@ -13,7 +13,7 @@ in
       enable = mkOption {
         type = types.bool;
         default = false;
-        description = ''
+        description = lib.mdDoc ''
           Enables usage of boot-control to mark A/B boot as successful.
         '';
       };

--- a/modules/boot-initrd.nix
+++ b/modules/boot-initrd.nix
@@ -6,7 +6,7 @@ with lib;
   options.mobile.boot = {
     stage-1.extraUtils = mkOption {
       type = types.listOf (types.either types.attrs types.package);
-      description = ''
+      description = lib.mdDoc ''
         Additional packages to be included inside stage-1.
 
         Do note that *special manipulation* happens and may
@@ -22,7 +22,7 @@ with lib;
     stage-1.contents = mkOption {
       type = types.listOf types.attrs;
       default = [];
-      description = ''
+      description = lib.mdDoc ''
         Additional files for the initrd.
 
         See `makeInitrd` for use of `contents`.

--- a/modules/bootloader.nix
+++ b/modules/bootloader.nix
@@ -14,7 +14,7 @@ in
         enable = mkOption {
           type = types.bool;
           default = config.mobile.enable;
-          description = ''
+          description = lib.mdDoc ''
             Whether the bootloader **configuration** for Mobile NixOS
             is enabled.
 

--- a/modules/devices-metadata.nix
+++ b/modules/devices-metadata.nix
@@ -13,7 +13,7 @@ in
     mobile.outputs.device-metadata = mkOption {
       type = types.package;
       internal = true;
-      description = ''
+      description = lib.mdDoc ''
         The device-metadata output is used internally by the documentation
         generation to generate the per-device pages.
 

--- a/modules/generated-filesystems.nix
+++ b/modules/generated-filesystems.nix
@@ -16,26 +16,26 @@ let
       options = {
         type = lib.mkOption {
           type = types.enum [ "ext4" "btrfs" ];
-          description = ''
+          description = lib.mdDoc ''
             Type of the generated filesystem.
           '';
         };
         label = lib.mkOption {
           type = types.str;
-          description = ''
+          description = lib.mdDoc ''
             The label used by the generated rootfs, when generating a rootfs, and
             the filesystem label a Mobile NixOS system will look for by default.
           '';
         };
         id = lib.mkOption {
           type = types.str;
-          description = ''
+          description = lib.mdDoc ''
             The UUID used by the generated rootfs, when generating a rootfs.
           '';
         };
         populateCommands = lib.mkOption {
           type = types.lines;
-          description = ''
+          description = lib.mdDoc ''
             Commands used to fill the filesystem.
 
             `$PWD` is the root of the filesystem.
@@ -44,21 +44,21 @@ let
         postProcess = lib.mkOption {
           type = types.lines;
           internal = true;
-          description = ''
+          description = lib.mdDoc ''
             Commands used to manipulate the filesystem after it has been
             created.
           '';
         };
         extraPadding = lib.mkOption {
           type = types.int;
-          description = ''
+          description = lib.mdDoc ''
             Extra padding to add to the filesystem image.
           '';
         };
         zstd = lib.mkOption {
           internal = true;
           type = types.bool;
-          description = ''
+          description = lib.mdDoc ''
             Whether to compress this artifact; used to work around size
             limitations in CI situations.
           '';
@@ -67,7 +67,7 @@ let
           internal = true;
           type = types.nullOr types.package;
           default = null;
-          description = ''
+          description = lib.mdDoc ''
             Use an output directly rather than creating it from the options.
           '';
         };
@@ -81,21 +81,21 @@ in
   options = {
     mobile.generatedFilesystems = lib.mkOption {
       type = types.attrsOf (types.submodule filesystemSubmodule);
-      description = ''
+      description = lib.mdDoc ''
         Filesystem definitions that will be created at build.
       '';
     };
     mobile.outputs.generatedFilesystems = lib.mkOption {
       type = with types; attrsOf package;
       internal = true;
-      description = ''
+      description = lib.mdDoc ''
         All generated filesystems from the build.
       '';
     };
     mobile.outputs.rootfs = lib.mkOption {
       type = types.package;
       visible = false;
-      description = ''
+      description = lib.mdDoc ''
         The rootfs image for the build.
       '';
     };

--- a/modules/hardware-allwinner.nix
+++ b/modules/hardware-allwinner.nix
@@ -10,12 +10,12 @@ in
     hardware.socs.allwinner-a64.enable = mkOption {
       type = types.bool;
       default = false;
-      description = "enable when SOC is Allwinner A64";
+      description = lib.mdDoc "enable when SOC is Allwinner A64";
     };
     hardware.socs.allwinner-r18.enable = mkOption {
       type = types.bool;
       default = false;
-      description = "enable when SOC is Allwinner-R18";
+      description = lib.mdDoc "enable when SOC is Allwinner-R18";
     };
   };
 

--- a/modules/hardware-exynos.nix
+++ b/modules/hardware-exynos.nix
@@ -9,7 +9,7 @@ in
     hardware.socs.exynos-7880.enable = mkOption {
       type = types.bool;
       default = false;
-      description = "enable when SOC is Exynos 7880";
+      description = lib.mdDoc "enable when SOC is Exynos 7880";
     };
   };
 

--- a/modules/hardware-generic.nix
+++ b/modules/hardware-generic.nix
@@ -10,19 +10,19 @@ in
     generic-x86_64.enable = mkOption {
       type = types.bool;
       default = false;
-      description = "Enable when system is a generic x86_64";
+      description = lib.mdDoc "Enable when system is a generic x86_64";
       internal = true;
     };
     generic-aarch64.enable = mkOption {
       type = types.bool;
       default = false;
-      description = "Enable when system is a generic AArch64";
+      description = lib.mdDoc "Enable when system is a generic AArch64";
       internal = true;
     };
     generic-armv7l.enable = mkOption {
       type = types.bool;
       default = false;
-      description = "Enable when system is a generic armv7l";
+      description = lib.mdDoc "Enable when system is a generic armv7l";
       internal = true;
     };
   };

--- a/modules/hardware-mediatek.nix
+++ b/modules/hardware-mediatek.nix
@@ -9,22 +9,22 @@ in
     hardware.socs.mediatek-mt6755.enable = mkOption {
       type = types.bool;
       default = false;
-      description = "enable when SOC is Mediatek MT6755 (Helio P10)";
+      description = lib.mdDoc "enable when SOC is Mediatek MT6755 (Helio P10)";
     };
     hardware.socs.mediatek-mt6785.enable = mkOption {
       type = types.bool;
       default = false;
-      description = "enable when SOC is Mediatek MT6785 (Helio G90)";
+      description = lib.mdDoc "enable when SOC is Mediatek MT6785 (Helio G90)";
     };
     hardware.socs.mediatek-mt8127.enable = mkOption {
       type = types.bool;
       default = false;
-      description = "enable when SOC is Mediatek MT8127";
+      description = lib.mdDoc "enable when SOC is Mediatek MT8127";
     };
     hardware.socs.mediatek-mt8183.enable = mkOption {
       type = types.bool;
       default = false;
-      description = "enable when SOC is Mediatek MT8183";
+      description = lib.mdDoc "enable when SOC is Mediatek MT8183";
     };
   };
 

--- a/modules/hardware-qualcomm.nix
+++ b/modules/hardware-qualcomm.nix
@@ -10,52 +10,52 @@ in
     hardware.socs.qualcomm-apq8064-1aa.enable = mkOption {
       type = types.bool;
       default = false;
-      description = "enable when SOC is APQ8064–1AA";
+      description = lib.mdDoc "enable when SOC is APQ8064–1AA";
     };
     hardware.socs.qualcomm-msm8940.enable = mkOption {
       type = types.bool;
       default = false;
-      description = "enable when SOC is msm8940";
+      description = lib.mdDoc "enable when SOC is msm8940";
     };
     hardware.socs.qualcomm-msm8953.enable = mkOption {
       type = types.bool;
       default = false;
-      description = "enable when SOC is msm8953";
+      description = lib.mdDoc "enable when SOC is msm8953";
     };
     hardware.socs.qualcomm-msm8939.enable = mkOption {
       type = types.bool;
       default = false;
-      description = "enable when SOC is msm8939";
+      description = lib.mdDoc "enable when SOC is msm8939";
     };
     hardware.socs.qualcomm-msm8996.enable = mkOption {
       type = types.bool;
       default = false;
-      description = "enable when SOC is msm8996";
+      description = lib.mdDoc "enable when SOC is msm8996";
     };
     hardware.socs.qualcomm-msm8998.enable = mkOption {
       type = types.bool;
       default = false;
-      description = "enable when SOC is msm8998";
+      description = lib.mdDoc "enable when SOC is msm8998";
     };
     hardware.socs.qualcomm-sc7180.enable = mkOption {
       type = types.bool;
       default = false;
-      description = "enable when SOC is 7c (SC7180)";
+      description = lib.mdDoc "enable when SOC is 7c (SC7180)";
     };
     hardware.socs.qualcomm-sdm660.enable = mkOption {
       type = types.bool;
       default = false;
-      description = "enable when SOC is SDM660";
+      description = lib.mdDoc "enable when SOC is SDM660";
     };
     hardware.socs.qualcomm-sdm845.enable = mkOption {
       type = types.bool;
       default = false;
-      description = "enable when SOC is SDM845";
+      description = lib.mdDoc "enable when SOC is SDM845";
     };
     hardware.socs.qualcomm-sm6125.enable = mkOption {
       type = types.bool;
       default = false;
-      description = "enable when SOC is SM6125";
+      description = lib.mdDoc "enable when SOC is SM6125";
     };
   };
 

--- a/modules/hardware-ram.nix
+++ b/modules/hardware-ram.nix
@@ -5,7 +5,7 @@ with lib;
 {
   options.mobile.hardware.ram = mkOption {
     type = types.int;
-    description = ''
+    description = lib.mdDoc ''
       Total RAM available (in MB, 1GB = 1024MB).
 
       This may be used to turn on or off features depending on the device's capabilities.

--- a/modules/hardware-rockchip.nix
+++ b/modules/hardware-rockchip.nix
@@ -10,7 +10,7 @@ in
     hardware.socs.rockchip-op1.enable = mkOption {
       type = types.bool;
       default = false;
-      description = "enable when SOC is RK3399-OP1";
+      description = lib.mdDoc "enable when SOC is RK3399-OP1";
     };
   };
 

--- a/modules/hardware-screen.nix
+++ b/modules/hardware-screen.nix
@@ -9,13 +9,13 @@ in
   options.mobile.hardware.screen = {
     width = mkOption {
       type = types.int;
-      description = ''
+      description = lib.mdDoc ''
         Width of the device's display.
       '';
     };
     height = mkOption {
       type = types.int;
-      description = ''
+      description = lib.mdDoc ''
         Height of the device's display.
       '';
     };

--- a/modules/hardware-soc.nix
+++ b/modules/hardware-soc.nix
@@ -9,7 +9,7 @@ in
     soc = mkOption {
       # This is used to enable a specific SOC on a device, while giving it a name.
       type = types.str;
-      description = ''
+      description = lib.mdDoc ''
         Give the SOC name for the device.
       '';
     };

--- a/modules/hardware.nix
+++ b/modules/hardware.nix
@@ -12,7 +12,7 @@ in
           type = types.listOf types.str;
           internal = true;
           default = [];
-          description = ''
+          description = lib.mdDoc ''
             Identifiers known by the boot menu to provide reboot options
             that are hardware-dependent. E.g. reboot to bootloader.
           '';

--- a/modules/initrd-boot-gui.nix
+++ b/modules/initrd-boot-gui.nix
@@ -25,7 +25,9 @@ in
     enable = mkOption {
       type = types.bool;
       default = true;
-      description = "enable splash and boot selection GUI";
+      description = lib.mdDoc ''
+        enable splash and boot selection GUI
+      '';
     };
     waitForDevices = {
       enable = mkOption {

--- a/modules/initrd-boot-gui.nix
+++ b/modules/initrd-boot-gui.nix
@@ -31,7 +31,7 @@ in
       enable = mkOption {
         type = types.bool;
         default = false;
-        description = ''
+        description = lib.mdDoc ''
           Whether to wait a bit for input devices before starting the user interface.
 
           This is only necessary on "slow" busses where devices may arrive a tad later than expected.
@@ -42,7 +42,7 @@ in
       delay = mkOption {
         type = types.int;
         default = 2;
-        description = ''
+        description = lib.mdDoc ''
           Minimum delay spent waiting for input devices to settle.
 
           The boot GUI will wait until this many seconds elapsed without changes before starting.

--- a/modules/initrd-fail.nix
+++ b/modules/initrd-fail.nix
@@ -11,14 +11,14 @@ in
       reboot = mkOption {
         type = types.bool;
         default = true;
-        description = ''
+        description = lib.mdDoc ''
           Reboots the device after a delay on failure.
         '';
       };
       delay = mkOption {
         type = types.int;
         default = 10;
-        description = ''
+        description = lib.mdDoc ''
           Duration (in seconds) before a reboot on failure.
         '';
       };

--- a/modules/initrd-fbterm.nix
+++ b/modules/initrd-fbterm.nix
@@ -19,14 +19,14 @@ in
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = ''
+      description = lib.mdDoc ''
         Enables fbterm.
       '';
     };
     fb = mkOption {
       type = types.str;
       default = "/dev/fb1";
-      description = ''
+      description = lib.mdDoc ''
         framebuffer to run fbterm on.
       '';
     };
@@ -34,7 +34,7 @@ in
       type = types.str;
       internal = true;
       default = "2";
-      description = ''
+      description = lib.mdDoc ''
         The tty to run on. This will be switched for you.
 
         This is used to side-step an issue where X11 will not start

--- a/modules/initrd-firmware.nix
+++ b/modules/initrd-firmware.nix
@@ -9,7 +9,7 @@ in
     mobile.boot.stage-1.firmware = lib.mkOption {
       type = types.listOf types.package;
       default = [];
-      description = ''
+      description = lib.mdDoc ''
         List of packages containing firmware files to be included in the
         stage-1 for the device.
       '';

--- a/modules/initrd-kernel.nix
+++ b/modules/initrd-kernel.nix
@@ -32,7 +32,7 @@ in
       type = types.bool;
       default = !config.mobile.enable;
       defaultText = literalExpression "!config.mobile.enable";
-      description = ''
+      description = lib.mdDoc ''
         Whether Mobile NixOS relies on upstream NixOS settings for kernel config.
 
         Enable this when using the NixOS machinery for kernels.
@@ -41,7 +41,7 @@ in
     modular = mkOption {
       type = types.bool;
       default = false;
-      description = ''
+      description = lib.mdDoc ''
         Whether the kernel is built with modules or not.
         This will enable modules closure generation and listing modules
         to bundle and load.
@@ -51,7 +51,7 @@ in
       type = types.listOf types.str;
       default = [
       ];
-      description = ''
+      description = lib.mdDoc ''
         Module names to add to the closure.
         They will be modprobed.
       '';
@@ -60,7 +60,7 @@ in
       type = types.listOf types.str;
       default = [
       ];
-      description = ''
+      description = lib.mdDoc ''
         Module names to add to the closure.
         They will not be modprobed.
       '';
@@ -68,7 +68,7 @@ in
     allowMissingModules = mkOption {
       type = types.bool;
       default = true;
-      description = ''
+      description = lib.mdDoc ''
         Chooses whether the modules closure build fails if a module is missing.
       '';
     };
@@ -77,7 +77,7 @@ in
     package = mkOption {
       type = types.nullOr types.package;
       default = null;
-      description = ''
+      description = lib.mdDoc ''
         Kernel to be used by the system-type to boot into the Mobile NixOS
         stage-1.
 

--- a/modules/initrd-logs.nix
+++ b/modules/initrd-logs.nix
@@ -10,14 +10,14 @@ in
     enable = mkOption {
       type = types.bool;
       default = config.mobile.boot.stage-1.enable;
-      description = ''
+      description = lib.mdDoc ''
         Enables bootlogd logging multiplexer.
       '';
     };
     kmsg = mkOption {
       type = types.bool;
       default = false;
-      description = ''
+      description = lib.mdDoc ''
         Enables logging to /dev/kmsg.
 
         Note that this may render switching to stage-2 inoperable.

--- a/modules/initrd-network.nix
+++ b/modules/initrd-network.nix
@@ -12,21 +12,21 @@ in
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = ''
+      description = lib.mdDoc ''
         Enables networking.
       '';
     };
     IP = mkOption {
       type = types.str;
       default = "172.16.42.1";
-      description = ''
+      description = lib.mdDoc ''
         IP address for the USB networking gadget.
       '';
     };
     hostIP = mkOption {
       type = types.str;
       default = "172.16.42.2";
-      description = ''
+      description = lib.mdDoc ''
         IP address for the USB networking gadget.
       '';
     };

--- a/modules/initrd-shell.nix
+++ b/modules/initrd-shell.nix
@@ -9,7 +9,7 @@ in
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = ''
+      description = lib.mdDoc ''
         Enables a shell before switching root.
 
         This shell (as currently configured) will not allow switching root.
@@ -18,7 +18,7 @@ in
     console = mkOption {
       type = types.str;
       default = "console";
-      description = ''
+      description = lib.mdDoc ''
         Selects the /dev/___ device to use.
 
         Use `ttyS0` for serial, `tty1` for first VT or keep the default to `console`
@@ -29,7 +29,7 @@ in
     shellOnFail = mkOption {
       type = types.bool;
       default = false;
-      description = ''
+      description = lib.mdDoc ''
         Enables a shell on failures.
       '';
     };

--- a/modules/initrd-ssh.nix
+++ b/modules/initrd-ssh.nix
@@ -14,7 +14,7 @@ in
     enable = mkOption {
       type = types.bool;
       default = false;
-      description = ''
+      description = lib.mdDoc ''
         Enables ssh during stage-1.
 
         **CURRENT CONFIGURATION ALSO OPENS ACCESS TO ALL WITHOUT A PASSWORD NOR SSH KEY.**

--- a/modules/initrd-usb.nix
+++ b/modules/initrd-usb.nix
@@ -14,7 +14,7 @@ in
     enable = mkOption {
       type = types.bool;
       default = true;
-      description = ''
+      description = lib.mdDoc ''
         Enables USB features.
         For now, only Android-based devices are supported.
       '';
@@ -22,7 +22,7 @@ in
     features = mkOption {
       type = types.listOf types.str;
       default = [];
-      description = ''
+      description = lib.mdDoc ''
         `android_usb` features to enable.
       '';
     };
@@ -30,26 +30,26 @@ in
   options.mobile.usb = {
     idVendor = mkOption {
       type = types.str;
-      description = ''
+      description = lib.mdDoc ''
         USB vendor ID for the USB gadget.
       '';
     };
     idProduct = mkOption {
       type = types.str;
-      description = ''
+      description = lib.mdDoc ''
         USB product ID for the USB gadget.
       '';
     };
     mode = mkOption {
       type = types.nullOr (types.enum [ "android_usb" "gadgetfs" ]);
       default = null;
-      description = ''
+      description = lib.mdDoc ''
         The USB gadget implementation the device uses.
       '';
     };
     gadgetfs.functions = mkOption {
       type = types.attrs;
-      description = ''
+      description = lib.mdDoc ''
         Mapping of logical gadgetfs functions to their implementation names.
       '';
     };

--- a/modules/initrd.nix
+++ b/modules/initrd.nix
@@ -233,7 +233,7 @@ in
       mobile.boot.stage-1.enable = mkOption {
         type = types.bool;
         default = config.mobile.enable;
-        description = ''
+        description = lib.mdDoc ''
           Whether to use the Mobile NixOS stage-1 implementation or not.
 
           This will forcible override the NixOS stage-1 when enabled.
@@ -243,7 +243,7 @@ in
       mobile.boot.stage-1.stage = mkOption {
         type = types.enum [ 0 1 ];
         default = 1;
-        description = ''
+        description = lib.mdDoc ''
           Used with a "specialization" of the config to build the "stage-0"
           init which can kexec into another kernel+initrd found on the system.
 
@@ -254,7 +254,7 @@ in
       mobile.boot.stage-1.compression = mkOption {
         type = types.enum [ "gzip" "xz" ];
         default = "gzip";
-        description = ''
+        description = lib.mdDoc ''
           The compression method for the stage-1 (initrd).
 
           This may be set as a default by some devices requiring specific
@@ -274,14 +274,14 @@ in
         type = JSONValue;
         default = {};
         internal = true;
-        description = ''
+        description = lib.mdDoc ''
           The things being put in the JSON configuration file in stage-1.
         '';
       };
       mobile.boot.stage-1.crashToBootloader = mkOption {
         type = types.bool;
         default = false;
-        description = ''
+        description = lib.mdDoc ''
           When the stage-1 bootloader crashes, prefer rebooting directly to
           bootloader rather than panic by killing init.
 
@@ -294,7 +294,7 @@ in
       mobile.boot.stage-1.earlyInitScripts = mkOption {
         type = types.lines;
         default = "";
-        description = ''
+        description = lib.mdDoc ''
           Additional shell commands to run before the actual init.
 
           Prefer writing a task. This should be used mainly to redirect logging,
@@ -305,7 +305,7 @@ in
       };
       mobile.boot.stage-1.environment = mkOption {
         type = types.attrsOf types.str;
-        description = ''
+        description = lib.mdDoc ''
           Environment variables present for the whole stage-1.
           Keep this as minimal as needed.
         '';
@@ -314,7 +314,7 @@ in
       mobile.boot.stage-1.extraUdevRules = mkOption {
         type = types.lines;
         default = "";
-        description = ''
+        description = lib.mdDoc ''
           Additional udev rules for stage-1.
         '';
         internal = true;
@@ -324,7 +324,7 @@ in
         extraUtils = mkOption {
           type = types.package;
           internal = true;
-          description = ''
+          description = lib.mdDoc ''
             Stripped packages for use in stage-1.
 
             See `mobile.boot.stage-1.extraUtils`.
@@ -333,14 +333,14 @@ in
         initrd = mkOption {
           type = types.str;
           internal = true;
-          description = ''
+          description = lib.mdDoc ''
             Path to the initrd, likely compressed, for the system.
           '';
         };
         initrd-meta = mkOption {
           type = types.package;
           internal = true;
-          description = ''
+          description = lib.mdDoc ''
             Additional metadata about the initrd; used for debugging.
           '';
         };

--- a/modules/initrd.nix
+++ b/modules/initrd.nix
@@ -265,10 +265,10 @@ in
         type = with types; listOf (either package path);
         default = [];
         internal = true;
-        description = "
+        description = lib.mdDoc ''
           Add tasks to the boot/init program.
           The build system for boot/init will `find -iname '*.rb'` the given paths.
-        ";
+        '';
       };
       mobile.boot.stage-1.bootConfig = mkOption {
         type = JSONValue;

--- a/modules/kernel-config.nix
+++ b/modules/kernel-config.nix
@@ -12,7 +12,7 @@ in
       kernel = {
         structuredConfig = mkOption {
           type = with types; listOf (functionTo attrs);
-          description = ''
+          description = lib.mdDoc ''
             Functions returning kernel structured config.
 
             The functions take one argument, an attrset of helpers.

--- a/modules/mobile-device.nix
+++ b/modules/mobile-device.nix
@@ -15,17 +15,17 @@ in
   options.mobile.device = {
     name = mkOption {
       type = types.str;
-      description = "The device's codename. Must match the device folder.";
+      description = lib.mdDoc "The device's codename. Must match the device folder.";
     };
 
     identity = {
       name = mkOption {
         type = types.str;
-        description = "The device's name as advertised by the manufacturer.";
+        description = lib.mdDoc "The device's name as advertised by the manufacturer.";
       };
       manufacturer = mkOption {
         type = types.str;
-        description = "The device's manufacturer name.";
+        description = lib.mdDoc "The device's manufacturer name.";
       };
     };
 

--- a/modules/mobile-device.nix
+++ b/modules/mobile-device.nix
@@ -32,7 +32,7 @@ in
     firmware = mkOption {
       type = types.nullOr types.package;
       default = null;
-      description = ''
+      description = lib.mdDoc ''
         Informal option that the end-user can use to get their device's firmware package.
 
         The firmware will be added to `hardware.firmware` automatically for most devices.
@@ -44,7 +44,7 @@ in
 
     enableFirmware = mkOption {
       type = types.bool;
-      description = ''
+      description = lib.mdDoc ''
         Enable automatically adding the firmware to the system configuration.
 
         This may be disabled by some devices that require manual operations
@@ -57,7 +57,7 @@ in
     supportLevel = mkOption {
       type = types.enum [ "supported" "best-effort" "vendor" "unsupported" "abandoned" ];
       default = "unsupported";
-      description = ''
+      description = lib.mdDoc ''
         Support level for the device.
       '';
     };

--- a/modules/mobile.nix
+++ b/modules/mobile.nix
@@ -12,7 +12,7 @@ in
       enable = mkOption {
         type = types.bool;
         default = true;
-        description = ''
+        description = lib.mdDoc ''
           When this setting is set to false, including Mobile
           NixOS in your NixOS configuration should be a no-op.
         '';
@@ -20,7 +20,7 @@ in
       configurationName = mkOption {
         internal = true;
         default = "mobile-nixos";
-        description = ''
+        description = lib.mdDoc ''
           Used for some identifiers like the image name.
 
           This is used in example systems to change the name of the produced

--- a/modules/outputs.nix
+++ b/modules/outputs.nix
@@ -10,7 +10,7 @@ in
     mobile = {
       outputs = {
         default = mkOption {
-          description = ''
+          description = lib.mdDoc ''
             Default most likely desired output for this Mobile NixOS build.
 
             The default depends on the system type in use.
@@ -19,7 +19,7 @@ in
           internal = true;
         };
         toplevel = mkOption {
-          description = ''
+          description = lib.mdDoc ''
             First-class attribute to refer to `config.system.build.toplevel`.
           '';
           internal = true;

--- a/modules/quirks/audio.nix
+++ b/modules/quirks/audio.nix
@@ -9,7 +9,7 @@ in
     alsa-ucm-meld = lib.mkOption {
       type = lib.types.bool;
       default = false;
-      description = ''
+      description = lib.mdDoc ''
         Combines the derivation output path share/alsa/ucm2/ with
         pkgs.alsa-ucm-conf and points ALSA to the result.
       '';

--- a/modules/quirks/exynos/exynos-fb-notify.nix
+++ b/modules/quirks/exynos/exynos-fb-notify.nix
@@ -9,7 +9,7 @@ in
     quirks.exynos.fb-notify.enable = mkOption {
       type = types.bool;
       default = false;
-      description = ''
+      description = lib.mdDoc ''
         Enable this on a device which requires the framebuffer
         to be notified for some components to work right.
 

--- a/modules/quirks/framebuffer.nix
+++ b/modules/quirks/framebuffer.nix
@@ -10,7 +10,7 @@ in
     quirks.fb-refresher.enable = mkOption {
       type = types.bool;
       default = false;
-      description = ''
+      description = lib.mdDoc ''
         Enables use of `msm-fb-refresher`.
         Use sparingly, it is better to patch software to flip buffers instead.
 
@@ -21,7 +21,7 @@ in
     quirks.fb-refresher.stage-1.enable = mkOption {
       type = types.bool;
       default = false;
-      description = ''
+      description = lib.mdDoc ''
         Add `msm-fb-refresher` to stage-1.
 
         It should not be needed for the usual assortment of Mobile NixOS tools.

--- a/modules/quirks/qualcomm/msm-dwc3.nix
+++ b/modules/quirks/qualcomm/msm-dwc3.nix
@@ -9,7 +9,7 @@ in
     quirks.qualcomm.dwc3-otg_switch.enable = mkOption {
       type = types.bool;
       default = false;
-      description = ''
+      description = lib.mdDoc ''
         Enable this on a device which requires otg_switch to be
         configured for OTG to work.
       '';

--- a/modules/quirks/qualcomm/msm-fb-notify.nix
+++ b/modules/quirks/qualcomm/msm-fb-notify.nix
@@ -9,7 +9,7 @@ in
     quirks.qualcomm.fb-notify.enable = mkOption {
       type = types.bool;
       default = false;
-      description = ''
+      description = lib.mdDoc ''
         Enable this on a device which requires the framebuffer
         to be notified for some components to work right.
 

--- a/modules/quirks/qualcomm/sdm845-modem.nix
+++ b/modules/quirks/qualcomm/sdm845-modem.nix
@@ -33,14 +33,14 @@ in
     quirks.qualcomm.sc7180-modem.enable = mkOption {
       type = types.bool;
       default = false;
-      description = ''
+      description = lib.mdDoc ''
         Enable this on a mainline-based SC7180 device for modem/Wi-Fi support
       '';
     };
     quirks.qualcomm.sdm845-modem.enable = mkOption {
       type = types.bool;
       default = false;
-      description = ''
+      description = lib.mdDoc ''
         Enable this on a mainline-based SDM845 device for modem support
       '';
     };

--- a/modules/quirks/qualcomm/wcnss-wlan.nix
+++ b/modules/quirks/qualcomm/wcnss-wlan.nix
@@ -9,7 +9,7 @@ in
     quirks.qualcomm.wcnss-wlan.enable = mkOption {
       type = types.bool;
       default = false;
-      description = ''
+      description = lib.mdDoc ''
         Enable this on a device which uses wcnss wlan.
       '';
     };

--- a/modules/quirks/wifi.nix
+++ b/modules/quirks/wifi.nix
@@ -9,7 +9,7 @@ in
     disableMacAddressRandomization = mkOption {
       type = types.bool;
       default = false;
-      description = ''
+      description = lib.mdDoc ''
         Disables MAC address randomization.
 
         This may be required by some hardware or drivers, or combination.

--- a/modules/recovery.nix
+++ b/modules/recovery.nix
@@ -15,7 +15,7 @@ in
       outputs = {
         recovery = mkOption {
           internal = true;
-          description = ''
+          description = lib.mdDoc ''
             The configuration, re-evaluated with assumptions for recovery use.
           '';
         };

--- a/modules/rootfs.nix
+++ b/modules/rootfs.nix
@@ -16,7 +16,7 @@ in
         enableDefaultConfiguration = mkOption {
           type = types.bool;
           default = config.mobile.enable;
-          description = ''
+          description = lib.mdDoc ''
             Whether some of the rootfs configuration is managed by Mobile NixOS or not.
           '';
         };

--- a/modules/shared-rootfs.nix
+++ b/modules/shared-rootfs.nix
@@ -10,7 +10,7 @@ in
       internal = true;
       type = types.bool;
       default = false;
-      description = ''
+      description = lib.mdDoc ''
         Enable when building a generic rootfs that does not include a kernel image.
 
         This makes sturdier rootfs that work on different devices.

--- a/modules/stage-0.nix
+++ b/modules/stage-0.nix
@@ -25,7 +25,7 @@ in
     mobile.quirks.supportsStage-0 = mkOption {
       type = types.bool;
       default = false;
-      description = ''
+      description = lib.mdDoc ''
         Set to true when a device, and its kernel, can use kexec.
 
         This will enable booting into the generation's kernel.
@@ -36,7 +36,7 @@ in
       nodes = mkOption {
         type = types.listOf types.str;
         default = [];
-        description = ''
+        description = lib.mdDoc ''
           FDT nodes to forward to the kexec'd system.
         '';
       };
@@ -46,7 +46,7 @@ in
         example = [
           ["/soc/mmc@1c10000/wifi@1" "local-mac-address"]
         ];
-        description = ''
+        description = lib.mdDoc ''
           Pair of [node prop] to forward to the kexec'd system.
 
           Only the prop described on the exact node will be forwarded.
@@ -58,7 +58,7 @@ in
       outputs = {
         stage-0 = mkOption {
           internal = true;
-          description = ''
+          description = lib.mdDoc ''
             The configuration, re-evaluated with assumptions for stage-0 use.
           '';
         };

--- a/modules/system-target.nix
+++ b/modules/system-target.nix
@@ -19,7 +19,7 @@ in
         "armv7l-linux"
         "x86_64-linux"
       ];
-      description = ''
+      description = lib.mdDoc ''
         Defines the kind of target architecture system the device is.
 
         This will automagically setup cross-compilation where possible.

--- a/modules/system-types.nix
+++ b/modules/system-types.nix
@@ -21,13 +21,13 @@ in
     system.types = mkOption {
       type = types.listOf types.str;
       internal = true;
-      description = ''
+      description = lib.mdDoc ''
         Registry of system types.
       '';
     };
     system.type = mkOption {
       type = types.enum known_system_types;
-      description = ''
+      description = lib.mdDoc ''
         Defines the kind of system the device is.
 
         The different kind of system types will define the outputs

--- a/modules/system-types/android/default.nix
+++ b/modules/system-types/android/default.nix
@@ -169,21 +169,21 @@ in
         android = {
           android-bootimg = lib.mkOption {
             type = types.package;
-            description = ''
+            description = lib.mdDoc ''
               `boot.img` type image for Android-based systems.
             '';
             visible = false;
           };
           android-recovery = lib.mkOption {
             type = types.package;
-            description = ''
+            description = lib.mdDoc ''
               `recovery.img` type image for Android-based systems.
             '';
             visible = false;
           };
           android-fastboot-images = lib.mkOption {
             type = types.package;
-            description = ''
+            description = lib.mdDoc ''
               Flashing scripts and images for use with fastboot or odin.
             '';
             visible = false;

--- a/modules/system-types/android/default.nix
+++ b/modules/system-types/android/default.nix
@@ -83,21 +83,21 @@ in
     mobile.system.android = {
       ab_partitions = lib.mkOption {
         type = types.bool;
-        description = "Configures whether the device uses an A/B partition scheme";
+        description = lib.mdDoc "Configures whether the device uses an A/B partition scheme";
         default = false;
         internal = true;
       };
 
       boot_as_recovery = lib.mkOption {
         type = types.bool;
-        description = "Configures whether the device uses 'boot as recovery'";
+        description = lib.mdDoc "Configures whether the device uses 'boot as recovery'";
         default = config.mobile.system.android.ab_partitions;
         internal = true;
       };
 
       device_name = lib.mkOption {
         type = types.nullOr types.str;
-        description = "Value of `ro.product.device` or `ro.build.product`. Used to compare against in flashable zips.";
+        description = lib.mdDoc "Value of `ro.product.device` or `ro.build.product`. Used to compare against in flashable zips.";
         default = null;
         internal = true;
       };
@@ -107,28 +107,28 @@ in
           "fastboot" # Default, using `fastboot`
           "odin"     # Mainly Samsung, using `heimdall`
         ];
-        description = "Configures which flashing method is used by the device.";
+        description = lib.mdDoc "Configures which flashing method is used by the device.";
         default = "fastboot";
         internal = true;
       };
 
       has_recovery_partition = lib.mkOption {
         type = types.bool;
-        description = "Configures whether the device uses a distinct recovery partition";
+        description = lib.mdDoc "Configures whether the device uses a distinct recovery partition";
         default = !config.mobile.system.android.boot_as_recovery;
         internal = true;
       };
 
       boot_partition_destination = lib.mkOption {
         type = types.str;
-        description = "Partition label on which to install the boot image. Some OEM name the partition BOOT.";
+        description = lib.mdDoc "Partition label on which to install the boot image. Some OEM name the partition BOOT.";
         default = "boot";
         internal = true;
       };
 
       system_partition_destination = lib.mkOption {
         type = types.str;
-        description = "Partition label on which to install the system image. E.g. change to `userdata` when it does not fit in the system partition.";
+        description = lib.mdDoc "Partition label on which to install the system image. E.g. change to `userdata` when it does not fit in the system partition.";
         default = "system";
         internal = true;
       };
@@ -136,7 +136,7 @@ in
       bootimg = {
         name = lib.mkOption {
           type = types.str;
-          description = "Suffix for the image name. Use it to distinguish speciality boot images.";
+          description = lib.mdDoc "Suffix for the image name. Use it to distinguish speciality boot images.";
           default = "boot.img";
           internal = true;
         };
@@ -144,7 +144,7 @@ in
         dt = lib.mkOption {
           type = types.nullOr types.path;
           default = null;
-          description = "Path to a flattened device tree to pass as --dt to mkbootimg";
+          description = lib.mdDoc "Path to a flattened device tree to pass as --dt to mkbootimg";
           internal = true;
         };
 
@@ -161,7 +161,7 @@ in
       appendDTB = lib.mkOption {
         type = with types; nullOr (listOf (oneOf [path str]));
         default = null;
-        description = "List of dtb files to append to the kernel, when device uses appended DTB.";
+        description = lib.mdDoc "List of dtb files to append to the kernel, when device uses appended DTB.";
       };
     };
     mobile = {

--- a/modules/system-types/android/flashable-zip.nix
+++ b/modules/system-types/android/flashable-zip.nix
@@ -68,21 +68,21 @@ in
         android = {
           android-flashable-bootimg = mkOption {
             type = types.package;
-            description = ''
+            description = lib.mdDoc ''
               `boot.img` in Android flashable zip format.
             '';
             visible = false;
           };
           android-flashable-system = mkOption {
             type = types.package;
-            description = ''
+            description = lib.mdDoc ''
               `system.img` in Android flashable zip format.
             '';
             visible = false;
           };
           android-flashable-zip = mkOption {
             type = types.package;
-            description = ''
+            description = lib.mdDoc ''
               Android flashable zip which will install `boot.img` and `system.img`.
             '';
             visible = false;

--- a/modules/system-types/depthcharge/default.nix
+++ b/modules/system-types/depthcharge/default.nix
@@ -34,14 +34,14 @@ in
         depthcharge = {
           disk-image = lib.mkOption {
             type = types.package;
-            description = ''
+            description = lib.mdDoc ''
               Full Mobile NixOS disk image for a depthcharge-based system.
             '';
             visible = false;
           };
           kpart = lib.mkOption {
             type = types.package;
-            description = ''
+            description = lib.mdDoc ''
               Kernel partition for a depthcharge-based system.
             '';
             visible = false;

--- a/modules/system-types/u-boot/default.nix
+++ b/modules/system-types/u-boot/default.nix
@@ -175,7 +175,7 @@ in
       additionalCommands = mkOption {
         type = types.lines;
         default = "";
-        description = ''
+        description = lib.mdDoc ''
           Additional U-Boot commands to run.
         '';
       };
@@ -185,21 +185,21 @@ in
       u-boot = {
         boot-partition = mkOption {
           type = types.package;
-          description = ''
+          description = lib.mdDoc ''
             Boot partition for the system.
           '';
           visible = false;
         };
         disk-image = lib.mkOption {
           type = types.package;
-          description = ''
+          description = lib.mdDoc ''
             Full Mobile NixOS disk image for a u-boot-based system.
           '';
           visible = false;
         };
         u-boot = mkOption {
           type = types.package;
-          description = ''
+          description = lib.mdDoc ''
             U-Boot build for the system.
           '';
           visible = false;

--- a/modules/system-types/uefi/default.nix
+++ b/modules/system-types/uefi/default.nix
@@ -99,7 +99,7 @@ in
       initialGapSize = mkOption {
         type = types.int;
         default = 0;
-        description = ''
+        description = lib.mdDoc ''
           Size (in bytes) to keep reserved in front of the first partition.
         '';
       };
@@ -109,21 +109,21 @@ in
       uefi = {
         boot-partition = mkOption {
           type = types.package;
-          description = ''
+          description = lib.mdDoc ''
             Boot partition for the system.
           '';
           visible = false;
         };
         disk-image = lib.mkOption {
           type = types.package;
-          description = ''
+          description = lib.mdDoc ''
             Full Mobile NixOS disk image for a UEFI-based system.
           '';
           visible = false;
         };
         efiKernel = mkOption {
           type = types.package;
-          description = ''
+          description = lib.mdDoc ''
             EFI executable with the kernel, cmdline and initramfs built-in.
           '';
           visible = false;

--- a/modules/system-types/uefi/vm.nix
+++ b/modules/system-types/uefi/vm.nix
@@ -20,7 +20,7 @@ in
         type = types.bool;
         default = false;
         internal = true;
-        description = ''
+        description = lib.mdDoc ''
           Internal switch to select whether the `outputs.uefi.vm` value points
           to the composeConfig usage, or to the actual output.
         '';
@@ -29,7 +29,7 @@ in
         uefi = {
           vm = mkOption {
             type = types.package;
-            description = ''
+            description = lib.mdDoc ''
               Script to start a UEFI-based virtual machine.
             '';
             visible = false;

--- a/overlay/mobile-nixos/kernel/eval-config.nix
+++ b/overlay/mobile-nixos/kernel/eval-config.nix
@@ -148,14 +148,14 @@
             configfile = lib.mkOption {
               readOnly = true;
               type = lib.types.str;
-              description = ''
+              description = lib.mdDoc ''
                 String that can directly be used as a kernel config file contents.
               '';
             };
             validatorSnippet = lib.mkOption {
               readOnly = true;
               type = lib.types.package;
-              description = ''
+              description = lib.mdDoc ''
                 Path to a script that can directly be called to validate the kernel config.
               '';
             };


### PR DESCRIPTION
Used this elegant context-aware mass-edit tool:

```
 $ find . -name '*.nix' -exec sed -i -e "s/description = ''/description = lib.mdDoc ''/g" '{}' ';'
```

* * *

This should unclog some issues in Hydra.

This would break eval on any Nixpkgs older than June last year, which is a fair trade-off:

 - https://github.com/NixOS/nixpkgs/commit/320aa2a7910a71371204d672ff612cc9af5337da#diff-b8abdbba66ddbc5583e31b562a5041d1977fd7fe7295d2d4cb8b0170fa1640f1

Anyway (not really documented) I assume any revision relatively older than the revision in `pkgs.nix` is unsupported. Let's retcon that the following line in the README meant just that:

> :warning: Note: Mobile NixOS is only expected to build succesfully against the unstable branch of Nixpkgs.
