### PR TITLE
boot/init: Fix mount regression from option added for systemd-boot

### DIFF
--- a/boot/init/lib/system.rb
+++ b/boot/init/lib/system.rb
@@ -158,7 +158,7 @@ module System
   #   @param dest [String] Destination path to mount to
   #   @param type [String] Type of the mount (+-t+).
   #   @param options [Array<String>] Mount options (+-o+).
-  def self.mount(source, dest = nil, type: nil, options: nil)
+  def self.mount(source, dest = nil, type: nil, options: [])
     # Fill-in the "reversed" optional parameters.
     unless dest
       dest = source
@@ -174,10 +174,14 @@ module System
       args << "-t"
       args << type
     end
-    if options
+
+    # Filter options that busybox mount can't handle.
+    options = options.select { |option| !option.match(/^x-/) }
+    unless options.empty?
       args << "-o"
       args << options.join(",")
     end
+
     args << source
     args << dest
 


### PR DESCRIPTION
A NixOS change for systemd-stage-1 added an `x-` mount option, which is not handled well by busybox mount.

 - https://github.com/NixOS/nixpkgs/commit/1b394913269a0b1086ebae1c0f30c3fa932a3ebb

The same option was not an issue for the shell-script stage-1 as it already stripped `x-` mount options

 - https://github.com/NixOS/nixpkgs/blob/8be838254badb578300520f61091a86fd0c7d328/nixos/modules/system/boot/stage-1-init.sh#L365-L366

Thus it's assumed safe to strip the options the same way.