### PR TITLE
modules/stage-0: Fix fdt-forward ref

### DIFF
--- a/modules/stage-0.nix
+++ b/modules/stage-0.nix
@@ -72,7 +72,7 @@ in
         mobile.boot.stage-1.stage = 0;
         mobile.boot.stage-1.extraUtils = [
           { package = pkgs.kexectools; }
-          { package = pkgs.fdt-forward; }
+          { package = fdt-forward; }
         ];
         mobile.boot.stage-1.bootConfig.stage-0 = {
           forward = {


### PR DESCRIPTION
See, the `with` thing was totally making things hard to reason about!

Fixes regression from https://github.com/NixOS/mobile-nixos/pull/611