### PR TITLE
Add improved semantics for eink devices

### DIFF
--- a/boot/lib/lvgui/lvgl/hacks.rb
+++ b/boot/lib/lvgui/lvgl/hacks.rb
@@ -47,6 +47,12 @@ module LVGL::Hacks
     )
   end
 
+  def self.theme_mono()
+    LVGUI::Native.lv_theme_set_current(
+      LVGUI::Native.lv_theme_mono_init(0, nil)
+    )
+  end
+
   def self.theme_nixos(font = nil, button_font = nil)
     LVGUI::Native.lv_theme_set_current(
       LVGUI::Native.lv_theme_nixos_init(font, button_font)

--- a/boot/lib/lvgui/lvgui/progress_bar.rb
+++ b/boot/lib/lvgui/lvgui/progress_bar.rb
@@ -37,6 +37,27 @@ class LVGUI::ProgressBar < LVGUI::Widget
     refresh_sizes
   end
 
+  def background_color=(color)
+    get_style(LVGL::CONT_STYLE::MAIN).tap do |style|
+      style.body_main_color = color
+      style.body_grad_color = color
+    end
+    @background.get_style().tap do |style|
+      style.body_main_color = color
+      style.body_grad_color = color
+    end
+  end
+
+  def foreground_color=(color)
+    @background.get_style().tap do |style|
+      style.body_border_color = color
+    end
+    @progress.get_style().tap do |style|
+      style.body_main_color = color
+      style.body_grad_color = color
+    end
+  end
+
   def refresh_sizes()
     width = get_width()
     [@background].each do |component|

--- a/boot/script-loader/mruby-lvgui-native/lvgui.nix
+++ b/boot/script-loader/mruby-lvgui-native/lvgui.nix
@@ -95,13 +95,13 @@ let
 in
   stdenv.mkDerivation {
     pname = "lvgui";
-    version = "2023-03-11";
+    version = "2023-05-01";
 
     src = fetchFromGitHub {
       repo = "lvgui";
       owner = "mobile-nixos";
-      rev = "e5e052e9ef85271caab13552fa503462d11c835f";
-      sha256 = "sha256-l54Lri0hKEXexO2AsrprnT+1df2Q4ORAvzhtjFwnkuU=";
+      rev = "e1a23580905419b598b7ed673e47bf210c502bb4";
+      sha256 = "sha256-VbvUVWifvkjQRyqXfNgIFc3LKpFfh7D1xGbJ02cZYpk=";
     };
 
     # Document `LVGL_ENV_SIMULATOR` in the built headers.

--- a/boot/script-loader/mruby-lvgui-native/src/gem.c
+++ b/boot/script-loader/mruby-lvgui-native/src/gem.c
@@ -5070,6 +5070,68 @@ mrb_mruby_lvgui_native_lv_theme_get_current(mrb_state *mrb, mrb_value self)
 ////////
 
 ////////
+// Bindings for: `lv_theme_t * lv_theme_mono_init(uint16_t unnamed_parameter_0, lv_font_t * unnamed_parameter_1)`
+
+static mrb_value
+mrb_mruby_lvgui_native_lv_theme_mono_init(mrb_state *mrb, mrb_value self)
+{
+    lv_theme_t * ret;
+  
+    //
+    // Parameters handling
+    //
+    
+    // Parameter handling for native parameter `uint16_t unnamed_parameter_0`
+    mrb_int param_unnamed_parameter_0_int;
+    uint16_t param_unnamed_parameter_0;
+    // Parameter handling for native parameter `lv_font_t * unnamed_parameter_1`
+    mrb_value param_unnamed_parameter_1_instance;
+    lv_font_t * param_unnamed_parameter_1;
+    
+    mrb_get_args(
+      mrb,
+      "io",
+      &param_unnamed_parameter_0_int,
+      &param_unnamed_parameter_1_instance
+    );
+    param_unnamed_parameter_0 = (uint16_t)param_unnamed_parameter_0_int;
+    param_unnamed_parameter_1 = mrb_mruby_lvgui_native_unwrap_pointer(
+      mrb,
+      param_unnamed_parameter_1_instance
+    );
+  
+    // Calling native function
+    ret = lv_theme_mono_init(param_unnamed_parameter_0, param_unnamed_parameter_1);
+  
+    // Converts return value back to a valid mruby value
+    return mrb_mruby_lvgui_native_wrap_pointer(mrb, (void *) ret);
+}
+
+//
+////////
+
+////////
+// Bindings for: `lv_theme_t * lv_theme_get_mono()`
+
+static mrb_value
+mrb_mruby_lvgui_native_lv_theme_get_mono(mrb_state *mrb, mrb_value self)
+{
+    lv_theme_t * ret;
+  
+  
+  
+  
+    // Calling native function
+    ret = lv_theme_get_mono();
+  
+    // Converts return value back to a valid mruby value
+    return mrb_mruby_lvgui_native_wrap_pointer(mrb, (void *) ret);
+}
+
+//
+////////
+
+////////
 // Bindings for: `lv_theme_t * lv_theme_night_init(uint16_t unnamed_parameter_0, lv_font_t * unnamed_parameter_1)`
 
 static mrb_value
@@ -13651,6 +13713,38 @@ mrb_mruby_lvgui_native_gem_init(mrb_state* mrb)
     mLVGUI__Native__References,
     mrb_symbol_value(mrb_intern_lit(mrb, "lv_theme_get_current")),
     mrb_mruby_lvgui_native_wrap_pointer(mrb, (void *) lv_theme_get_current)
+  );
+
+  // ```lv_theme_t * lv_theme_mono_init(uint16_t unnamed_parameter_0, lv_font_t * unnamed_parameter_1);```
+  mrb_define_module_function(
+    mrb,
+    mLVGUI__Native,
+    "lv_theme_mono_init",
+    mrb_mruby_lvgui_native_lv_theme_mono_init,
+    MRB_ARGS_REQ(2)
+  );
+  
+  mrb_hash_set(
+    mrb,
+    mLVGUI__Native__References,
+    mrb_symbol_value(mrb_intern_lit(mrb, "lv_theme_mono_init")),
+    mrb_mruby_lvgui_native_wrap_pointer(mrb, (void *) lv_theme_mono_init)
+  );
+
+  // ```lv_theme_t * lv_theme_get_mono();```
+  mrb_define_module_function(
+    mrb,
+    mLVGUI__Native,
+    "lv_theme_get_mono",
+    mrb_mruby_lvgui_native_lv_theme_get_mono,
+    MRB_ARGS_REQ(0)
+  );
+  
+  mrb_hash_set(
+    mrb,
+    mLVGUI__Native__References,
+    mrb_symbol_value(mrb_intern_lit(mrb, "lv_theme_get_mono")),
+    mrb_mruby_lvgui_native_wrap_pointer(mrb, (void *) lv_theme_get_mono)
   );
 
   // ```lv_theme_t * lv_theme_night_init(uint16_t unnamed_parameter_0, lv_font_t * unnamed_parameter_1);```

--- a/boot/splash/configuration.rb
+++ b/boot/splash/configuration.rb
@@ -1,0 +1,12 @@
+# Handles lazy-loading the configuration, and giving a value for a given key.
+module Configuration
+  def self.[](key)
+    @configuration ||=
+      if File.exist?("/etc/boot/config")
+        JSON.parse(File.read("/etc/boot/config"))
+      else
+        {}
+      end
+    @configuration[key]
+  end
+end

--- a/boot/splash/default.nix
+++ b/boot/splash/default.nix
@@ -12,6 +12,7 @@ mobile-nixos.mkLVGUIApp {
   enableDebugInformation = true;
   src = lib.cleanSource ./.;
   rubyFiles = [
+    "configuration.rb"
     "ui.rb"
     "main.rb"
   ];

--- a/boot/splash/default.nix
+++ b/boot/splash/default.nix
@@ -3,7 +3,7 @@
 let
   assets = runCommand "boot-splash-assets" {} ''
     mkdir -p $out
-    cp ${../../artwork/logo/logo.white.svg} $out/logo.svg
+    ln -s /etc/logo.svg $out/logo.svg
   '';
 in
 mobile-nixos.mkLVGUIApp {

--- a/boot/splash/ui.rb
+++ b/boot/splash/ui.rb
@@ -17,13 +17,15 @@ class UI
   BG_COLOR = Configuration["splash"] && Configuration["splash"]["background"]
   BG_COLOR = BG_COLOR.to_i(16) if BG_COLOR.is_a?(String)
   BG_COLOR ||= 0xFF000000
+  THEME = Configuration["splash"] && Configuration["splash"]["theme"]
+  THEME ||= "night"
 
   attr_reader :screen
   attr_reader :progress_bar
   attr_reader :ask_identifier
 
   # As this is not using BaseWindow, LVGUI::init isn't handled for us.
-  LVGUI.init(theme: :night, assets_path: "boot-splash/assets")
+  LVGUI.init(theme: THEME.to_sym, assets_path: "boot-splash/assets")
 
   def initialize()
     add_screen

--- a/boot/splash/ui.rb
+++ b/boot/splash/ui.rb
@@ -84,9 +84,9 @@ class UI
 
   def add_screen()
     @screen = LVGL::LVContainer.new()
-    @screen.get_style(LVGL::CONT_STYLE::MAIN).dup.tap do |style|
-      @screen.set_style(LVGL::CONT_STYLE::MAIN, style)
-
+    # NOTE: we don't need to `#dup` the screen's style, it's unique.
+    # (`#dup`ing it also crashes with the mono theme :/)
+    @screen.get_style(LVGL::CONT_STYLE::MAIN).tap do |style|
       # Background for the splash, assumed black.
       style.body_main_color = BG_COLOR
       style.body_grad_color = BG_COLOR

--- a/boot/splash/ui.rb
+++ b/boot/splash/ui.rb
@@ -11,6 +11,13 @@ module Kernel
 end
 
 class UI
+  FG_COLOR = Configuration["splash"] && Configuration["splash"]["foreground"]
+  FG_COLOR = FG_COLOR.to_i(16) if FG_COLOR.is_a?(String)
+  FG_COLOR ||= 0xFFFFFFFF
+  BG_COLOR = Configuration["splash"] && Configuration["splash"]["background"]
+  BG_COLOR = BG_COLOR.to_i(16) if BG_COLOR.is_a?(String)
+  BG_COLOR ||= 0xFF000000
+
   attr_reader :screen
   attr_reader :progress_bar
   attr_reader :ask_identifier
@@ -38,7 +45,7 @@ class UI
     @label = LVGL::LVLabel.new(@page)
     @label.get_style(LVGL::LABEL_STYLE::MAIN).dup.tap do |style|
       @label.set_style(LVGL::LABEL_STYLE::MAIN, style)
-      style.text_color = 0xFFFFFFFF
+      style.text_color = FG_COLOR
     end
     @label.set_long_mode(LVGL::LABEL_LONG::BREAK)
     @label.set_align(LVGL::LABEL_ALIGN::CENTER)
@@ -71,6 +78,8 @@ class UI
     @progress_bar.set_height(3 * @unit)
     @progress_bar.set_width(@page.get_width * 0.7)
     @progress_bar.set_pos(*center(@progress_bar))
+    @progress_bar.foreground_color = FG_COLOR
+    @progress_bar.background_color = BG_COLOR
   end
 
   def add_screen()
@@ -79,8 +88,8 @@ class UI
       @screen.set_style(LVGL::CONT_STYLE::MAIN, style)
 
       # Background for the splash, assumed black.
-      style.body_main_color = 0xFF000000
-      style.body_grad_color = 0xFF000000
+      style.body_main_color = BG_COLOR
+      style.body_grad_color = BG_COLOR
     end
   end
 
@@ -90,8 +99,8 @@ class UI
     @page.set_height(@screen.get_height)
     @page.get_style(LVGL::CONT_STYLE::MAIN).dup.tap do |style|
       @page.set_style(LVGL::CONT_STYLE::MAIN, style)
-      style.body_main_color = 0xFF000000
-      style.body_grad_color = 0xFF000000
+      style.body_main_color = BG_COLOR
+      style.body_grad_color = BG_COLOR
       style.body_border_width = 0
     end
   end
@@ -102,15 +111,15 @@ class UI
     @recovery_container.set_width(@page.get_width)
     @recovery_container.get_style(LVGL::CONT_STYLE::MAIN).dup.tap do |style|
       @recovery_container.set_style(LVGL::CONT_STYLE::MAIN, style)
-      style.body_main_color = 0xFF000000
-      style.body_grad_color = 0xFF000000
+      style.body_main_color = BG_COLOR
+      style.body_grad_color = BG_COLOR
       style.body_border_width = 0
     end
 
     recovery_label = LVGL::LVLabel.new(@recovery_container)
     recovery_label.get_style(LVGL::LABEL_STYLE::MAIN).dup.tap do |style|
       recovery_label.set_style(LVGL::LABEL_STYLE::MAIN, style)
-      style.text_color = 0xFFFFFFFF
+      style.text_color = FG_COLOR
     end
     recovery_label.set_long_mode(LVGL::LABEL_LONG::BREAK)
     recovery_label.set_align(LVGL::LABEL_ALIGN::CENTER)
@@ -137,9 +146,9 @@ class UI
     @cover.get_style().dup.tap do |style|
       @cover.set_style(style)
 
-      # Background for the splash, assumed black.
-      style.body_main_color = 0xFF000000
-      style.body_grad_color = 0xFF000000
+      # Background for the splash
+      style.body_main_color = BG_COLOR
+      style.body_grad_color = BG_COLOR
       # Some themes will add a border to LVObject.
       style.body_border_width = 0
     end
@@ -155,17 +164,17 @@ class UI
       set_pwd_mode(true)
       get_style(LVGL::TA_STYLE::BG).dup.tap do |style|
         set_style(LVGL::TA_STYLE::BG, style)
-        style.body_main_color = 0xFF000000
-        style.body_grad_color = 0xFF000000
+        style.body_main_color = BG_COLOR
+        style.body_grad_color = BG_COLOR
         style.body_radius = 5
-        style.body_border_color = 0xFFFFFFFF
+        style.body_border_color = FG_COLOR
         style.body_border_width = 3
         style.body_border_opa = 255
-        style.text_color = 0xFFFFFFFF
+        style.text_color = FG_COLOR
       end
       get_style(LVGL::TA_STYLE::PLACEHOLDER).dup.tap do |style|
         set_style(LVGL::TA_STYLE::PLACEHOLDER, style)
-        style.text_color = 0xFFAAAAAA
+        style.text_color = LVGL::LVColor.mix(FG_COLOR, BG_COLOR, 100)
       end
     end
 

--- a/modules/hardware-eink.nix
+++ b/modules/hardware-eink.nix
@@ -1,0 +1,58 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib)
+    mkIf
+    mkOption
+    types
+  ;
+  cfg = config.mobile.hardware.eink;
+in
+{
+  options.mobile.hardware.eink = {
+    enable = mkOption {
+      default = false;
+      description = lib.mdDoc ''
+        Enable to change some defaults so they work better on an eink display.
+      '';
+    };
+    enableEinkTheme = mkOption {
+      default = cfg.enable;
+      description = lib.mdDoc ''
+        Enable only the eink changes affecting the theme.
+      '';
+    };
+  };
+  config = mkIf cfg.enableEinkTheme {
+    boot.kernelParams = [
+      # Black on white fbcon
+      "vt.default_red=0xFF,0xBC,0x4F,0xB4,0x56,0xBC,0x4F,0x00,0xA1,0xCF,0x84,0xCA,0x8D,0xB4,0x84,0x68"
+      "vt.default_grn=0xFF,0x55,0xBA,0xBA,0x4D,0x4D,0xB3,0x00,0xA0,0x8F,0xB3,0xCA,0x88,0x93,0xA4,0x68"
+      "vt.default_blu=0xFF,0x58,0x5F,0x58,0xC5,0xBD,0xC5,0x00,0xA8,0xBB,0xAB,0x97,0xBD,0xC7,0xC5,0x68"
+    ];
+
+    # Why not use `logo.svg`?
+    # It's because it's not pure black, it has blue.
+    # Let's use a pure black logo for eink!
+    mobile.boot.stage-1.gui.logo = pkgs.runCommand "logo.eink.svg" {} ''
+      sed -e 's/#ffffff/#000000/g' ${../artwork/logo/logo.white.svg} > $out
+    '';
+
+    # With this one, we have to switch colours around!
+    mobile.boot.stage-1.kernel.logo.logo = pkgs.runCommand "kernel-logo.eink.svg" {} ''
+      sed \
+        -e 's/#ffffff/#xxxxxx/g' \
+        -e 's/#000000/#ffffff/g' \
+        -e 's/#xxxxxx/#000000/g' \
+        ${../artwork/boot-logo.svg} > $out
+    '';
+
+    mobile.boot.stage-1.bootConfig = {
+      splash = {
+        theme = "mono";
+        background = "0xFFFFFFFF";
+        foreground = "0xFF000000";
+      };
+    };
+  };
+}

--- a/modules/initrd-boot-gui.nix
+++ b/modules/initrd-boot-gui.nix
@@ -57,6 +57,18 @@ in
         '';
       };
     };
+    logo = mkOption {
+      type = with types; either package path;
+      internal = true;
+      default = ../artwork/logo/logo.white.svg;
+      description = lib.mdDoc ''
+        Logo shown during stage-1 init.
+
+        Option marked internal since there are some particular quirks in changing the logo.
+
+        It may not work as expected.
+      '';
+    };
   };
 
   config = mkIf (config.mobile.boot.stage-1.enable) (mkMerge [
@@ -88,6 +100,10 @@ in
         {
           object = "${minimalX11Config}";
           symlink = "/etc/X11";
+        }
+        {
+          object = cfg.logo;
+          symlink = "/etc/logo.svg";
         }
       ];
 

--- a/modules/initrd-boot-gui.nix
+++ b/modules/initrd-boot-gui.nix
@@ -1,7 +1,13 @@
 { config, lib, pkgs, ... }:
 
 let
-  inherit (lib) mkIf mkMerge mkOption types;
+  inherit (lib)
+    mkDefault
+    mkIf
+    mkMerge
+    mkOption
+    types
+  ;
   cfg = config.mobile.boot.stage-1.gui;
   inherit (config.boot.initrd) luks;
   minimalX11Config = pkgs.runCommand "minimalX11Config" {
@@ -89,11 +95,20 @@ in
         XKB_CONFIG_ROOT = "/etc/X11/xkb";
         XLOCALEDIR = "/etc/X11/locale";
       };
-      mobile.boot.stage-1.bootConfig = mkIf (cfg.waitForDevices.enable) {
-        quirks = {
-          wait_for_devices_delay = cfg.waitForDevices.delay;
-        };
-      };
+      mobile.boot.stage-1.bootConfig = mkMerge [
+        (mkIf (cfg.waitForDevices.enable) {
+          quirks = {
+            wait_for_devices_delay = cfg.waitForDevices.delay;
+          };
+        })
+        {
+          splash = {
+            theme = mkDefault "night";
+            background = mkDefault "0xFF000000";
+            foreground = mkDefault "0xFFFFFFFF";
+          };
+        }
+      ];
     })
   ]);
 }

--- a/modules/module-list.nix
+++ b/modules/module-list.nix
@@ -10,6 +10,7 @@
   ./cross-workarounds.nix
   ./devices-metadata.nix
   ./documentation.nix
+  ./hardware-eink.nix
   ./generated-filesystems.nix
   ./hardware-allwinner.nix
   ./hardware-exynos.nix


### PR DESCRIPTION
This adds a few options to improve use on eink displays.

The gist of it is these options ensures inverted "black on white" works. Up to and excluding later stage-2, this is verified to do a flicker-free black-on-white from the moment the kernel logo is shown.

I have tested this on the `pine64-pinenote` (PR pending) and the new VM with #612. Up until `cage` comes-up, the display sees no black updates; even a single frame will be rendered in my experience, and made obvious from the slow refresh. See https://github.com/mobile-nixos/lvgui/pull/17 for the fix for the one flicker we were in control of.

Relatedly, with the lvgui change we *should* be able, with some additional knowledge, to smoothly transition from the logo to the stage-1 progress, if it was desired. Including, but not limited, to adding support for BGRT *shenanigans* on UEFI+ACPI. With our kernel logo we should be able to re-use the same SVG file to do the same when there's no BGRT.

* * *

What was done

 - Use the new test VM with kernel to have the full boot flow including the logo, while enabling `hardware.eink`
 - Tested with WIP device `pine64-pinenote`