### PR TITLE
Update nixpkgs and bootlogd version.

### DIFF
--- a/overlay/bootlogd/default.nix
+++ b/overlay/bootlogd/default.nix
@@ -2,13 +2,13 @@
 
 stdenv.mkDerivation {
   pname = "bootlogd";
-  version = "2020-02-02";
+  version = "2023-07-20";
 
   src = fetchFromGitHub {
     owner = "mobile-nixos";
     repo = "bootlogd";
-    rev = "e5af793da15def578eb3b25cb2c02196267021b1";
-    sha256 = "0m6y1369xs8hds66q5z2bxd80vxwnkqsnppmkfqk6i1d2259i903";
+    rev = "b9a89f30c1c6987eeb4277a071808621d6251f4e";
+    sha256 = "sha256-9XC1NiOEU3+fk5qFhSFpn1Bb+ydoloDFZn0BPxTstV4=";
   };
 
   sourceRoot = "source/src";

--- a/pkgs.nix
+++ b/pkgs.nix
@@ -1,6 +1,6 @@
 let
-  sha256 = "sha256:1qm1ffipjsqrd2f3y1x8n8d9afc659plaxp131wh3ixvnmvqxiy6";
-  rev = "3e313808bd2e0a0669430787fb22e43b2f4bf8bf";
+  sha256 = "sha256:1gvi4vlq1cxyi3w2mqm939c5ib5509a2ycpwyki51jdgcpkh4x9c";
+  rev = "684c17c429c42515bafb3ad775d2a710947f3d67";
 in
 builtins.trace "(Using pinned Nixpkgs at ${rev})"
 import (fetchTarball {


### PR DESCRIPTION
Hardening flags were enabled in nixpkgs so bootlogd needs to be updated: https://github.com/mobile-nixos/bootlogd/pull/9

I update both of them simultaneously so that we don't build bootlogd without hardening. Also there is a deprecation warning with new nixpkgs:

```
trace: warning: literalExample is deprecated, use literalExpression instead, or use literalMD for a non-Nix description.
```

But I couldn't find where it comes from.