### PR TITLE
Add options to better control console parameters 

### DIFF
--- a/devices/asus-dumo/default.nix
+++ b/devices/asus-dumo/default.nix
@@ -25,11 +25,7 @@
   };
 
   # Serial console on ttyS2, using a suzyqable or equivalent.
-  boot.kernelParams = [
-    "console=ttyS2,115200n8"
-    "earlyprintk=ttyS2,115200n8"
-    "vt.global_cursor_default=0"
-  ];
+  mobile.boot.serialConsole = "ttyS2,115200n8";
 
   mobile.system.type = "depthcharge";
 

--- a/devices/families/sdm845-mainline/default.nix
+++ b/devices/families/sdm845-mainline/default.nix
@@ -49,10 +49,6 @@
     ];
   };
 
-  boot.kernelParams = [
-    "console=tty0"
-  ];
-
   mobile.usb.mode = "gadgetfs";
   # The identifiers used here serve as a compatible well-known identifier.
   mobile.usb.idVendor = lib.mkDefault "18D1"; # Google

--- a/devices/google-marlin/default.nix
+++ b/devices/google-marlin/default.nix
@@ -39,10 +39,8 @@
 
   mobile.system.vendor.partition = "/dev/disk/by-partlabel/vendor_a";
 
-  boot.kernelParams = [
-    # For use with the "Nexus-style" UART cable, add the following kernel parameter.
-    # "console=ttyHSL0,115200,n8"
-  ];
+  # For use with the "Nexus-style" UART cable, add the following kernel parameter.
+  mobile.boot.serialConsole = "ttyHSL0,115200n8";
 
   mobile.usb.mode = "android_usb";
   # Google

--- a/devices/lenovo-krane/default.nix
+++ b/devices/lenovo-krane/default.nix
@@ -37,12 +37,8 @@
     dtbs = "${config.mobile.boot.stage-1.kernel.package}/dtbs/mediatek";
   };
 
-  boot.kernelParams = [
-    # Serial console on ttyS0, using a suzyqable or equivalent.
-    # TODO: option to enable serial console.
-    #"console=ttyS0,115200n8"
-    #"earlyprintk=ttyS0,115200n8"
-  ];
+  # Serial console on ttyS0, using a suzyqable or equivalent.
+  mobile.boot.serialConsole = "ttyS0,115200n8";
 
   systemd.services."serial-getty@ttyS0" = {
     enable = true;

--- a/devices/lenovo-wormdingler/default.nix
+++ b/devices/lenovo-wormdingler/default.nix
@@ -37,12 +37,8 @@
     dtbs = "${config.mobile.boot.stage-1.kernel.package}/dtbs/qcom";
   };
 
-  boot.kernelParams = [
-    # Serial console on ttyMSM0, using a suzyqable or equivalent.
-    # TODO: option to enable serial console.
-    #"console=ttyMSM0,115200n8"
-    #"earlyprintk=ttyMSM0,115200n8"
-  ];
+  # Serial console on ttyMSM0, using a suzyqable or equivalent.
+  mobile.boot.serialConsole = "ttyMSM0,115200n8";
 
   systemd.services."serial-getty@ttyMSM0" = {
     enable = true;

--- a/devices/pine64-pinephone/default.nix
+++ b/devices/pine64-pinephone/default.nix
@@ -30,11 +30,11 @@
   };
 
   boot.kernelParams = lib.mkAfter [
-    # TODO: useSerial option
-    # Serial console on ttyS0, using the serial headphone adapter.
-    "console=ttyS0,115200"
     "earlycon=uart,mmio32,0x01c28000"
   ];
+
+  # Serial console on ttyS0, using the serial headphone adapter.
+  mobile.boot.serialConsole = "ttyS0,115200";
 
   mobile.system.type = "u-boot";
 

--- a/devices/pine64-pinetab/default.nix
+++ b/devices/pine64-pinetab/default.nix
@@ -24,13 +24,13 @@
   };
 
   boot.kernelParams = [
-    # Serial console on ttyS0, using the serial headphone adapter.
-    "console=ttyS0,115200"
-    "vt.global_cursor_default=0"
     "earlycon=uart,mmio32,0x01c28000"
     "panic=10"
     "consoleblank=0"
   ];
+
+  # Serial console on ttyS0, using the serial headphone adapter.
+  mobile.boot.serialConsole = "ttyS0,115200";
 
   mobile.system.type = "u-boot";
 

--- a/examples/hello/configuration.nix
+++ b/examples/hello/configuration.nix
@@ -71,6 +71,10 @@ in
     log.level = "DEBUG";
   };
 
+  mobile.beautification = {
+    silentBoot = lib.mkDefault true;
+  };
+
   # Ensure hello-gui isn't trampled over by the TTY
   systemd.services."getty@tty1" = {
     enable = false;

--- a/modules/boot.nix
+++ b/modules/boot.nix
@@ -1,0 +1,66 @@
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.mobile.boot;
+  inherit (lib)
+    mkBefore
+    mkOption
+    mkOptionDefault
+    optional
+    types
+  ;
+in
+{
+  options.mobile.boot = {
+    defaultConsole = mkOption {
+      type = with types; nullOr str;
+      description = lib.mdDoc ''
+        When not null, sets a `console=` parameter early in the kernel cmdline.
+
+        This option is useful to control the default console that will be
+        used by the produced system, since otherwise it is impossible to
+        remove an added `console=` parameter from the cmdline.
+
+        When using beautification options with the kernel logo, the console
+        will be set to tty2, "losing" messages to the second VT. Without
+        beautification, this will be set to `tty1`.
+
+        You can also add additional console params to the kernel cmdline,
+        the last valid one in the list will be used for kernel messages by
+        default during boot.
+      '';
+    };
+    additionalConsoles = mkOption {
+      type = with types; listOf str;
+      default = [ ];
+      example = [ "ttyS0" ];
+      description = lib.mdDoc ''
+        List of additional console names to be prepended in the list of
+        consoles in the kernel cmdline.
+
+        These will have a lower priority than the console listed in `defaultConsole`,
+        and assumedly other kernel cmdline parameters added by the user.
+
+        This option is useful to add additional consoles like the serial
+        console to the list so that console multiplexing during boot can
+        print messages to it too.
+
+        The kernel's own messages will not be printed on those consoles.
+      '';
+    };
+  };
+  config = {
+    mobile.boot.defaultConsole = mkOptionDefault (
+      # We add the default default console only when the whole of Mobile NixOS is enabled.
+      if config.mobile.enable then "tty1" else null
+    );
+    boot.kernelParams = mkBefore (
+      map
+      (console: "console=${console}")
+      (
+        cfg.additionalConsoles
+        ++ (optional (cfg.defaultConsole != null) cfg.defaultConsole)
+      )
+    );
+  };
+}

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -5,6 +5,7 @@
   ./beautification.nix
   ./boot-control.nix
   ./boot-initrd.nix
+  ./boot.nix
   ./bootloader.nix
   ./cross-workarounds.nix
   ./devices-metadata.nix

--- a/modules/system-types/uefi/vm.nix
+++ b/modules/system-types/uefi/vm.nix
@@ -40,9 +40,9 @@ in
   };
   config = mkMerge [
     (mkIf config.mobile.quirks.uefi.enableVM {
-      boot.kernelParams = mkAfter [
-        "console=ttyS0"
-      ];
+      # With the VM build, it's waaay more convenient to have the serial output in the terminal.
+      mobile.boot.enableDefaultSerial = true;
+      mobile.boot.serialConsole = "ttyS0";
 
       mobile.boot.stage-1.kernel.modules = [
             # Networking


### PR DESCRIPTION
This PR adds new semantics for managing the boot consoles.

Managing `console=` params manually is *foolish*.

With these options, we can set defaults by prefixing them, and more importantly, better control the order of our defaults.

This also adds *knowledge* about the serial console. This way enabling it is easier and universal.

* * *

What was done:

 - Tested on Steam Deck (generic UEFI)
 - Tested on `oneplus-enchilada`
 - Verified with VM that serial feature works.
 - Verified with `nix repl` that `config.boot.kernelParams` now strictly prefixes `console=` with our default configs.