### PR TITLE
modules/stage-0: Ensure enabling/disabling is a no-op

### DIFF
--- a/modules/stage-0.nix
+++ b/modules/stage-0.nix
@@ -68,8 +68,8 @@ in
 
   config = {
     mobile.outputs.stage-0 = (config.lib.mobile-nixos.composeConfig {
-      config = { config, ... }: {
-        mobile.boot.stage-1.stage = if supportsStage-0 then 0 else 1;
+      config = { config, ... }: lib.mkIf supportsStage-0 {
+        mobile.boot.stage-1.stage = 0;
         mobile.boot.stage-1.extraUtils = [
           { package = pkgs.kexectools; }
           { package = pkgs.fdt-forward; }


### PR DESCRIPTION
This ensures that, for implementation details, bits that use stage-0 as a synonym for stage-1 when it is not supported gets the same exact eval than the one for stage-1.

Without this change, some `fdt-forward` and changes made under that `mkIf` would end-up included. `fdt-forward` was found to be in the stage-1 image even though it was irrelevant.