### PR TITLE
eval-with-configuration: Expose options

### DIFF
--- a/lib/eval-with-configuration.nix
+++ b/lib/eval-with-configuration.nix
@@ -64,6 +64,7 @@ in
 
   # The evaluated config
   inherit (eval) config;
+  inherit (eval) options;
 
   # The final pkgs set, usable as -A pkgs.[...] on the CLI.
   inherit (eval) pkgs;


### PR DESCRIPTION
This can be useful when used with `nix repl`. For example, using:

```
:p options.environment.systemPackages.definitionsWithLocations
```

You can figure out where a specific package was added, when simple grepping is hard in Nixpkgs.