### PR TITLE
modules/beautification: Add missing lib.mdDoc

### DIFF
--- a/modules/beautification.nix
+++ b/modules/beautification.nix
@@ -25,7 +25,7 @@ in
           type = types.bool;
           default = config.mobile.enable;
           defaultText = "config.mobile.enable";
-          description = ''
+          description = lib.mdDoc ''
             Whether silentBoot assumes the kernel logo is used as early splash,
             or leaves the fbcon unmapped such that (possibly) the vendor splash
             is kept on the display until the stage-1 boot interface starts.


### PR DESCRIPTION
I'm confused as to why nothing breaks anymore(?) without `mdDoc` being added, like it did a small while back.