### PR TITLE
Fix eval with bootspec enabled

### DIFF
--- a/modules/initrd-kernel.nix
+++ b/modules/initrd-kernel.nix
@@ -204,6 +204,7 @@ in
                   baseVersion = "3.18";
                   kernelOlder = lib.versionOlder baseVersion;
                   kernelAtLeast = lib.versionAtLeast baseVersion;
+                  modDirVersion = "99";
                 };
                 version = "99";
               } "mkdir $out; touch $out/no-kernel"

--- a/overlay/mobile-nixos/kernel/builder.nix
+++ b/overlay/mobile-nixos/kernel/builder.nix
@@ -549,7 +549,7 @@ stdenv.mkDerivation (inputArgs // {
     # appropriately for different quirks.
     inherit isQcdt isExynosDT;
 
-    inherit baseVersion;
+    inherit baseVersion modDirVersion;
     kernelOlder = lib.versionOlder baseVersion;
     kernelAtLeast = lib.versionAtLeast baseVersion;
 


### PR DESCRIPTION
Fixes #624

* * *

What was done

 - Tested on generic UEFI non-kernel-builder setup (no-op)
 - Tested on `lenovo-wormdingler` with shared rootfs option enabled, and with kernel; fixes eval in both cases.